### PR TITLE
TE-4321 Fix graphiant_bgp template to support BGP peers with multiple different local interfaces in the same segment

### DIFF
--- a/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
@@ -6,31 +6,42 @@ bgp_peering:
         - demo_bgp_outbound_filter
       segments:
         - lan_segment: lan-7-test
-          local_ipv4_address: 10.1.7.1
-          local_interface: GigabitEthernet7/0/0.18
           neighbors:
             - remote_ipv4_address: 10.1.7.11
               peer_as: 60011
+              local_interface: GigabitEthernet7/0/0.18
               ipv4_inbound_filter: demo_bgp_inbound_filter
               ipv4_outbound_filter: demo_bgp_outbound_filter
+              hold_timer: 180
+              keepalive_timer: 60
+              ebgp_multi_hop: 1
+              as_override: false
+              remote_private_as: false
+              allow_as_in: 1
+              # send_community: true
+              # bfd: true
+              # md5_password: "mustchangeme"
+
   - edge-2-sdktest:
       route_policies:
         - demo_bgp_inbound_filter
         - demo_bgp_outbound_filter
       segments:
         - lan_segment: lan-7-test
-          local_ipv4_address: 10.2.7.2
-          local_interface: GigabitEthernet8/0/0.28
           neighbors:
             - remote_ipv4_address: 10.2.7.12
               peer_as: 60021
               ipv4_inbound_filter: demo_bgp_inbound_filter
               ipv4_outbound_filter: demo_bgp_outbound_filter
         - lan_segment: lan-8-test
-          local_ipv4_address: 10.2.8.2
-          local_interface: GigabitEthernet8/0/0.29
           neighbors:
             - remote_ipv4_address: 10.2.8.12
               peer_as: 60023
+              local_interface: GigabitEthernet8/0/0.29
+              ipv4_inbound_filter: demo_bgp_inbound_filter
+              ipv4_outbound_filter: demo_bgp_outbound_filter
+            - remote_ipv4_address: 10.2.88.13
+              peer_as: 60024
+              local_interface: GigabitEthernet8/0/0.30
               ipv4_inbound_filter: demo_bgp_inbound_filter
               ipv4_outbound_filter: demo_bgp_outbound_filter

--- a/ansible_collections/graphiant/naas/configs/sample_interface_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_interface_config.yaml
@@ -50,6 +50,15 @@ interfaces:
           mtu: 1450
           v4_tcp_mss: 1392
           v6_tcp_mss: 1220
+        - vlan: 30
+          lan: lan-8-test
+          ipv4: 10.2.88.3/24
+          ipv6: 2001:10:2:88::3/64
+          description: Segment-8 interface
+          alias: Gig8.30
+          mtu: 1450
+          v4_tcp_mss: 1392
+          v6_tcp_mss: 1220
 
   - edge-3-sdktest:  
     # WAN Sub-Interface with DHCP IPv4/IPv6 assignment

--- a/ansible_collections/graphiant/naas/templates/bgp_peering_template.yaml
+++ b/ansible_collections/graphiant/naas/templates/bgp_peering_template.yaml
@@ -22,7 +22,11 @@
                                 "neighbor": {
                                     "peerAsn": {{ neighbor.peer_as }},
                                     "localInterface": {
-                                        "interface": "{{ entry.local_interface }}"
+                                        {% if neighbor.local_interface %}
+                                            "interface": "{{ neighbor.local_interface }}"
+                                        {% else %}
+                                            "interface": null
+                                        {% endif %}
                                     },
                                     "remoteAddress": "{{ neighbor.remote_ipv4_address }}",
                                     "enabled": true,
@@ -94,7 +98,11 @@
                                     "asOverride": {{ neighbor.as_override | default('false') }},
                                     "removePrivateAs": {{ neighbor.remote_private_as | default('false') }},
                                     "allowAsIn": {
-                                        "count": null
+                                        {% if neighbor.allow_as_in %}
+                                            "count": {{ neighbor.allow_as_in }}
+                                        {% else %}
+                                            "count": null
+                                        {% endif %}
                                     }
                                 }
                             {% else %}


### PR DESCRIPTION
Issue: https://github.com/Graphiant-Inc/graphiant-playbooks/issues/17

TE-4321 Fix graphiant_bgp template to support BGP peers with multiple different local interfaces in the same segment

- local_ipv4_address is not used in template/payload, so removed it
- Make local_interface optional (sets null if not provided, matching UI behavior)
- Update sample config to demonstrate multiple neighbors with different interfaces
- Add prerequisite interface config for testing