### PR TITLE
TE-4354 :: BFD Support in BGP peering

### DIFF
--- a/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
@@ -21,8 +21,8 @@ bgp_peering:
               # send_community: true
               # md5_password: "mustchangeme"
               bfd: true
-              minimumInterval: 1200 # in milliseconds, Range: 250-30000 (default: 1000)
-              localMultiplier: 4 # Range: 1-255 (default: 3)
+              minimum_interval: 1200 # in milliseconds, Range: 250-30000 (default: 1000)
+              local_multiplier: 4 # Range: 1-255 (default: 3)
 
   - edge-2-sdktest:
       route_policies:

--- a/ansible_collections/graphiant/naas/templates/bgp_peering_template.yaml
+++ b/ansible_collections/graphiant/naas/templates/bgp_peering_template.yaml
@@ -20,14 +20,14 @@
                         "{{ neighbor.remote_ipv4_address }}": {
                             {% if action != "delete" %}
                                 "neighbor": {
+                                    {% if neighbor.peer_as %}
                                     "peerAsn": {{ neighbor.peer_as }},
+                                    {% endif %}
+                                    {% if neighbor.local_interface %}
                                     "localInterface": {
-                                        {% if neighbor.local_interface %}
-                                            "interface": "{{ neighbor.local_interface }}"
-                                        {% else %}
-                                            "interface": null
-                                        {% endif %}
+                                        "interface": "{{ neighbor.local_interface }}"
                                     },
+                                    {% endif %}
                                     "remoteAddress": "{{ neighbor.remote_ipv4_address }}",
                                     "enabled": true,
                                     "state": "UnknownBGPNeighborState",
@@ -43,10 +43,12 @@
                                     "maxPrefixValue": {},
                                     "bfd": {
                                         "bfd": {
-                                            "enabled": {{ neighbor.bfd | default('false') }}
-                                            {% if neighbor.bfd %}
-                                            ,"minimumInterval": {{ neighbor.minimumInterval | default(1000) }},
-                                            "localMultiplier": {{ neighbor.localMultiplier | default(3) }}
+                                            "enabled": {{ neighbor.bfd | default('false') }}{% if neighbor.minimum_interval or neighbor.local_multiplier %},{% endif %}
+                                            {% if neighbor.minimum_interval %}
+                                            "minimumInterval": {{ neighbor.minimum_interval }}{% if neighbor.local_multiplier %},{% endif %}
+                                            {% endif %}
+                                            {% if neighbor.local_multiplier %}
+                                            "localMultiplier": {{ neighbor.local_multiplier }}
                                             {% endif %}
                                         }
                                     },


### PR DESCRIPTION
`TASK [Configure BGP peering] ********************************************************************************************************************************************
changed: [localhost]

TASK [Display BGP peering result] ***************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Successfully configured BGP peering and attached policies\n\nDetailed logs:\n2026-01-16 14:59:52,593 - Graphiant_playbook - INFO - Poller attempt: 1/3\n2026-01-16 14:59:52,593 - Graphiant_playbook - INFO - Calling method post_global_summary()...\n2026-01-16 14:59:52,594 - Graphiant_playbook - INFO - post_global_summary : config to be pushed : \nipfix_exported_type=None ntp_type=None prefix_set_type=None routing_policy_type=True snmp_type=None syslog_server_type=None traffic_policy_type=None\n2026-01-16 14:59:54,295 - Graphiant_playbook - INFO - Poller attempt: 1/3\n2026-01-16 14:59:54,296 - Graphiant_playbook - INFO - Calling method post_global_summary()...\n2026-01-16 14:59:54,296 - Graphiant_playbook - INFO - post_global_summary : config to be pushed : \nipfix_exported_type=None ntp_type=None prefix_set_type=None routing_policy_type=True snmp_type=None syslog_server_type=None traffic_policy_type=None\n2026-01-16 14:59:56,027 - Graphiant_playbook - INFO - Configured BGP peering for device: edge-1-sdktest (ID: 30000034190)\n2026-01-16 14:59:56,266 - Graphiant_playbook - INFO - Poller attempt: 1/3\n2026-01-16 14:59:56,266 - Graphiant_playbook - INFO - Calling method post_global_summary()...\n2026-01-16 14:59:56,266 - Graphiant_playbook - INFO - post_global_summary : config to be pushed : \nipfix_exported_type=None ntp_type=None prefix_set_type=None routing_policy_type=True snmp_type=None syslog_server_type=None traffic_policy_type=None\n2026-01-16 14:59:57,966 - Graphiant_playbook - INFO - Poller attempt: 1/3\n2026-01-16 14:59:57,966 - Graphiant_playbook - INFO - Calling method post_global_summary()...\n2026-01-16 14:59:57,966 - Graphiant_playbook - INFO - post_global_summary : config to be pushed : \nipfix_exported_type=None ntp_type=None prefix_set_type=None routing_policy_type=True snmp_type=None syslog_server_type=None traffic_policy_type=None\n2026-01-16 14:59:59,717 - Graphiant_playbook - INFO - Configured BGP peering for device: edge-2-sdktest (ID: 30000034191)\n2026-01-16 14:59:59,717 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 1, time remaining 120.00s\n2026-01-16 14:59:59,718 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 1, time remaining 120.00s\n2026-01-16 14:59:59,961 - Graphiant_playbook - INFO - put_device_config : config to be pushed for 30000034190: \n{\n  \"edge\": {\n    \"routePolicies\": {\n      \"demo_bgp_inbound_filter\": {\n        \"policy\": {\n          \"globalId\": 43860,\n          \"isGlobalSync\": true\n        }\n      },\n      \"demo_bgp_outbound_filter\": {\n        \"policy\": {\n          \"globalId\": 43861,\n          \"isGlobalSync\": true\n        }\n      }\n    },\n    \"segments\": {\n      \"lan-7-test\": {\n        \"bgpNeighbors\": {\n          \"10.1.7.11\": {\n            \"neighbor\": {\n              \"addressFamilies\": {\n                \"ipv4\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv4\",\n                    \"inboundPolicy\": {\n                      \"policy\": \"demo_bgp_inbound_filter\"\n                    },\n                    \"outboundPolicy\": {\n                      \"policy\": \"demo_bgp_outbound_filter\"\n                    }\n                  }\n                },\n                \"ipv6\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv6\"\n                  }\n                }\n              },\n              \"allowAsIn\": {\n                \"count\": 1\n              },\n              \"asOverride\": false,\n              \"bfd\": {\n                \"bfd\": {\n                  \"enabled\": true,\n                  \"localMultiplier\": 4,\n                  \"minimumInterval\": 1200\n                }\n              },\n              \"ebgpMultihopTtl\": {\n                \"multiHop\": 1\n              },\n              \"enabled\": true,\n              \"holdTimerValue\": {\n                \"timer\": 180\n              },\n              \"keepaliveTimerValue\": {\n                \"timer\": 60\n              },\n              \"localInterface\": {\n                \"interface\": \"GigabitEthernet7/0/0.18\"\n              },\n              \"maxPrefixValue\": {},\n              \"md5Password\": {},\n              \"peerAsn\": 60011,\n              \"remoteAddress\": \"10.1.7.11\",\n              \"removePrivateAs\": false,\n              \"sendCommunity\": true\n            }\n          }\n        }\n      }\n    }\n  }\n}\n2026-01-16 15:00:00,318 - Graphiant_playbook - INFO - put_device_config : config to be pushed for 30000034191: \n{\n  \"edge\": {\n    \"routePolicies\": {\n      \"demo_bgp_inbound_filter\": {\n        \"policy\": {\n          \"globalId\": 43860,\n          \"isGlobalSync\": true\n        }\n      },\n      \"demo_bgp_outbound_filter\": {\n        \"policy\": {\n          \"globalId\": 43861,\n          \"isGlobalSync\": true\n        }\n      }\n    },\n    \"segments\": {\n      \"lan-7-test\": {\n        \"bgpNeighbors\": {\n          \"10.2.7.12\": {\n            \"neighbor\": {\n              \"addressFamilies\": {\n                \"ipv4\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv4\",\n                    \"inboundPolicy\": {\n                      \"policy\": \"demo_bgp_inbound_filter\"\n                    },\n                    \"outboundPolicy\": {\n                      \"policy\": \"demo_bgp_outbound_filter\"\n                    }\n                  }\n                },\n                \"ipv6\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv6\"\n                  }\n                }\n              },\n              \"allowAsIn\": {},\n              \"asOverride\": false,\n              \"bfd\": {\n                \"bfd\": {\n                  \"enabled\": true,\n                  \"localMultiplier\": 3,\n                  \"minimumInterval\": 1000\n                }\n              },\n              \"ebgpMultihopTtl\": {\n                \"multiHop\": 1\n              },\n              \"enabled\": true,\n              \"holdTimerValue\": {\n                \"timer\": 90\n              },\n              \"keepaliveTimerValue\": {\n                \"timer\": 30\n              },\n              \"localInterface\": {},\n              \"maxPrefixValue\": {},\n              \"md5Password\": {},\n              \"peerAsn\": 60021,\n              \"remoteAddress\": \"10.2.7.12\",\n              \"removePrivateAs\": false,\n              \"sendCommunity\": true\n            }\n          }\n        }\n      },\n      \"lan-8-test\": {\n        \"bgpNeighbors\": {\n          \"10.2.8.12\": {\n            \"neighbor\": {\n              \"addressFamilies\": {\n                \"ipv4\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv4\",\n                    \"inboundPolicy\": {\n                      \"policy\": \"demo_bgp_inbound_filter\"\n                    },\n                    \"outboundPolicy\": {\n                      \"policy\": \"demo_bgp_outbound_filter\"\n                    }\n                  }\n                },\n                \"ipv6\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv6\"\n                  }\n                }\n              },\n              \"allowAsIn\": {},\n              \"asOverride\": false,\n              \"bfd\": {\n                \"bfd\": {\n                  \"enabled\": false\n                }\n              },\n              \"ebgpMultihopTtl\": {\n                \"multiHop\": 1\n              },\n              \"enabled\": true,\n              \"holdTimerValue\": {\n                \"timer\": 90\n              },\n              \"keepaliveTimerValue\": {\n                \"timer\": 30\n              },\n              \"localInterface\": {\n                \"interface\": \"GigabitEthernet8/0/0.29\"\n              },\n              \"maxPrefixValue\": {},\n              \"md5Password\": {},\n              \"peerAsn\": 60023,\n              \"remoteAddress\": \"10.2.8.12\",\n              \"removePrivateAs\": false,\n              \"sendCommunity\": true\n            }\n          },\n          \"10.2.88.13\": {\n            \"neighbor\": {\n              \"addressFamilies\": {\n                \"ipv4\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv4\",\n                    \"inboundPolicy\": {\n                      \"policy\": \"demo_bgp_inbound_filter\"\n                    },\n                    \"outboundPolicy\": {\n                      \"policy\": \"demo_bgp_outbound_filter\"\n                    }\n                  }\n                },\n                \"ipv6\": {\n                  \"family\": {\n                    \"addressFamily\": \"ipv6\"\n                  }\n                }\n              },\n              \"allowAsIn\": {},\n              \"asOverride\": false,\n              \"bfd\": {\n                \"bfd\": {\n                  \"enabled\": false\n                }\n              },\n              \"ebgpMultihopTtl\": {\n                \"multiHop\": 1\n              },\n              \"enabled\": true,\n              \"holdTimerValue\": {\n                \"timer\": 90\n              },\n              \"keepaliveTimerValue\": {\n                \"timer\": 30\n              },\n              \"localInterface\": {\n                \"interface\": \"GigabitEthernet8/0/0.30\"\n              },\n              \"maxPrefixValue\": {},\n              \"md5Password\": {},\n              \"peerAsn\": 60024,\n              \"remoteAddress\": \"10.2.88.13\",\n              \"removePrivateAs\": false,\n              \"sendCommunity\": true\n            }\n          }\n        }\n      }\n    }\n  }\n}\n2026-01-16 15:00:01,790 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 1, time remaining 120.00s\n2026-01-16 15:00:02,117 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 1, time remaining 120.00s\n2026-01-16 15:00:02,215 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:02,215 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:02,215 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:02,531 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:02,531 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:02,532 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:12,221 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 2, time remaining 109.57s\n2026-01-16 15:00:12,537 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 2, time remaining 109.58s\n2026-01-16 15:00:12,633 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:12,633 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:12,633 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:12,942 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:12,943 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:12,943 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:22,638 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 3, time remaining 99.15s\n2026-01-16 15:00:22,944 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 3, time remaining 99.17s\n2026-01-16 15:00:23,050 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:23,050 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:23,050 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:23,373 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:23,373 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:23,373 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:33,051 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 4, time remaining 88.74s\n2026-01-16 15:00:33,378 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 4, time remaining 88.74s\n2026-01-16 15:00:33,474 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:33,474 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034190 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:33,474 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:33,791 - Graphiant_playbook - INFO - verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..\n2026-01-16 15:00:33,791 - Graphiant_playbook - INFO - Exception caught while calling method verify_device_portal_status(): APIError('verify_device_portal_status: 30000034191 Portal Status: Configuring Expected: Ready. Retrying..')\n2026-01-16 15:00:33,791 - Graphiant_playbook - INFO - Sleeping for 10 seconds before poller re-attempt...\n2026-01-16 15:00:43,480 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 5, time remaining 78.31s\n2026-01-16 15:00:43,795 - Graphiant_playbook - INFO - ansible_collections.graphiant.naas.plugins.module_utils.libs.gcsdk_client.verify_device_portal_status(): attempt 5, time remaining 78.32s\n2026-01-16 15:00:44,229 - Graphiant_playbook - INFO - Successfully configured BGP peering for 2 devices\n"
}

PLAY RECAP **************************************************************************************************************************************************************
localhost                  : ok=6    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   `