### PR TITLE
TE-4366 Fix idempotent in the interface related modules operations (part1) and add tests

### DIFF
--- a/ansible_collections/graphiant/naas/configs/de_workflows_configs/sample_edge_lan_interfaces_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/de_workflows_configs/sample_edge_lan_interfaces_config.yaml
@@ -2,14 +2,12 @@ interfaces:
   - edge-1-sdktest:
     # LAN Sub-Interface (VLAN) with Static IPv4 assignment
     - name: GigabitEthernet4/0/0
-      sub_interfaces:
+      subinterfaces:
         - vlan: 1
           lan: lan-segment-3
           ipv4: 10.1.1.1/24
           description: lan-segment-3 interface
-          alias: Gig3.1
-          v4_tcp_mss: 1392
-          v6_tcp_mss: 1220
+          alias: Gig4.1
 
   - edge-2-sdktest:
     # LAN interface with Static IPv4 assignments
@@ -17,9 +15,6 @@ interfaces:
       ipv4: 10.1.2.1/24
       lan: lan-segment-3
       description: lan-segment-3 interface
-      mtu: 1500
-      v4_tcp_mss: 1392
-      v6_tcp_mss: 1220
 
   - edge-3-sdktest:  
     # LAN Interface with Static IPv4/IPv6 assignment
@@ -27,6 +22,3 @@ interfaces:
       ipv4: 10.1.3.1/24
       lan: lan-segment-3
       description: lan-segment-3 interface
-      mtu: 1500
-      v4_tcp_mss: 1392
-      v6_tcp_mss: 1220

--- a/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_bgp_peering.yaml
@@ -7,7 +7,7 @@ bgp_peering:
       segments:
         - lan_segment: lan-7-test
           neighbors:
-            - remote_ipv4_address: 10.1.7.11
+            - remote_ipv4_address: 10.1.17.11
               peer_as: 60011
               local_interface: GigabitEthernet7/0/0.18
               ipv4_inbound_filter: demo_bgp_inbound_filter
@@ -31,19 +31,19 @@ bgp_peering:
       segments:
         - lan_segment: lan-7-test
           neighbors:
-            - remote_ipv4_address: 10.2.7.12
+            - remote_ipv4_address: 10.3.177.11
               peer_as: 60021
               ipv4_inbound_filter: demo_bgp_inbound_filter
               ipv4_outbound_filter: demo_bgp_outbound_filter
               bfd: true
         - lan_segment: lan-8-test
           neighbors:
-            - remote_ipv4_address: 10.2.8.12
+            - remote_ipv4_address: 10.2.18.11
               peer_as: 60023
               local_interface: GigabitEthernet8/0/0.29
               ipv4_inbound_filter: demo_bgp_inbound_filter
               ipv4_outbound_filter: demo_bgp_outbound_filter
-            - remote_ipv4_address: 10.2.88.13
+            - remote_ipv4_address: 10.2.188.11
               peer_as: 60024
               local_interface: GigabitEthernet8/0/0.30
               ipv4_inbound_filter: demo_bgp_inbound_filter

--- a/ansible_collections/graphiant/naas/configs/sample_global_ipfix_exporters.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_global_ipfix_exporters.yaml
@@ -2,7 +2,7 @@ ipfix_exporters:
   # Global IPFIX Exporter Configuration
   - name: ipfix-global-test
     exporter:
-      destinationAddress: 10.1.7.2
+      destinationAddress: 10.1.17.2
       destinationPort: 70
       monitoredSegments:
         - lan-7-test

--- a/ansible_collections/graphiant/naas/configs/sample_global_lan_segments.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_global_lan_segments.yaml
@@ -18,3 +18,15 @@ lan_segments:
 
   - name: "lan-8-test"
     description: "LAN segment for testing"
+
+  - name: "lag-test"
+    description: "LAN segment for testing lag interface"
+
+  - name: "lag-test-2"
+    description: "LAN segment for testing lag interface"
+
+  - name: "lag-test-101"
+    description: "LAN segment for testing lag interface"
+
+  - name: "lag-test-102"
+    description: "LAN segment for testing lag interface"

--- a/ansible_collections/graphiant/naas/configs/sample_global_syslog_servers.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_global_syslog_servers.yaml
@@ -2,7 +2,7 @@ syslog_servers:
   # Global Syslog Server Configuration
   - name: syslog-global-test
     target:
-      host: 10.1.7.2
+      host: 10.1.17.2
       port: 443
       transport: tcp
       severity: alert

--- a/ansible_collections/graphiant/naas/configs/sample_interface_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_interface_config.yaml
@@ -1,3 +1,11 @@
+# Interface Configuration
+# Supported parameter aliases:
+#   - subinterfaces / sub_interfaces (legacy)
+#   - maxTransmissionUnit / mtu (legacy)
+#   - adminStatus / enabled (legacy)
+#   - v4TcpMss / v4_tcp_mss (legacy)
+#   - v6TcpMss / v6_tcp_mss (legacy)
+
 interfaces:
   - edge-1-sdktest:
     # WAN Interface with IPv4/IPv6 DHCP enabled
@@ -5,94 +13,104 @@ interfaces:
       circuit: c-gigabitethernet5-0-0
       description: Wan 2 interface
       alias: Gig5
-      mtu: 1500
-    # LAN Sub-Interface (VLAN) with Static IP assignment
+    # LAN Sub-Interface (VLAN) with Static IPv4 assignment
+    - name: GigabitEthernet4/0/0
+      subinterfaces:
+        - vlan: 1
+          lan: lan-segment-3
+          ipv4: 10.1.1.1/24
+          description: lan-segment-3 interface
+          alias: Gig4.1
+    # LAN Interface and Sub-Interface (VLAN) with Static IP assignment
     - name: GigabitEthernet7/0/0
-      ipv4: 10.1.1.1/24
-      ipv6: 2001:10:1:1::1/64
+      ipv4: 10.1.11.1/24
+      ipv6: 2001:db8:10:1:11::1/64
       lan: lan-1-test
-      description: Segment-1 interface
-      mtu: 1500
-      sub_interfaces:
+      description: Segment lan-1-test interface
+      maxTransmissionUnit: 1500
+      subinterfaces:
         - vlan: 18
           lan: lan-7-test
-          ipv4: 10.1.7.1/24
-          ipv6: 2001:10:1:7::1/64
+          ipv4: 10.1.17.1/24
+          ipv6: 2001:db8:10:1:17::1/64
           description: Segment lan-7-test interface
           alias: Gig7.18
-          v4_tcp_mss: 1392
-          v6_tcp_mss: 1220
+          v4TcpMss: 1392
+          v6TcpMss: 1220
 
   - edge-2-sdktest:
     # WAN Interface with Static IPv4 and DHCP IPv6 assignment and not enabling it
     - name: GigabitEthernet5/0/0
       circuit: c-gigabitethernet5-0-0
       ipv4: 100.200.1.1/24
-      enabled: false
-      mtu: 1500
+      adminStatus: false
+    # LAN interface with Static IPv4 assignments
+    - name: GigabitEthernet4/0/0
+      ipv4: 10.1.2.1/24
+      lan: lan-segment-3
+      description: lan-segment-3 interface
     # LAN interface and Multiple LAN Sub-Interfaces(VLANs) with Static IPv4/IPv6 assignments
     - name: GigabitEthernet8/0/0
-      ipv4: 10.2.1.2/24
-      ipv6: 2001:10:2:1::2/64
+      ipv4: 10.2.11.1/24
+      ipv6: 2001:db8:10:2:11::1/64
       lan: lan-1-test
       description: Segment-1 interface
-      mtu: 1500
-      v4_tcp_mss: 1392
-      v6_tcp_mss: 1220
-      sub_interfaces:
+      maxTransmissionUnit: 1500
+      v4TcpMss: 1392
+      subinterfaces:
         - vlan: 28
           lan: lan-7-test
-          ipv4: 10.2.7.2/24
-          ipv6: 2001:10:2:7::2/64
+          ipv4: 10.3.177.2/24
+          ipv6: 2001:10:3:177::2/64
           description: Segment-7 interface
           alias: Gig8.28
         - vlan: 29
           lan: lan-8-test
-          ipv4: 10.2.8.2/24
-          ipv6: 2001:10:2:8::2/64
+          ipv4: 10.2.18.1/24
+          ipv6: 2001:db8:10:2:18::1/64
           description: Segment-8 interface
           alias: Gig8.29
-          mtu: 1450
-          v4_tcp_mss: 1392
-          v6_tcp_mss: 1220
+          v4TcpMss: 1392
         - vlan: 30
           lan: lan-8-test
-          ipv4: 10.2.88.3/24
-          ipv6: 2001:10:2:88::3/64
+          ipv4: 10.2.188.1/24
+          ipv6: 2001:10:2:188::1/64
           description: Segment-8 interface
           alias: Gig8.30
-          mtu: 1450
-          v4_tcp_mss: 1392
-          v6_tcp_mss: 1220
 
   - edge-3-sdktest:  
-    # WAN Sub-Interface with DHCP IPv4/IPv6 assignment
+    # WAN Sub-Interface with IPv4/IPv6 assignment
     - name: GigabitEthernet5/0/0
       circuit: c-gigabitethernet5-0-0
       ipv4: 100.200.1.1/24
-      enabled: false
-      mtu: 1450
-      sub_interfaces:
+      adminStatus: false
+      maxTransmissionUnit: 1450
+      subinterfaces:
         - vlan: 1001
           circuit: c-gigabitethernet5-0-0.1001
           description: c-gigabitethernet5-0-0.1001 wan subinterface
           alias: Gig5.1001
-          ipv4: 100.200.30.3/24
-          ipv6: 2001:10:2:30::1/64
-
+          ipv4: 100.200.30.1/24
+          ipv6: 2001:db8:100:200:30::1/64
     # LAN Interface with Static IPv4/IPv6 assignment
+    - name: GigabitEthernet4/0/0
+      ipv4: 10.1.3.1/24
+      lan: lan-segment-3
+      description: lan-segment-3 interface
+
+    # LAN Interface and Sub-Interface (VLAN) with Static IPv4/IPv6 assignment
     - name: GigabitEthernet8/0/0
-      ipv4: 10.3.7.3/24
-      ipv6: 2001:10:3:7::3/64
+      ipv4: 10.3.17.1/24
+      ipv6: 2001:db8:10:3:17::1/64
       lan: lan-7-test
       description: Segment-7 interface
-      mtu: 1500
+      mtu: 1450
       v4_tcp_mss: 1392
       v6_tcp_mss: 1220
       sub_interfaces:
         - vlan: 28
           lan: lan-7-test
-          ipv4: 10.2.7.3/24
-          ipv6: 2001:10:2:7::3/64
-          description: Segment-7 interface
+          ipv4: 10.3.177.3/24
+          ipv6: 2001:10:3:177::3/64
+          description: Segment-7 subinterface
           alias: Gig8.28

--- a/ansible_collections/graphiant/naas/configs/sample_lag_interface_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_lag_interface_config.yaml
@@ -1,44 +1,57 @@
 # LAG Interface Configuration Parameters:
 # ==============================
 # Below are the examples for each operation:
-# when operation: configure or deconfigure
-# lagInterfaces:
-#   - edge-1-sdktest:
-#     - name: LAG1
-#       alias: LAG1
-#       segment: lag-test
-#       mtu: 1500
-#       ipv4: 10.1.0.1/24
-#       ipv6: 2001:10:1:0::1/64
-#       lacpMode: ACTIVE
-#       lacpTimer: FAST
-#       lagMembers:
-#         - GigabitEthernet4/0/0
-#   - edge-2-sdktest:
-#     - name: LAG1
-#       alias: LAG1
-#       segment: lag-test
-#       mtu: 1500
-#       ipv4: 10.2.0.1/24
-#       ipv6: 2001:10:2:0::1/64
-#       lacpMode: PASSIVE
-#       lacpTimer: SLOW
-#       lagMembers:
-#         - GigabitEthernet4/0/0
-#         - GigabitEthernet6/0/0
-#       subinterfaces:
-#         - vlan: 101
-#           segment: lag-test-101
-#           alias: LAG1-101
-#           description: Segment lag-test-101 interface
-#           ipv4: 10.2.1.1/24
-#           ipv6: 2001:10:2:1::1/64
-#         - vlan: 102
-#           segment: lag-test-102
-#           alias: LAG1-102
-#           description: Segment lag-test-102 interface
-#           ipv4: 10.2.2.1/24
-#           ipv6: 2001:10:2:2::1/64
+# when operation: configure or deconfigure or add_lag_members or remove_lag_members or update_lacp_configs or delete_lag_subinterfaces
+lagInterfaces:
+  - edge-1-sdktest:
+    - name: LAG1
+      alias: LAG1
+      adminStatus: true
+      segment: lag-test
+      mtu: 1500
+      ipv4: 10.1.0.1/24
+      ipv6: 2001:10:1:0::1/64
+      lacpMode: ACTIVE
+      lacpTimer: FAST
+      lagMembers:
+        - GigabitEthernet6/0/0
+    - name: LAG2
+      alias: LAG2
+      segment: lag-test-2
+      mtu: 1500
+      ipv4: 10.1.2.1/24
+      ipv6: 2001:10:1:2::1/64
+      lacpMode: PASSIVE
+      lacpTimer: FAST
+      lagMembers:
+        - GigabitEthernet8/0/0
+
+  - edge-2-sdktest:
+    - name: LAG1
+      alias: LAG1
+      segment: lag-test
+      mtu: 1500
+      ipv4: 10.2.0.1/24
+      ipv6: 2001:10:2:0::1/64
+      lacpMode: PASSIVE
+      lacpTimer: SLOW
+      lagMembers:
+        - GigabitEthernet6/0/0
+        - GigabitEthernet7/0/0
+      subinterfaces:
+        - vlan: 101
+          segment: lag-test-101
+          alias: LAG1-101
+          description: Segment lag-test-101 interface
+          ipv4: 10.2.1.1/24
+          ipv6: 2001:10:2:1::1/64
+        - vlan: 102
+          segment: lag-test-102
+          alias: LAG1-102
+          description: Segment lag-test-102 interface
+          ipv4: 10.2.2.1/24
+          ipv6: 2001:10:2:2::1/64
+
 #
 # When operation: add_lag_members or remove_lag_members
 # lagInterfaces:
@@ -63,7 +76,8 @@
 #       lacpMode: ACTIVE  # Supported values: "ACTIVE" or "PASSIVE"
 #       lacpTimer: FAST   # Supported values: "FAST" or "SLOW"
 #
-# When operation: add_lag_subinterfaces or delete_lag_subinterfaces
+# When operation: delete_lag_subinterfaces
+# Note: To add/configure LAG subinterfaces, use "configure" operation with subinterfaces in the config file.
 # lagInterfaces:
 #   - gw-2-sdktest:
 #     - name: LAG1

--- a/ansible_collections/graphiant/naas/configs/sample_vrrp_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_vrrp_config.yaml
@@ -1,6 +1,6 @@
 # VRRP Configuration Parameters:
 # ==============================
-# interfaceName: Name of the interface (e.g., "GigabitEthernet7/0/0")
+# name: Name of the interface (e.g., "GigabitEthernet7/0/0")
 # vlan: (optional) VLAN ID of the subinterface. Omit for main interface VRRP.
 # vrrp_ipv4 / vrrp_ipv6:
 #   enabled: true/false - Enable or disable VRRP group
@@ -17,14 +17,14 @@
 vrrp_config:
   # Edge Device 1: Configure VRRP on main interface
   - edge-1-sdktest:
-    - interfaceName: GigabitEthernet7/0/0
+    - name: GigabitEthernet7/0/0
       # No vlan specified = main interface
       # VRRP IPv4 configuration
       vrrp_ipv4:
         enabled: true
         virtualRouterId: 1
         priority: 120
-        virtualIp: "10.1.1.100"
+        virtualIp: "10.1.11.100"
         preempt: true
         allowInterOperability: true
         trackedInterfaces:
@@ -33,14 +33,14 @@ vrrp_config:
 
   # Edge Device 2: Configure VRRP on subinterface (VLAN)
   - edge-2-sdktest:
-    - interfaceName: GigabitEthernet8/0/0
+    - name: GigabitEthernet8/0/0
       vlan: 28
       # VRRP IPv4 configuration
       vrrp_ipv4:
         enabled: true
         virtualRouterId: 10
         priority: 120
-        virtualIp: "10.2.7.100"
+        virtualIp: "10.3.177.100"
         preempt: true
         allowInterOperability: false
         trackedInterfaces:
@@ -51,20 +51,20 @@ vrrp_config:
         enabled: true
         virtualRouterId: 11
         priority: 120
-        virtualIp: "2001:10:2:7::100"
+        virtualIp: "2001:10:3:177::100"
         preempt: false
         allowInterOperability: false
 
   # Edge Device 3: Configure VRRP on subinterface
   - edge-3-sdktest:
     # Subinterface VRRP
-    - interfaceName: GigabitEthernet8/0/0
+    - name: GigabitEthernet8/0/0
       vlan: 28
       vrrp_ipv4:
-        enabled: true
+        enabled: false
         virtualRouterId: 10
         priority: 100
-        virtualIp: "10.2.7.100"
+        virtualIp: "10.3.177.100"
         preempt: true
         allowInterOperability: false
         trackedInterfaces:
@@ -74,6 +74,6 @@ vrrp_config:
         enabled: true
         virtualRouterId: 11
         priority: 110
-        virtualIp: "2001:10:2:7::100"
+        virtualIp: "2001:10:3:177::100"
         preempt: false
         allowInterOperability: false

--- a/ansible_collections/graphiant/naas/playbooks/lag_interface_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/lag_interface_management.yml
@@ -17,11 +17,14 @@
       # password: "{{ graphiant_password | default(lookup('ini', 'password file=/absolute/path/credentials.ini section=credentials')) }}"
 
   tasks:
+    # Note: All LAG operations are idempotent - safe to run multiple times
+    # The module automatically checks existing state and skips if already configured/added/removed/updated
+
     - name: Configure LAG interfaces (LAG + optional subinterfaces)
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: configure
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
         state: present
       register: configure_result
@@ -37,7 +40,7 @@
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: add_lag_members
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
       register: add_members_result
       tags: ['add_lag_members']
@@ -52,7 +55,7 @@
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: remove_lag_members
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
       register: remove_members_result
       tags: ['remove_lag_members']
@@ -67,7 +70,7 @@
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: update_lacp_configs
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
       register: update_lacp_result
       tags: ['update_lacp_configs']
@@ -78,26 +81,12 @@
       when: update_lacp_result is defined and update_lacp_result.msg is defined
       tags: ['update_lacp_configs']
 
-    - name: Configure LAG subinterfaces (VLANs)
-      graphiant.naas.graphiant_lag_interfaces:
-        <<: *graphiant_client_params
-        operation: add_lag_subinterfaces
-        config_yaml_file: "sample_lag_interface_config.yaml"
-        detailed_logs: true
-      register: add_subif_result
-      tags: ['add_lag_subinterfaces']
-
-    - name: Display Configure LAG Subinterfaces Results
-      ansible.builtin.debug:
-        msg: "{{ add_subif_result.msg }}"
-      when: add_subif_result is defined and add_subif_result.msg is defined
-      tags: ['add_lag_subinterfaces']
-
     - name: Delete LAG subinterfaces (VLANs)
+      # Idempotent: Skips if LAG or subinterface doesn't exist
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: delete_lag_subinterfaces
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
       register: delete_subif_result
       tags: ['delete_lag_subinterfaces']
@@ -112,7 +101,7 @@
       graphiant.naas.graphiant_lag_interfaces:
         <<: *graphiant_client_params
         operation: deconfigure
-        config_yaml_file: "sample_lag_interface_config.yaml"
+        lag_config_file: "sample_lag_interface_config.yaml"
         detailed_logs: true
         state: absent
       register: deconfigure_result

--- a/ansible_collections/graphiant/naas/playbooks/vrrp_interface_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/vrrp_interface_management.yml
@@ -17,6 +17,9 @@
       # password: "{{ graphiant_password | default(lookup('ini', 'password file=/absolute/path/credentials.ini section=credentials')) }}"
 
   tasks:
+    # Note: All VRRP operations are idempotent - safe to run multiple times
+    # The module automatically checks existing state and skips if already configured/enabled/disabled
+
     - name: Configure VRRP on interfaces
       graphiant.naas.graphiant_vrrp:
         <<: *graphiant_client_params
@@ -33,7 +36,22 @@
       when: configure_result is defined and configure_result.msg is defined
       tags: ['vrrp_interfaces', 'configure']
 
-    - name: Deconfigure VRRP from interfaces
+    - name: Enable existing VRRP configurations
+      graphiant.naas.graphiant_vrrp:
+        <<: *graphiant_client_params
+        operation: enable
+        vrrp_config_file: "sample_vrrp_config.yaml"
+        detailed_logs: true
+      register: enable_result
+      tags: ['vrrp_interfaces', 'enable']
+
+    - name: Display VRRP Enable Results
+      ansible.builtin.debug:
+        msg: "{{ enable_result.msg }}"
+      when: enable_result is defined and enable_result.msg is defined
+      tags: ['vrrp_interfaces', 'enable']
+
+    - name: Deconfigure VRRP from interfaces (disable)
       graphiant.naas.graphiant_vrrp:
         <<: *graphiant_client_params
         operation: deconfigure

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/config_utils.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/config_utils.py
@@ -179,8 +179,8 @@ class ConfigUtils(PortalUtils):
         Raises:
             ConfigurationError: If required parameters are missing.
         """
-        self._validate_required_params(kwargs, ['interfaceName'])
-        LOG.info("VRRP on interfaces: %s %s", action.upper(), kwargs.get('interfaceName'))
+        self._validate_required_params(kwargs, ['name'])
+        LOG.info("VRRP on interfaces: %s %s", action.upper(), kwargs.get('name'))
 
         try:
             result = self.template.render_vrrp_interfaces(action=action, **kwargs)
@@ -189,9 +189,9 @@ class ConfigUtils(PortalUtils):
                     config_payload["interfaces"] = {}
                 config_payload["interfaces"].update(result["interfaces"])
             else:
-                LOG.warning("No interfaces found in VRRP template result for %s", kwargs.get('interfaceName'))
+                LOG.warning("No interfaces found in VRRP template result for %s", kwargs.get('name'))
         except Exception as e:
-            LOG.error("Failed to process VRRP on interfaces %s: %s", kwargs.get('interfaceName'), str(e))
+            LOG.error("Failed to process VRRP on interfaces %s: %s", kwargs.get('name'), str(e))
             raise ConfigurationError(f"VRRP on interfaces processing failed: {str(e)}")
 
     def device_circuit(self, config_payload, action="add", **kwargs):

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/interface_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/interface_manager.py
@@ -18,7 +18,176 @@ class InterfaceManager(BaseManager):
 
     Handles the configuration and deconfiguration of network interfaces,
     including both regular interfaces and VLAN sub-interfaces.
+
+    Notes:
+        - Configure workflows push configuration via PUT and may not be fully idempotent.
+        - Deconfigure workflows are designed to be idempotent by checking current device state
+          (via `gsdk.get_device_info`) before building delete payloads.
+        - For WAN circuits, the backend can treat "detaching a circuit from an interface" as a
+          circuit removal operation. If that circuit still has static routes, the request may
+          fail with: `error removing circuit "<name>". Remove static routes first.`
+          Use `deconfigure_wan_circuits_interfaces()` or `deconfigure_interfaces()` to ensure
+          static routes are removed before WAN interface reset/detach.
     """
+
+    @staticmethod
+    def _get_subinterfaces(interface_config):
+        """Get subinterfaces from config, supporting both 'subinterfaces' and 'sub_interfaces' keys."""
+        return interface_config.get('subinterfaces') or interface_config.get('sub_interfaces') or []
+
+    @staticmethod
+    def _check_interface_exists(gcs_device_info, interface_name, vlan=None):
+        """
+        Check if an interface or subinterface exists on the device.
+
+        Args:
+            gcs_device_info: Device info object from gsdk.get_device_info()
+            interface_name: Name of the interface (e.g., 'GigabitEthernet7/0/0')
+            vlan: Optional VLAN ID for subinterface
+
+        Returns:
+            bool: True if interface/subinterface exists, False otherwise
+        """
+        if not hasattr(gcs_device_info, 'device'):
+            return False
+
+        device = gcs_device_info.device
+        if not hasattr(device, 'interfaces') or not device.interfaces:
+            return False
+
+        # Find the interface
+        target_interface = None
+        for interface in device.interfaces:
+            if getattr(interface, 'name', None) == interface_name:
+                target_interface = interface
+                break
+
+        if not target_interface:
+            return False
+
+        # If checking for subinterface
+        if vlan:
+            vlan_int = int(vlan) if vlan else None
+            if hasattr(target_interface, 'subinterfaces') and target_interface.subinterfaces:
+                for subintf in target_interface.subinterfaces:
+                    subintf_vlan = getattr(subintf, 'vlan', None)
+                    if subintf_vlan == vlan_int:
+                        return True
+            return False
+
+        # Main interface exists
+        return True
+
+    @staticmethod
+    def _get_interface_obj(gcs_device_info, interface_name):
+        """Return the interface object from device info, if present."""
+        if not hasattr(gcs_device_info, 'device'):
+            return None
+        device = gcs_device_info.device
+        if not hasattr(device, 'interfaces') or not device.interfaces:
+            return None
+        for interface in device.interfaces:
+            if getattr(interface, 'name', None) == interface_name:
+                return interface
+        return None
+
+    @classmethod
+    def _get_interface_lan(cls, gcs_device_info, interface_name):
+        """
+        Best-effort extraction of the interface LAN segment identifier/name from device info.
+        Returns None if not available.
+        """
+        interface = cls._get_interface_obj(gcs_device_info, interface_name)
+        if not interface:
+            return None
+
+        # Common attribute names seen across SDK models / versions
+        for attr in ('lan', 'lanSegment', 'lan_segment'):
+            val = getattr(interface, attr, None)
+            if val is None:
+                continue
+            if isinstance(val, str):
+                return val
+            # SDK objects sometimes wrap values; prefer "name" if present
+            if hasattr(val, 'name'):
+                return getattr(val, 'name')
+            return str(val)
+        return None
+
+    @classmethod
+    def _get_interface_circuit(cls, gcs_device_info, interface_name):
+        """
+        Best-effort extraction of the interface circuit identifier/name from device info.
+        Returns None if not available / not set.
+        """
+        interface = cls._get_interface_obj(gcs_device_info, interface_name)
+        if not interface:
+            return None
+
+        # Common attribute names seen across SDK models / versions
+        for attr in ('circuit', 'wanCircuit', 'wan_circuit'):
+            val = getattr(interface, attr, None)
+            if val is None:
+                continue
+            if isinstance(val, str):
+                return val
+            if hasattr(val, 'name'):
+                return getattr(val, 'name')
+            return str(val)
+        return None
+
+    @staticmethod
+    def _get_circuits_list(gcs_device_info):
+        """Return circuits list from SDK device info (best-effort)."""
+        if not hasattr(gcs_device_info, 'device'):
+            return []
+        return getattr(gcs_device_info.device, 'circuits', None) or []
+
+    @classmethod
+    def _get_circuit_obj(cls, gcs_device_info, circuit_name):
+        """Return the circuit object from device info, if present."""
+        for circuit in cls._get_circuits_list(gcs_device_info):
+            if getattr(circuit, 'name', None) == circuit_name:
+                return circuit
+        return None
+
+    @classmethod
+    def _get_circuit_static_route_prefixes(cls, gcs_device_info, circuit_name):
+        """
+        Return a set of static route prefixes currently present on a circuit.
+
+        SDK models typically represent this as:
+        - device.circuits[] (ManaV2Circuit)
+        - circuit.static_routes[] (List[ManaV2StaticRoute])
+        - static_route.prefix (str)
+        """
+        circuit = cls._get_circuit_obj(gcs_device_info, circuit_name)
+        if not circuit:
+            return set()
+
+        static_routes = getattr(circuit, 'static_routes', None)
+        if static_routes is None:
+            static_routes = getattr(circuit, 'staticRoutes', None)  # fallback for older SDK naming
+        if not static_routes:
+            return set()
+
+        # SDK model: List[ManaV2StaticRoute] where each route has .prefix
+        if isinstance(static_routes, (list, tuple)):
+            return {r.prefix for r in static_routes if getattr(r, 'prefix', None)}
+
+        # Defensive: some SDKs/serializers can expose this as dict keyed by prefix
+        if isinstance(static_routes, dict):
+            return {p for p, v in static_routes.items() if v not in (None, {})}
+
+        if hasattr(static_routes, 'to_dict'):
+            try:
+                sr = static_routes.to_dict()
+                if isinstance(sr, dict):
+                    return {p for p, v in sr.items() if v not in (None, {})}
+            except Exception:  # pylint: disable=broad-except
+                return set()
+
+        return set()
 
     def configure(self, interface_config_file: str, circuit_config_file: str = None) -> dict:  # pylint: disable=arguments-renamed
         """
@@ -92,10 +261,9 @@ class InterfaceManager(BaseManager):
                         if interface_config.get('circuit'):
                             referenced_circuits.add(interface_config['circuit'])
                         # Check subinterfaces for circuit references
-                        if interface_config.get('sub_interfaces'):
-                            for sub_interface in interface_config.get('sub_interfaces', []):
-                                if sub_interface.get('circuit'):
-                                    referenced_circuits.add(sub_interface['circuit'])
+                        for sub_interface in self._get_subinterfaces(interface_config):
+                            if sub_interface.get('circuit'):
+                                referenced_circuits.add(sub_interface['circuit'])
 
                     LOG.info("[configure] Processing device: %s (ID: %s)", device_name, device_id)
                     LOG.info("Referenced circuits: %s", list(referenced_circuits))
@@ -123,12 +291,11 @@ class InterfaceManager(BaseManager):
                         lan_subinterfaces = []
                         wan_subinterfaces = []
 
-                        if interface_config.get('sub_interfaces'):
-                            for sub_interface in interface_config.get('sub_interfaces', []):
-                                if sub_interface.get('lan'):
-                                    lan_subinterfaces.append(sub_interface)
-                                if sub_interface.get('circuit'):
-                                    wan_subinterfaces.append(sub_interface)
+                        for sub_interface in self._get_subinterfaces(interface_config):
+                            if sub_interface.get('lan'):
+                                lan_subinterfaces.append(sub_interface)
+                            if sub_interface.get('circuit'):
+                                wan_subinterfaces.append(sub_interface)
 
                         # Process this interface if it has any configuration
                         if has_lan_main or has_wan_main or lan_subinterfaces or wan_subinterfaces:
@@ -186,25 +353,38 @@ class InterfaceManager(BaseManager):
     def deconfigure(self, interface_config_file: str, circuit_config_file: str = None,  # pylint: disable=arguments-renamed
                     circuits_only: bool = False) -> dict:
         """
-        Deconfigure interfaces and circuits for multiple devices concurrently.
-        This method combines all interface and circuit deconfigurations in a single API call per device.
-        Circuits with staticRoutes configuration are explicitly deconfigured to ensure proper cleanup.
+        Deconfigure interfaces and (optionally) circuit static routes for multiple devices concurrently (idempotent).
+
+        This is the low-level deconfigure implementation that builds a single per-device payload.
+        It checks current device state (interfaces, subinterfaces, LAN/circuit attachment) before
+        building a delete payload.
+
+        Important WAN note:
+          - When resetting a WAN interface, the payload detaches the circuit (sets `circuit: null`).
+            The backend may treat that as a circuit removal and fail if static routes still exist.
+          - This method does NOT stage circuit-static-route deletion ahead of interface reset when
+            `circuits_only=False`. For WAN-safe staged deconfiguration, use:
+            `deconfigure_wan_circuits_interfaces(..., circuits_only=False)` or
+            `deconfigure_interfaces(..., circuits_only=False)`.
 
         Args:
             interface_config_file: Path to the YAML file containing interface configurations
             circuit_config_file: Optional path to the YAML file containing circuit configurations
-            circuits_only: If True, only deconfigure circuits, skip interface deconfiguration
+            circuits_only: If True, only remove circuit static routes (skip interface deconfiguration)
 
         Returns:
-            dict: Result with 'changed' status and list of deconfigured devices
-            Note: Always returns changed=True when devices are deconfigured since we push
-            via PUT API. True idempotency would require comparing current vs desired state.
+            dict: Result with 'changed' status, deconfigured and skipped devices/interfaces
 
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
-        result = {'changed': False, 'deconfigured_devices': []}
+        result = {
+            'changed': False,
+            'deconfigured_devices': [],
+            'deconfigured_interfaces': [],
+            'skipped_interfaces': []
+        }
 
         try:
             # Load interface configurations
@@ -247,10 +427,13 @@ class InterfaceManager(BaseManager):
                         raise ConfigurationError(f"Device '{device_name}' is not found in the current enterprise: "
                                                  f"{self.gsdk.enterprise_info['company_name']}. "
                                                  f"Please check device name and enterprise credentials.")
-                    output_config[device_id] = {
-                        "device_id": device_id,
-                        "edge": {"interfaces": {}, "circuits": {}}
-                    }
+
+                    # Get device info for idempotency check
+                    gcs_device_info = self.gsdk.get_device_info(device_id)
+
+                    # Only include sections we actually intend to change.
+                    # Avoid sending empty {"circuits": {}} which some backends interpret as "delete all circuits".
+                    device_config = {"interfaces": {}}
 
                     # Collect circuit names referenced in this device's interfaces and subinterfaces
                     referenced_circuits = set()
@@ -259,10 +442,9 @@ class InterfaceManager(BaseManager):
                         if interface_config.get('circuit'):
                             referenced_circuits.add(interface_config['circuit'])
                         # Check subinterfaces for circuit references
-                        if interface_config.get('sub_interfaces'):
-                            for sub_interface in interface_config.get('sub_interfaces', []):
-                                if sub_interface.get('circuit'):
-                                    referenced_circuits.add(sub_interface['circuit'])
+                        for sub_interface in self._get_subinterfaces(interface_config):
+                            if sub_interface.get('circuit'):
+                                referenced_circuits.add(sub_interface['circuit'])
 
                     LOG.info("[deconfigure] Processing device: %s (ID: %s)", device_name, device_id)
                     LOG.info("Referenced circuits: %s", list(referenced_circuits))
@@ -272,12 +454,51 @@ class InterfaceManager(BaseManager):
                     if circuits_only:
                         for circuit_config in configs.get("circuits", []):
                             if circuit_config.get('circuit') in referenced_circuits:
+                                circuit_name = circuit_config.get('circuit')
+                                # Idempotency: only push deletions for staticRoutes that actually exist
+                                existing_prefixes = self._get_circuit_static_route_prefixes(gcs_device_info, circuit_name)
+                                if not existing_prefixes:
+                                    LOG.info(" ✓ Circuit '%s' has no staticRoutes on %s, skipping", circuit_name, device_name)
+                                    result['skipped_interfaces'].append({
+                                        'device': device_name,
+                                        'interface': circuit_name,
+                                        'vlan': None,
+                                        'reason': 'Circuit has no staticRoutes'
+                                    })
+                                    continue
+
+                                # If config provides specific static_routes, delete only those that exist;
+                                # otherwise delete all existing staticRoutes on the circuit.
+                                requested_routes = circuit_config.get('static_routes')
+                                if requested_routes:
+                                    requested_prefixes = set(requested_routes.keys())
+                                    prefixes_to_delete = sorted(existing_prefixes.intersection(requested_prefixes))
+                                else:
+                                    prefixes_to_delete = sorted(existing_prefixes)
+
+                                if not prefixes_to_delete:
+                                    LOG.info(" ✓ Circuit '%s' staticRoutes already removed on %s, skipping", circuit_name, device_name)
+                                    result['skipped_interfaces'].append({
+                                        'device': device_name,
+                                        'interface': circuit_name,
+                                        'vlan': None,
+                                        'reason': 'StaticRoutes already removed'
+                                    })
+                                    continue
+
+                                delete_config = circuit_config.copy()
+                                # Ensure we always generate explicit route deletions (route:null) instead of empty staticRoutes:{}
+                                delete_config['static_routes'] = {pfx: {} for pfx in prefixes_to_delete}
+
+                                device_config.setdefault("circuits", {})
                                 self.config_utils.device_circuit(
-                                    output_config[device_id]["edge"],
+                                    device_config,
                                     action="delete",
-                                    **circuit_config
+                                    **delete_config
                                 )
-                                LOG.info(" ✓ To deconfigure circuit '%s' for device: %s", circuit_config.get('circuit'), device_name)
+                                circuits_deconfigured += 1
+                                LOG.info(" ✓ To deconfigure %s staticRoutes on circuit '%s' for device: %s",
+                                         len(prefixes_to_delete), circuit_name, device_name)
                             else:
                                 LOG.info(" ✗ Skipping circuit '%s' - not referenced in interface configs", circuit_config.get('circuit'))
 
@@ -291,53 +512,147 @@ class InterfaceManager(BaseManager):
                             lan_subinterfaces = []
                             wan_subinterfaces = []
 
-                            if interface_config.get('sub_interfaces'):
-                                for sub_interface in interface_config.get('sub_interfaces', []):
-                                    if sub_interface.get('lan'):
-                                        lan_subinterfaces.append(sub_interface)
-                                    if sub_interface.get('circuit'):
-                                        wan_subinterfaces.append(sub_interface)
+                            for sub_interface in self._get_subinterfaces(interface_config):
+                                if sub_interface.get('lan'):
+                                    lan_subinterfaces.append(sub_interface)
+                                if sub_interface.get('circuit'):
+                                    wan_subinterfaces.append(sub_interface)
 
                             # Process this interface if it has any configuration
                             if has_lan_main or has_wan_main or lan_subinterfaces or wan_subinterfaces:
-                                # Combine all subinterfaces
-                                all_subinterfaces = lan_subinterfaces + wan_subinterfaces
+                                interface_name = interface_config.get('name')
+                                main_interface_exists = self._check_interface_exists(gcs_device_info, interface_name)
+                                current_lan = self._get_interface_lan(gcs_device_info, interface_name) if main_interface_exists else None
+                                current_circuit = self._get_interface_circuit(gcs_device_info, interface_name) if main_interface_exists else None
 
-                                if all_subinterfaces:
-                                    # Interface has subinterfaces
-                                    combined_config = interface_config.copy()
-                                    combined_config['sub_interfaces'] = all_subinterfaces
-                                    self.config_utils.device_interface(
-                                        output_config[device_id]["edge"],
-                                        action="delete",
-                                        default_lan=default_lan,
-                                        **combined_config
-                                    )
-                                    interfaces_deconfigured += 1 + len(all_subinterfaces)
-                                    LOG.info(" ✓ To deconfigure interface '%s' with %s subinterfaces for device: %s",
-                                             interface_config.get('name'), len(all_subinterfaces), device_name)
-                                else:
-                                    # Interface has no subinterfaces
-                                    self.config_utils.device_interface(
-                                        output_config[device_id]["edge"],
-                                        action="delete",
-                                        default_lan=default_lan,
-                                        **interface_config
-                                    )
-                                    interfaces_deconfigured += 1
-                                    LOG.info(" ✓ To deconfigure interface '%s' for device: %s", interface_config.get('name'), device_name)
+                                # For ethernet interfaces, "deconfigure main" means:
+                                # - set parent LAN to default LAN
+                                # - clear circuit
+                                # We should only do that if the parent isn't already in that state.
+                                parent_requested = bool(has_lan_main or has_wan_main)
+                                main_needs_reset = (
+                                    main_interface_exists
+                                    and parent_requested
+                                    and ((current_lan != default_lan) or (current_circuit is not None))
+                                )
+
+                                # Check if main interface exists
+                                if parent_requested:
+                                    if not main_interface_exists:
+                                        LOG.info(" ✗ Interface '%s' does not exist on %s, skipping", interface_name, device_name)
+                                        result['skipped_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': None,
+                                            'reason': 'Interface does not exist'
+                                        })
+                                    elif main_needs_reset:
+                                        LOG.info(
+                                            " ✓ Interface '%s' exists on %s (lan=%s circuit=%s), will reset to %s",
+                                            interface_name, device_name, current_lan, current_circuit, default_lan
+                                        )
+                                    else:
+                                        LOG.info(
+                                            " ✓ Interface '%s' already at default state on %s (lan=%s circuit=%s), skipping parent reset",
+                                            interface_name, device_name, current_lan, current_circuit
+                                        )
+
+                                # Check if subinterfaces exist
+                                existing_subinterfaces = []
+                                for sub_interface in lan_subinterfaces + wan_subinterfaces:
+                                    vlan = sub_interface.get('vlan')
+                                    if self._check_interface_exists(gcs_device_info, interface_name, vlan):
+                                        existing_subinterfaces.append(sub_interface)
+                                        needs_deconfigure = True
+                                        LOG.info(" ✓ Subinterface '%s.%s' exists on %s, will deconfigure",
+                                                 interface_name, vlan, device_name)
+                                    else:
+                                        LOG.info(" ✗ Subinterface '%s.%s' does not exist on %s, skipping",
+                                                 interface_name, vlan, device_name)
+                                        result['skipped_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': vlan,
+                                            'reason': 'Subinterface does not exist'
+                                        })
+
+                                needs_deconfigure = bool(existing_subinterfaces) or main_needs_reset
+
+                                if needs_deconfigure:
+                                    if existing_subinterfaces:
+                                        # Interface has subinterfaces
+                                        combined_config = interface_config.copy()
+                                        # Remove any existing subinterface keys to avoid including non-existent subinterfaces
+                                        combined_config.pop('sub_interfaces', None)
+                                        combined_config.pop('subinterfaces', None)
+                                        combined_config['sub_interfaces'] = existing_subinterfaces
+
+                                        # If the parent is already at default state, don't include lan/circuit in payload.
+                                        # This ensures we only delete subinterfaces (as per config) without resetting parent again.
+                                        if parent_requested and not main_needs_reset:
+                                            combined_config.pop('lan', None)
+                                            combined_config.pop('circuit', None)
+
+                                        self.config_utils.device_interface(
+                                            device_config,
+                                            action="delete",
+                                            default_lan=default_lan,
+                                            **combined_config
+                                        )
+                                        interfaces_deconfigured += (1 if main_needs_reset else 0) + len(existing_subinterfaces)
+                                        LOG.info(" ✓ To deconfigure interface '%s' with %s subinterfaces for device: %s",
+                                                 interface_name, len(existing_subinterfaces), device_name)
+                                        if main_needs_reset:
+                                            result['deconfigured_interfaces'].append({
+                                                'device': device_name,
+                                                'interface': interface_name,
+                                                'vlan': None
+                                            })
+                                        for sub_intf in existing_subinterfaces:
+                                            result['deconfigured_interfaces'].append({
+                                                'device': device_name,
+                                                'interface': interface_name,
+                                                'vlan': sub_intf.get('vlan')
+                                            })
+                                    elif main_needs_reset:
+                                        # Interface has no subinterfaces (or all subinterfaces were skipped)
+                                        # Remove any subinterface keys to avoid including non-existent subinterfaces
+                                        clean_config = interface_config.copy()
+                                        clean_config.pop('sub_interfaces', None)
+                                        clean_config.pop('subinterfaces', None)
+                                        self.config_utils.device_interface(
+                                            device_config,
+                                            action="delete",
+                                            default_lan=default_lan,
+                                            **clean_config
+                                        )
+                                        interfaces_deconfigured += 1
+                                        LOG.info(" ✓ To deconfigure interface '%s' for device: %s", interface_name, device_name)
+                                        result['deconfigured_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': None
+                                        })
                             else:
                                 LOG.info(" ✗ Skipping interface '%s' - no configuration found", interface_config.get('name'))
                     else:
                         LOG.info(" ✗ Skipping interface '%s' - no configuration found", interface_config.get('name'))
 
-                    if circuits_only:
-                        LOG.info("Device %s summary: %s circuits to be deconfigured (circuits-only mode)",
-                                 device_name, circuits_deconfigured)
+                    # Only add to output_config if there's something to deconfigure
+                    if device_config.get("interfaces") or device_config.get("circuits"):
+                        output_config[device_id] = {
+                            "device_id": device_id,
+                            "edge": device_config
+                        }
+                        if circuits_only:
+                            LOG.info("Device %s summary: %s circuits to be deconfigured (circuits-only mode)",
+                                     device_name, circuits_deconfigured)
+                        else:
+                            LOG.info("Device %s summary: %s circuits and %s interfaces to be deconfigured",
+                                     device_name, circuits_deconfigured, interfaces_deconfigured)
+                        LOG.info("Final config for %s: %s", device_name, device_config)
                     else:
-                        LOG.info("Device %s summary: %s circuits and %s interfaces to be deconfigured",
-                                 device_name, circuits_deconfigured, interfaces_deconfigured)
-                    LOG.info("Final config for %s: %s", device_name, output_config[device_id]['edge'])
+                        LOG.info("Device %s: All interfaces already deconfigured or not configured", device_name)
 
                 except DeviceNotFoundError:
                     LOG.error("Device not found: %s", device_name)
@@ -395,8 +710,13 @@ class InterfaceManager(BaseManager):
                                circuits_only: bool = False) -> dict:
         """
         Deconfigure all interfaces and circuits for multiple devices concurrently.
-        This method calls the deconfigure method to handle all deconfigurations in a single API call per device.
-        Circuits with staticRoutes configuration are explicitly deconfigured to ensure proper cleanup.
+        For WAN interfaces, circuit detachment may be treated by the backend as a "circuit removal" operation.
+        If the referenced circuit still has static routes, that detachment can fail with:
+        `error removing circuit "<name>". Remove static routes first.`
+
+        To prevent this, this orchestrator performs a two-stage flow when `circuits_only=False`:
+        - Stage 1: remove static routes from referenced circuits (idempotent)
+        - Stage 2: deconfigure interfaces (reset WAN/LAN parents to default LAN, delete subinterfaces as needed)
 
         Args:
             interface_config_file: Path to the YAML file containing interface configurations
@@ -410,9 +730,33 @@ class InterfaceManager(BaseManager):
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
-        return self.deconfigure(interface_config_file, circuit_config_file, circuits_only)
+        # Circuits-only mode is effectively "remove static routes from referenced circuits".
+        if circuits_only:
+            return self.deconfigure_wan_circuits_interfaces(
+                interface_config_file=interface_config_file,
+                circuit_config_file=circuit_config_file,
+                circuits_only=True,
+            )
 
-    def configure_circuits(self, circuit_config_file: str, interface_config_file: str) -> None:
+        # Stage 1: ensure no static routes remain on referenced circuits before detaching WAN interfaces.
+        stage1 = self.deconfigure_wan_circuits_interfaces(
+            interface_config_file=interface_config_file,
+            circuit_config_file=circuit_config_file,
+            circuits_only=True,
+        )
+
+        # Stage 2: deconfigure interfaces (LAN + WAN).
+        stage2 = self.deconfigure(interface_config_file, circuit_config_file, circuits_only=False)
+
+        # Merge results: surface circuit-route work alongside interface work.
+        merged = stage2
+        merged['changed'] = bool(stage1.get('changed') or stage2.get('changed'))
+        merged['deconfigured_devices'] = sorted(set(stage1.get('deconfigured_devices', [])) | set(stage2.get('deconfigured_devices', [])))
+        merged['deconfigured_circuits'] = stage1.get('deconfigured_circuits', [])
+        merged['skipped_circuits'] = stage1.get('skipped_circuits', [])
+        return merged
+
+    def configure_circuits(self, circuit_config_file: str, interface_config_file: str) -> dict:
         """
         Configure circuits only for multiple devices concurrently.
         This method uses configure_wan_circuits_interfaces with circuits_only=True.
@@ -422,16 +766,24 @@ class InterfaceManager(BaseManager):
             circuit_config_file: Path to the YAML file containing circuit configurations
             interface_config_file: Path to the YAML file containing interface configurations
 
+        Returns:
+            dict: Result with 'changed' status and list of configured devices
+
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
         LOG.info("Configuring circuits only using circuit config: %s and interface config: %s", circuit_config_file, interface_config_file)
-        self.configure_wan_circuits_interfaces(circuit_config_file, interface_config_file, circuits_only=True)
+        return self.configure_wan_circuits_interfaces(circuit_config_file, interface_config_file, circuits_only=True)
 
-    def deconfigure_circuits(self, circuit_config_file: str, interface_config_file: str) -> None:
+    def deconfigure_circuits(self, circuit_config_file: str, interface_config_file: str) -> dict:
         """
-        Deconfigure circuits only (staticRoutes) for multiple devices concurrently.
+        Deconfigure circuits only (static routes) for multiple devices concurrently (idempotent).
+
+        This operation removes static routes from the referenced circuits. It checks the current
+        device state first, and skips the configuration push when there are no matching static routes
+        to delete (returns `changed: False`).
+
         This method uses deconfigure_wan_circuits_interfaces with circuits_only=True.
         Only circuits referenced in the interface config will be deconfigured.
 
@@ -439,14 +791,18 @@ class InterfaceManager(BaseManager):
             circuit_config_file: Path to the YAML file containing circuit configurations
             interface_config_file: Path to the YAML file containing interface configurations
 
+        Returns:
+            dict: Result with 'changed' status, deconfigured devices, and per-circuit details.
+                  Includes `deconfigured_circuits` and `skipped_circuits` when available.
+
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
         LOG.info("Deconfiguring circuits only using circuit config: %s and interface config: %s", circuit_config_file, interface_config_file)
-        self.deconfigure_wan_circuits_interfaces(interface_config_file, circuit_config_file, circuits_only=True)
+        return self.deconfigure_wan_circuits_interfaces(interface_config_file, circuit_config_file, circuits_only=True)
 
-    def configure_lan_interfaces(self, interface_config_file: str) -> None:
+    def configure_lan_interfaces(self, interface_config_file: str) -> dict:
         """
         Configure LAN interfaces for multiple devices concurrently.
         Only interfaces with 'lan' key will be configured.
@@ -454,17 +810,22 @@ class InterfaceManager(BaseManager):
         Args:
             interface_config_file: Path to the YAML file containing interface configurations
 
+        Returns:
+            dict: Result with 'changed' status and list of configured devices
+
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
+        result = {'changed': False, 'configured_devices': []}
+
         try:
             config_data = self.render_config_file(interface_config_file)
             output_config = {}
 
             if 'interfaces' not in config_data:
                 LOG.warning("No interfaces configuration found in %s", interface_config_file)
-                return
+                return result
 
             for device_info in config_data.get("interfaces"):
                 for device_name, config_list in device_info.items():
@@ -482,11 +843,10 @@ class InterfaceManager(BaseManager):
                             has_lan_main = config.get('lan') is not None
                             lan_subinterfaces = []
 
-                            if config.get('sub_interfaces'):
-                                for sub_interface in config.get('sub_interfaces', []):
-                                    if sub_interface.get('lan'):
-                                        lan_subinterfaces.append(sub_interface)
-                                        LOG.info(" ✓ Found LAN subinterface '%s.%s' for device: %s", config.get('name'), sub_interface.get('vlan'), device_name)
+                            for sub_interface in self._get_subinterfaces(config):
+                                if sub_interface.get('lan'):
+                                    lan_subinterfaces.append(sub_interface)
+                                    LOG.info(" ✓ Found LAN subinterface '%s.%s' for device: %s", config.get('name'), sub_interface.get('vlan'), device_name)
 
                             # Process this interface if it has any LAN configuration
                             if has_lan_main or lan_subinterfaces:
@@ -502,7 +862,8 @@ class InterfaceManager(BaseManager):
                                 elif has_lan_main:
                                     # Only main interface has LAN config
                                     main_config = config.copy()
-                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces
+                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces (both param names)
+                                    main_config.pop('subinterfaces', None)
                                     self.config_utils.device_interface(device_config, action="add", **main_config)
                                     lan_interfaces_configured += 1
                                     LOG.info(" ✓ To configure LAN main interface '%s' for device: %s", config.get('name'), device_name)
@@ -541,26 +902,48 @@ class InterfaceManager(BaseManager):
 
             if output_config:
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
+                result['changed'] = True
+                result['configured_devices'] = list(output_config.keys())
                 LOG.info("Successfully configured LAN interfaces for %s devices", len(output_config))
             else:
                 LOG.warning("No LAN interface configurations to apply")
+
+            return result
 
         except Exception as e:
             LOG.error("Error in LAN interface configuration: %s", str(e))
             raise ConfigurationError(f"LAN interface configuration failed: {str(e)}")
 
-    def deconfigure_lan_interfaces(self, interface_config_file: str) -> None:
+    def deconfigure_lan_interfaces(self, interface_config_file: str) -> dict:
         """
-        Deconfigure LAN interfaces for multiple devices concurrently.
-        Only interfaces with 'lan' key will be deconfigured.
+        Deconfigure LAN interfaces for multiple devices concurrently (idempotent).
+
+        Behavior:
+          - If the *parent* interface has a `lan` key in the config, deconfigure means "reset the
+            parent to the enterprise default LAN" (and delete any listed LAN subinterfaces).
+          - If the config only contains LAN subinterfaces under a parent, deconfigure deletes only
+            those subinterfaces and does NOT reset the parent (important for ethernet parents that
+            are allowed to remain on the default LAN).
+
+        The method checks if interfaces/subinterfaces exist before attempting deletion.
 
         Args:
             interface_config_file: Path to the YAML file containing interface configurations
+
+        Returns:
+            dict: Result with 'changed' status, deconfigured and skipped devices/interfaces
 
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
+        result = {
+            'changed': False,
+            'deconfigured_devices': [],
+            'deconfigured_interfaces': [],
+            'skipped_interfaces': []
+        }
+
         try:
             config_data = self.render_config_file(interface_config_file)
             output_config = {}
@@ -568,7 +951,7 @@ class InterfaceManager(BaseManager):
 
             if 'interfaces' not in config_data:
                 LOG.warning("No interfaces configuration found in %s", interface_config_file)
-                return
+                return result
 
             for device_info in config_data.get("interfaces"):
                 for device_name, config_list in device_info.items():
@@ -578,6 +961,10 @@ class InterfaceManager(BaseManager):
                             raise ConfigurationError(f"Device '{device_name}' is not found in the current enterprise: "
                                                      f"{self.gsdk.enterprise_info['company_name']}. "
                                                      f"Please check device name and enterprise credentials.")
+
+                        # Get device info for idempotency check
+                        gcs_device_info = self.gsdk.get_device_info(device_id)
+
                         device_config = {"interfaces": {}}
 
                         lan_interfaces_deconfigured = 0
@@ -586,55 +973,111 @@ class InterfaceManager(BaseManager):
                             has_lan_main = config.get('lan') is not None
                             lan_subinterfaces = []
 
-                            if config.get('sub_interfaces'):
-                                for sub_interface in config.get('sub_interfaces', []):
-                                    if sub_interface.get('lan'):
-                                        lan_subinterfaces.append(sub_interface)
-                                        LOG.info(" ✓ Found LAN subinterface '%s.%s' for device: %s", config.get('name'), sub_interface.get('vlan'), device_name)
+                            for sub_interface in self._get_subinterfaces(config):
+                                if sub_interface.get('lan'):
+                                    lan_subinterfaces.append(sub_interface)
+                                    LOG.info(" ✓ Found LAN subinterface '%s.%s' for device: %s", config.get('name'), sub_interface.get('vlan'), device_name)
 
                             # Process this interface if it has any LAN configuration
                             if has_lan_main or lan_subinterfaces:
-                                if has_lan_main and lan_subinterfaces:
-                                    # Both main interface and subinterfaces have LAN config
-                                    combined_config = config.copy()
-                                    combined_config['sub_interfaces'] = lan_subinterfaces
-                                    self.config_utils.device_interface(device_config, action="delete",
-                                                                       **combined_config, default_lan=default_lan)
-                                    lan_interfaces_deconfigured += 1 + len(lan_subinterfaces)
-                                    LOG.info(" ✓ To deconfigure LAN main interface '%s' and %s LAN subinterfaces for device: %s",
-                                             config.get('name'), len(lan_subinterfaces), device_name)
+                                interface_name = config.get('name')
+                                main_interface_exists = self._check_interface_exists(gcs_device_info, interface_name)
+                                current_lan = self._get_interface_lan(gcs_device_info, interface_name) if main_interface_exists else None
+                                # In LAN deconfigure workflow for ethernet interfaces:
+                                # - If the *parent* interface has a LAN config (`lan` key), deconfigure means
+                                #   reset parent interface to default LAN (and optionally delete listed subinterfaces).
+                                # - If the config only mentions LAN subinterfaces, we should ONLY delete those
+                                #   subinterfaces and MUST NOT reset the parent (the parent may already be in default LAN).
+                                parent_should_default = main_interface_exists and has_lan_main
+                                main_needs_reset = parent_should_default and (current_lan != default_lan)
 
-                                elif has_lan_main:
-                                    # Only main interface has LAN config
-                                    main_config = config.copy()
-                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces
-                                    self.config_utils.device_interface(device_config, action="delete", **main_config,
-                                                                       default_lan=default_lan)
-                                    lan_interfaces_deconfigured += 1
-                                    LOG.info(" ✓ To deconfigure LAN main interface '%s' for device: %s", config.get('name'), device_name)
+                                if has_lan_main and not main_interface_exists:
+                                    LOG.info(" ✗ LAN main interface '%s' does not exist on %s, skipping",
+                                             interface_name, device_name)
+                                    result['skipped_interfaces'].append({
+                                        'device': device_name,
+                                        'interface': interface_name,
+                                        'vlan': None,
+                                        'reason': 'Interface does not exist'
+                                    })
 
-                                elif lan_subinterfaces:
-                                    # Only subinterfaces have LAN config - create minimal config
-                                    subinterface_config = {
-                                        'name': config.get('name'),
-                                        'sub_interfaces': lan_subinterfaces
-                                    }
-                                    self.config_utils.device_interface(device_config, action="delete",
-                                                                       **subinterface_config, default_lan=default_lan)
-                                    lan_interfaces_deconfigured += len(lan_subinterfaces)
-                                    LOG.info(" ✓ Deconfigure %s LAN subinterfaces for interface '%s' on device: %s",
-                                             len(lan_subinterfaces), config.get('name'), device_name)
+                                # Check if subinterfaces exist
+                                existing_subinterfaces = []
+                                for sub_interface in lan_subinterfaces:
+                                    vlan = sub_interface.get('vlan')
+                                    if self._check_interface_exists(gcs_device_info, interface_name, vlan):
+                                        existing_subinterfaces.append(sub_interface)
+                                        LOG.info(" ✓ LAN subinterface '%s.%s' exists on %s, will deconfigure",
+                                                 interface_name, vlan, device_name)
+                                    else:
+                                        LOG.info(" ✗ LAN subinterface '%s.%s' does not exist on %s, skipping",
+                                                 interface_name, vlan, device_name)
+                                        result['skipped_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': vlan,
+                                            'reason': 'Subinterface does not exist'
+                                        })
+
+                                needs_deconfigure = bool(existing_subinterfaces) or main_needs_reset
+
+                                if not needs_deconfigure:
+                                    if parent_should_default and current_lan == default_lan:
+                                        LOG.info(" ✓ LAN interface '%s' already deconfigured on %s (parent on %s), skipping",
+                                                 interface_name, device_name, default_lan)
+                                    continue
+
+                                # Build a minimal delete payload that matches UI behavior:
+                                # - parent interface LAN set to default-<enterpriseId>
+                                # - subinterfaces deleted (if any exist)
+                                payload_config = {'name': interface_name}
+                                if parent_should_default:
+                                    # Any truthy value triggers template to set parent LAN to default_lan
+                                    payload_config['lan'] = True
+                                if existing_subinterfaces:
+                                    payload_config['sub_interfaces'] = existing_subinterfaces
+
+                                self.config_utils.device_interface(
+                                    device_config,
+                                    action="delete",
+                                    default_lan=default_lan,
+                                    **payload_config
+                                )
+
+                                lan_interfaces_deconfigured += (1 if main_needs_reset else 0) + len(existing_subinterfaces)
+
+                                if main_needs_reset:
+                                    LOG.info(" ✓ To deconfigure LAN main interface '%s' (set to %s) for device: %s",
+                                             interface_name, default_lan, device_name)
+                                    result['deconfigured_interfaces'].append({
+                                        'device': device_name,
+                                        'interface': interface_name,
+                                        'vlan': None
+                                    })
+                                if existing_subinterfaces:
+                                    LOG.info(" ✓ To deconfigure %s LAN subinterfaces for interface '%s' on device: %s",
+                                             len(existing_subinterfaces), interface_name, device_name)
+                                    for sub_intf in existing_subinterfaces:
+                                        result['deconfigured_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': sub_intf.get('vlan')
+                                        })
                             else:
                                 LOG.info(" ✗ Skipping interface '%s' - no LAN configuration found", config.get('name'))
 
-                        if lan_interfaces_deconfigured > 0:
-                            output_config[device_id] = {
-                                "device_id": device_id,
-                                "edge": device_config
-                            }
-                            LOG.info("Device %s summary: %s LAN interfaces to be deconfigured", device_name, lan_interfaces_deconfigured)
+                        # Only add to output_config if there's something to deconfigure
+                        if device_config.get("interfaces"):
+                            if lan_interfaces_deconfigured > 0:
+                                output_config[device_id] = {
+                                    "device_id": device_id,
+                                    "edge": device_config
+                                }
+                                LOG.info("Device %s summary: %s LAN interfaces to be deconfigured", device_name, lan_interfaces_deconfigured)
+                            else:
+                                LOG.info("Device %s: No LAN interfaces found to deconfigure", device_name)
                         else:
-                            LOG.info("Device %s: No LAN interfaces found to deconfigure", device_name)
+                            LOG.info("Device %s: All interfaces already deconfigured or not configured", device_name)
 
                     except DeviceNotFoundError:
                         LOG.error("Device not found: %s", device_name)
@@ -649,9 +1092,14 @@ class InterfaceManager(BaseManager):
 
             if output_config:
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
+                result['changed'] = True
+                result['deconfigured_devices'] = list(output_config.keys())
                 LOG.info("Successfully deconfigured LAN interfaces for %s devices", len(output_config))
             else:
-                LOG.warning("No LAN interface configurations to remove")
+                LOG.info("No LAN changes needed - all interfaces already deconfigured or not configured (changed: %s)",
+                         result['changed'])
+
+            return result
 
         except Exception as e:
             LOG.error("Error in LAN interface deconfiguration: %s", str(e))
@@ -661,20 +1109,27 @@ class InterfaceManager(BaseManager):
             raise ConfigurationError(f"LAN interface deconfiguration failed: {str(e)}")
 
     def configure_wan_circuits_interfaces(self, circuit_config_file: str, interface_config_file: str,
-                                          circuits_only: bool = False) -> None:
+                                          circuits_only: bool = False) -> dict:
         """
-        Configure both circuits and interfaces for multiple devices concurrently.
-        This method combines circuit and interface configuration in a single operation.
+        Configure WAN circuits and WAN interfaces for multiple devices concurrently.
+
+        Only circuits referenced by the interface configuration (main interface or subinterfaces)
+        are included in the payload.
 
         Args:
             circuit_config_file: Path to the YAML file containing circuit configurations
             interface_config_file: Path to the YAML file containing interface configurations
-            circuits_only: If True, only configure circuits (not interfaces) that are referenced in interface config
+            circuits_only: If True, only configure referenced circuits (skip interface configuration)
+
+        Returns:
+            dict: Result with 'changed' status and list of configured devices
 
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
+        result = {'changed': False, 'configured_devices': []}
+
         try:
             # Load circuit configurations
             circuit_config_data = self.render_config_file(circuit_config_file)
@@ -721,10 +1176,9 @@ class InterfaceManager(BaseManager):
                         if interface_config.get('circuit'):
                             referenced_circuits.add(interface_config['circuit'])
                         # Check subinterfaces for circuit references
-                        if interface_config.get('sub_interfaces'):
-                            for sub_interface in interface_config.get('sub_interfaces', []):
-                                if sub_interface.get('circuit'):
-                                    referenced_circuits.add(sub_interface['circuit'])
+                        for sub_interface in self._get_subinterfaces(interface_config):
+                            if sub_interface.get('circuit'):
+                                referenced_circuits.add(sub_interface['circuit'])
 
                     if circuits_only:
                         LOG.info("[configure_wan_circuits_interfaces] Processing device: %s (ID: %s) - CIRCUITS ONLY MODE", device_name, device_id)
@@ -754,13 +1208,12 @@ class InterfaceManager(BaseManager):
                             has_wan_main = interface_config.get('circuit') is not None
                             wan_subinterfaces = []
 
-                            if interface_config.get('sub_interfaces'):
-                                for sub_interface in interface_config.get('sub_interfaces', []):
-                                    if sub_interface.get('circuit'):
-                                        wan_subinterfaces.append(sub_interface)
-                                        LOG.info(" ✓ Found WAN subinterface '%s.%s' with circuit '%s' for device: %s",
-                                                 interface_config.get('name'), sub_interface.get('vlan'),
-                                                 sub_interface.get('circuit'), device_name)
+                            for sub_interface in self._get_subinterfaces(interface_config):
+                                if sub_interface.get('circuit'):
+                                    wan_subinterfaces.append(sub_interface)
+                                    LOG.info(" ✓ Found WAN subinterface '%s.%s' with circuit '%s' for device: %s",
+                                             interface_config.get('name'), sub_interface.get('vlan'),
+                                             sub_interface.get('circuit'), device_name)
 
                             # Process this interface if it has any WAN configuration
                             if has_wan_main or wan_subinterfaces:
@@ -781,7 +1234,8 @@ class InterfaceManager(BaseManager):
                                 elif has_wan_main:
                                     # Only main interface has WAN config
                                     main_config = interface_config.copy()
-                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces
+                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces (both param names)
+                                    main_config.pop('subinterfaces', None)
                                     self.config_utils.device_interface(
                                         output_config[device_id]["edge"],
                                         action="add",
@@ -823,6 +1277,8 @@ class InterfaceManager(BaseManager):
 
             if output_config:
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
+                result['changed'] = True
+                result['configured_devices'] = list(output_config.keys())
                 if circuits_only:
                     LOG.info("Successfully configured circuits for %s devices (circuits-only mode)", len(output_config))
                 else:
@@ -833,28 +1289,52 @@ class InterfaceManager(BaseManager):
                 else:
                     LOG.warning("No circuit or interface configurations to apply")
 
+            return result
+
         except Exception as e:
             LOG.error("Error in WAN circuits and interfaces configuration: %s", str(e))
             raise ConfigurationError(f"WAN circuits and interfaces configuration failed: {str(e)}")
 
     def deconfigure_wan_circuits_interfaces(self, interface_config_file: str, circuit_config_file: str = None,
-                                            circuits_only: bool = False) -> None:
+                                            circuits_only: bool = False) -> dict:
         """
-        Deconfigure wan interfaces for multiple devices concurrently.
-        if circuits_only is True, only deconfigure circuits, skip interface deconfiguration
-            Circuits with staticRoutes configuration are explicitly deconfigured to ensure proper cleanup.
-        if circuits_only is False, deconfigure interfaces only since circuits will be deconfigured automatically if
-           circuits did not have staticRoutes configuration.
+        Deconfigure WAN interfaces and/or circuit static routes for multiple devices concurrently (idempotent).
+
+        - If `circuits_only` is True: only deconfigure circuit static routes (skip interface deconfiguration).
+          Static route deletion is idempotent: routes are removed only if they currently exist on the device.
+        - If `circuits_only` is False: deconfigure WAN interfaces (circuits may be affected implicitly by the platform).
+
+        For idempotency, this method checks for current interface/subinterface existence and for circuit static routes
+        (via `gsdk.get_device_info`) before building a delete payload.
+
+        Ordering:
+          - This method performs a two-stage WAN workflow when `circuits_only=False`:
+            1) Remove static routes from referenced circuits (if any exist)
+            2) Reset WAN interfaces to enterprise default LAN and detach circuits
+          - This avoids backend failures when detaching a circuit that still has static routes.
 
         Args:
             interface_config_file: Path to the YAML file containing interface configurations
             circuit_config_file: Optional path to the YAML file containing circuit configurations
             circuits_only: If True, only deconfigure circuits, skip interface deconfiguration
 
+        Returns:
+            dict: Result with 'changed' status, deconfigured and skipped devices/interfaces.
+                  When `circuits_only=True`, also includes `deconfigured_circuits` and `skipped_circuits`.
+
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
+        result = {
+            'changed': False,
+            'deconfigured_devices': [],
+            'deconfigured_interfaces': [],
+            'skipped_interfaces': [],
+            'deconfigured_circuits': [],
+            'skipped_circuits': []
+        }
+
         try:
             interface_config_data = self.render_config_file(interface_config_file)
 
@@ -863,7 +1343,14 @@ class InterfaceManager(BaseManager):
             if circuit_config_file:
                 circuit_config_data = self.render_config_file(circuit_config_file)
 
-            output_config = {}
+            # Two-stage workflow:
+            # 1) Remove circuit static routes for referenced WAN circuits (if any).
+            # 2) Reset WAN interface(s) to default LAN and detach circuits.
+            #
+            # The backend can treat detaching a circuit from a WAN interface as a "circuit removal"
+            # operation and will fail if static routes still exist on that circuit.
+            output_config_circuits = {}
+            output_config_interfaces = {}
             default_lan = f'default-{self.gsdk.get_enterprise_id()}'
 
             # Collect all device configurations first
@@ -893,10 +1380,9 @@ class InterfaceManager(BaseManager):
                         raise ConfigurationError(f"Device '{device_name}' is not found in the current enterprise: "
                                                  f"{self.gsdk.enterprise_info['company_name']}. "
                                                  f"Please check device name and enterprise credentials.")
-                    output_config[device_id] = {
-                        "device_id": device_id,
-                        "edge": {"interfaces": {}, "circuits": {}}
-                    }
+
+                    # Get device info for idempotency check
+                    gcs_device_info = self.gsdk.get_device_info(device_id)
 
                     # Collect circuit names referenced in this device's interfaces and subinterfaces
                     referenced_circuits = set()
@@ -905,28 +1391,84 @@ class InterfaceManager(BaseManager):
                         if interface_config.get('circuit'):
                             referenced_circuits.add(interface_config['circuit'])
                         # Check subinterfaces for circuit references
-                        if interface_config.get('sub_interfaces'):
-                            for sub_interface in interface_config.get('sub_interfaces', []):
-                                if sub_interface.get('circuit'):
-                                    referenced_circuits.add(sub_interface['circuit'])
+                        for sub_interface in self._get_subinterfaces(interface_config):
+                            if sub_interface.get('circuit'):
+                                referenced_circuits.add(sub_interface['circuit'])
 
                     LOG.info("[deconfigure_wan_circuits_interfaces] Processing device: %s (ID: %s)", device_name, device_id)
                     LOG.info("Referenced circuits: %s", list(referenced_circuits))
 
-                    # Process circuits for this device (explicit deconfiguration for circuits with staticRoutes)
+                    # Build separate payloads for circuits vs interfaces to enforce ordering.
+                    device_circuit_config = {}
+                    device_interface_config = {}
+
+                    # Process circuits for this device (static route deconfiguration)
                     circuits_deconfigured = 0
-                    if circuits_only:
+                    if configs.get("circuits"):
+                        device_circuit_config.setdefault("circuits", {})
                         for circuit_config in configs.get("circuits", []):
-                            if circuit_config.get('circuit') in referenced_circuits:
-                                self.config_utils.device_circuit(
-                                    output_config[device_id]["edge"],
-                                    action="delete",
-                                    **circuit_config
-                                )
-                                circuits_deconfigured += 1
-                                LOG.info(" ✓ To deconfigure circuit '%s' for device: %s", circuit_config.get('circuit'), device_name)
+                            circuit_name = circuit_config.get('circuit')
+                            if circuit_name not in referenced_circuits:
+                                LOG.info(" ✗ Skipping circuit '%s' - not referenced in interface configs", circuit_name)
+                                continue
+
+                            existing_prefixes = self._get_circuit_static_route_prefixes(gcs_device_info, circuit_name)
+                            LOG.info("[circuits-idempotency] %s/%s circuit '%s' existing static route prefixes: %s",
+                                     device_name, device_id, circuit_name, sorted(existing_prefixes))
+
+                            # If static_routes are specified in YAML, delete only those (and only if they exist).
+                            # If none specified, interpret deconfigure as "remove any existing static routes".
+                            static_routes_cfg = circuit_config.get('static_routes') or {}
+
+                            if static_routes_cfg:
+                                requested_prefixes = set(static_routes_cfg.keys()) if isinstance(static_routes_cfg, dict) else set()
+                                prefixes_to_delete = sorted(requested_prefixes & existing_prefixes)
+                                missing_prefixes = sorted(requested_prefixes - existing_prefixes)
+                                LOG.info("[circuits-idempotency] %s/%s circuit '%s' requested=%s will_delete=%s missing=%s",
+                                         device_name, device_id, circuit_name,
+                                         sorted(requested_prefixes), prefixes_to_delete, missing_prefixes)
+                                for prefix in missing_prefixes:
+                                    result['skipped_circuits'].append({
+                                        'device': device_name,
+                                        'circuit': circuit_name,
+                                        'prefix': prefix,
+                                        'reason': 'Static route does not exist'
+                                    })
                             else:
-                                LOG.info(" ✗ Skipping circuit '%s' - not referenced in interface configs", circuit_config.get('circuit'))
+                                prefixes_to_delete = sorted(existing_prefixes)
+                                LOG.info("[circuits-idempotency] %s/%s circuit '%s' no static_routes in YAML; will_delete_all_existing=%s",
+                                         device_name, device_id, circuit_name, prefixes_to_delete)
+
+                            if not prefixes_to_delete:
+                                LOG.info(" ✓ No static route changes needed for circuit '%s' on %s, skipping",
+                                         circuit_name, device_name)
+                                result['skipped_circuits'].append({
+                                    'device': device_name,
+                                    'circuit': circuit_name,
+                                    'prefix': None,
+                                    'reason': 'Static routes already deconfigured'
+                                })
+                                continue
+
+                            delete_circuit_config = circuit_config.copy()
+                            # Template expects static_routes dict keyed by prefix; values can be empty for delete.
+                            delete_circuit_config['static_routes'] = {p: {} for p in prefixes_to_delete}
+                            LOG.info("[circuits-idempotency] %s/%s circuit '%s' building delete payload for prefixes=%s",
+                                     device_name, device_id, circuit_name, prefixes_to_delete)
+
+                            self.config_utils.device_circuit(
+                                device_circuit_config,
+                                action="delete",
+                                **delete_circuit_config
+                            )
+                            circuits_deconfigured += 1
+                            result['deconfigured_circuits'].append({
+                                'device': device_name,
+                                'circuit': circuit_name,
+                                'static_routes': prefixes_to_delete
+                            })
+                            LOG.info(" ✓ To deconfigure %s static routes on circuit '%s' for device: %s",
+                                     len(prefixes_to_delete), circuit_name, device_name)
 
                     # Process interfaces for this device - skip if circuits_only=True
                     interfaces_deconfigured = 0
@@ -935,73 +1477,194 @@ class InterfaceManager(BaseManager):
                             # Check if this interface has any WAN configuration (main interface or subinterfaces)
                             has_wan_main = interface_config.get('circuit') is not None
                             wan_subinterfaces = []
+                            interface_name = interface_config.get('name')
 
-                            if interface_config.get('sub_interfaces'):
-                                for sub_interface in interface_config.get('sub_interfaces', []):
-                                    if sub_interface.get('circuit'):
-                                        wan_subinterfaces.append(sub_interface)
-                                        LOG.info(" ✓ Found WAN subinterface '%s.%s' with circuit '%s' for device: %s",
-                                                 interface_config.get('name'), sub_interface.get('vlan'),
-                                                 sub_interface.get('circuit'), device_name)
+                            for sub_interface in self._get_subinterfaces(interface_config):
+                                if sub_interface.get('circuit'):
+                                    wan_subinterfaces.append(sub_interface)
+                                    LOG.info(" ✓ Found WAN subinterface '%s.%s' with circuit '%s' for device: %s",
+                                             interface_name, sub_interface.get('vlan'),
+                                             sub_interface.get('circuit'), device_name)
 
                             # Process this interface if it has any WAN configuration
                             if has_wan_main or wan_subinterfaces:
-                                if has_wan_main and wan_subinterfaces:
-                                    # Both main interface and subinterfaces have WAN config
-                                    combined_config = interface_config.copy()
-                                    combined_config['sub_interfaces'] = wan_subinterfaces
-                                    self.config_utils.device_interface(
-                                        output_config[device_id]["edge"],
-                                        action="delete",
-                                        default_lan=default_lan,
-                                        **combined_config
-                                    )
-                                    interfaces_deconfigured += 1 + len(wan_subinterfaces)
-                                    LOG.info(" ✓ To deconfigure WAN main interface '%s' with circuit '%s' and %s WAN subinterfaces for device: %s",
-                                             interface_config.get('name'), interface_config.get('circuit'),
-                                             len(wan_subinterfaces), device_name)
+                                main_interface_exists = self._check_interface_exists(gcs_device_info, interface_name)
+                                current_lan = self._get_interface_lan(gcs_device_info, interface_name) if main_interface_exists else None
+                                current_circuit = self._get_interface_circuit(gcs_device_info, interface_name) if main_interface_exists else None
 
-                                elif has_wan_main:
-                                    # Only main interface has WAN config
-                                    main_config = interface_config.copy()
-                                    main_config.pop('sub_interfaces', None)  # Remove subinterfaces
-                                    self.config_utils.device_interface(
-                                        output_config[device_id]["edge"],
-                                        action="delete",
-                                        default_lan=default_lan,
-                                        **main_config
-                                    )
-                                    interfaces_deconfigured += 1
-                                    LOG.info(" ✓ To deconfigure WAN main interface '%s' with circuit '%s' for device: %s",
-                                             interface_config.get('name'), interface_config.get('circuit'), device_name)
+                                # For ethernet WAN: "deconfigure main" means reset parent to default LAN and clear circuit.
+                                # Only do that when needed (state-aware idempotency).
+                                main_needs_reset = (
+                                    has_wan_main
+                                    and main_interface_exists
+                                    and ((current_lan != default_lan) or (current_circuit is not None))
+                                )
 
-                                elif wan_subinterfaces:
-                                    # Only subinterfaces have WAN config - create minimal config
-                                    subinterface_config = {
-                                        'name': interface_config.get('name'),
-                                        'sub_interfaces': wan_subinterfaces
-                                    }
-                                    self.config_utils.device_interface(
-                                        output_config[device_id]["edge"],
-                                        action="delete",
-                                        default_lan=default_lan,
-                                        **subinterface_config
-                                    )
-                                    interfaces_deconfigured += len(wan_subinterfaces)
-                                    LOG.info(" ✓ Deconfigure %s WAN subinterfaces for interface '%s' on device: %s",
-                                             len(wan_subinterfaces), interface_config.get('name'), device_name)
+                                # Check if main interface exists (if it has WAN config)
+                                if has_wan_main:
+                                    if main_interface_exists:
+                                        if main_needs_reset:
+                                            LOG.info(
+                                                " ✓ WAN main interface '%s' exists on %s (lan=%s circuit=%s), will reset to %s",
+                                                interface_name, device_name, current_lan, current_circuit, default_lan
+                                            )
+                                        else:
+                                            LOG.info(
+                                                " ✓ WAN main interface '%s' already deconfigured on %s (lan=%s circuit=%s), skipping parent reset",
+                                                interface_name, device_name, current_lan, current_circuit
+                                            )
+                                    else:
+                                        LOG.info(" ✗ WAN main interface '%s' does not exist on %s, skipping",
+                                                 interface_name, device_name)
+                                        result['skipped_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': None,
+                                            'reason': 'Interface does not exist'
+                                        })
+
+                                # Check if subinterfaces exist
+                                existing_subinterfaces = []
+                                for sub_interface in wan_subinterfaces:
+                                    vlan = sub_interface.get('vlan')
+                                    if self._check_interface_exists(gcs_device_info, interface_name, vlan):
+                                        existing_subinterfaces.append(sub_interface)
+                                        LOG.info(" ✓ WAN subinterface '%s.%s' exists on %s, will deconfigure",
+                                                 interface_name, vlan, device_name)
+                                    else:
+                                        LOG.info(" ✗ WAN subinterface '%s.%s' does not exist on %s, skipping",
+                                                 interface_name, vlan, device_name)
+                                        result['skipped_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': vlan,
+                                            'reason': 'Subinterface does not exist'
+                                        })
+
+                                needs_deconfigure = bool(existing_subinterfaces) or main_needs_reset
+
+                                if not needs_deconfigure:
+                                    # Nothing to do: parent already reset and no subinterfaces exist
+                                    result['skipped_interfaces'].append({
+                                        'device': device_name,
+                                        'interface': interface_name,
+                                        'vlan': None,
+                                        'reason': 'WAN interface already deconfigured'
+                                    })
+                                    continue
+
+                                if needs_deconfigure:
+                                    device_interface_config.setdefault("interfaces", {})
+                                    if has_wan_main and existing_subinterfaces:
+                                        # Both main interface and subinterfaces have WAN config
+                                        combined_config = interface_config.copy()
+                                        combined_config['sub_interfaces'] = existing_subinterfaces
+                                        # If parent is already reset, don't include circuit in payload; just delete subinterfaces.
+                                        if has_wan_main and not main_needs_reset:
+                                            combined_config.pop('circuit', None)
+                                        self.config_utils.device_interface(
+                                            device_interface_config,
+                                            action="delete",
+                                            default_lan=default_lan,
+                                            **combined_config
+                                        )
+                                        interfaces_deconfigured += (1 if main_needs_reset else 0) + len(existing_subinterfaces)
+                                        if main_needs_reset:
+                                            LOG.info(
+                                                " ✓ To reset WAN main interface '%s' to %s and deconfigure %s WAN subinterfaces for device: %s",
+                                                interface_name, default_lan, len(existing_subinterfaces), device_name
+                                            )
+                                            result['deconfigured_interfaces'].append({
+                                                'device': device_name,
+                                                'interface': interface_name,
+                                                'vlan': None
+                                            })
+                                        else:
+                                            LOG.info(
+                                                " ✓ To deconfigure %s WAN subinterfaces for interface '%s' on device: %s (parent already reset)",
+                                                len(existing_subinterfaces), interface_name, device_name
+                                            )
+                                        for sub_intf in existing_subinterfaces:
+                                            result['deconfigured_interfaces'].append({
+                                                'device': device_name,
+                                                'interface': interface_name,
+                                                'vlan': sub_intf.get('vlan')
+                                            })
+
+                                    elif has_wan_main and main_needs_reset:
+                                        # Only main interface needs reset (idempotent)
+                                        main_config = interface_config.copy()
+                                        main_config.pop('sub_interfaces', None)  # Remove subinterfaces (both param names)
+                                        main_config.pop('subinterfaces', None)
+                                        device_interface_config.setdefault("interfaces", {})
+                                        self.config_utils.device_interface(
+                                            device_interface_config,
+                                            action="delete",
+                                            default_lan=default_lan,
+                                            **main_config
+                                        )
+                                        interfaces_deconfigured += 1
+                                        LOG.info(" ✓ To deconfigure WAN main interface '%s' with circuit '%s' for device: %s",
+                                                 interface_name, interface_config.get('circuit'), device_name)
+                                        result['deconfigured_interfaces'].append({
+                                            'device': device_name,
+                                            'interface': interface_name,
+                                            'vlan': None
+                                        })
+
+                                    elif existing_subinterfaces:
+                                        # Only subinterfaces have WAN config - create minimal config
+                                        subinterface_config = {
+                                            'name': interface_name,
+                                            'sub_interfaces': existing_subinterfaces
+                                        }
+                                        device_interface_config.setdefault("interfaces", {})
+                                        self.config_utils.device_interface(
+                                            device_interface_config,
+                                            action="delete",
+                                            default_lan=default_lan,
+                                            **subinterface_config
+                                        )
+                                        interfaces_deconfigured += len(existing_subinterfaces)
+                                        LOG.info(" ✓ Deconfigure %s WAN subinterfaces for interface '%s' on device: %s",
+                                                 len(existing_subinterfaces), interface_name, device_name)
+                                        for sub_intf in existing_subinterfaces:
+                                            result['deconfigured_interfaces'].append({
+                                                'device': device_name,
+                                                'interface': interface_name,
+                                                'vlan': sub_intf.get('vlan')
+                                            })
                             else:
                                 LOG.info(" ✗ Skipping interface '%s' - no configuration found", interface_config.get('name'))
                     else:
                         LOG.info(" ✓ Skipping WAN interface deconfiguration (circuits-only mode)")
 
-                    if circuits_only:
-                        LOG.info("Device %s summary: %s circuits to be deconfigured (circuits-only mode)",
+                    # Stage 1 (circuits): only if we have any static routes to remove
+                    if device_circuit_config.get("circuits"):
+                        output_config_circuits[device_id] = {
+                            "device_id": device_id,
+                            "edge": device_circuit_config
+                        }
+                        LOG.info("Device %s summary (stage1): %s circuits with static routes to be deconfigured",
                                  device_name, circuits_deconfigured)
+                        LOG.info("Final circuits config for %s: %s", device_name, device_circuit_config)
                     else:
-                        LOG.info("Device %s summary: %s circuits and %s WAN interfaces to be deconfigured",
-                                 device_name, circuits_deconfigured, interfaces_deconfigured)
-                    LOG.info("Final config for %s: %s", device_name, output_config[device_id]['edge'])
+                        LOG.info("Device %s (stage1): No circuit static route changes needed", device_name)
+
+                    # Stage 2 (interfaces): only if interface changes exist and we're not in circuits-only mode
+                    if not circuits_only and device_interface_config.get("interfaces"):
+                        output_config_interfaces[device_id] = {
+                            "device_id": device_id,
+                            "edge": device_interface_config
+                        }
+                        LOG.info("Device %s summary (stage2): %s WAN interfaces to be deconfigured",
+                                 device_name, interfaces_deconfigured)
+                        LOG.info("Final interfaces config for %s: %s", device_name, device_interface_config)
+                    else:
+                        if circuits_only:
+                            LOG.info("Device %s (stage2): skipped (circuits-only mode)", device_name)
+                        else:
+                            LOG.info("Device %s (stage2): No WAN interface changes needed", device_name)
 
                 except DeviceNotFoundError:
                     LOG.error("Device not found: %s", device_name)
@@ -1014,17 +1677,27 @@ class InterfaceManager(BaseManager):
                     LOG.error("Full traceback: %s", traceback.format_exc())
                     raise ConfigurationError(f"Deconfiguration failed for {device_name}: {str(e)}")
 
-            if output_config:
-                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
-                if circuits_only:
-                    LOG.info("Successfully deconfigured circuits for %s devices (circuits-only mode)", len(output_config))
-                else:
-                    LOG.info("Successfully deconfigured circuits and interfaces for %s devices", len(output_config))
+            # Execute stage 1 first (remove static routes), then stage 2 (detach circuits / reset WAN interfaces).
+            if output_config_circuits:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config_circuits)
+                result['changed'] = True
+                LOG.info("Successfully deconfigured circuit static routes for %s devices (stage1)",
+                         len(output_config_circuits))
+
+            if output_config_interfaces:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config_interfaces)
+                result['changed'] = True
+                LOG.info("Successfully deconfigured WAN interfaces for %s devices (stage2)",
+                         len(output_config_interfaces))
+
+            deconfigured_device_ids = sorted(set(output_config_circuits.keys()) | set(output_config_interfaces.keys()))
+            if deconfigured_device_ids:
+                result['deconfigured_devices'] = deconfigured_device_ids
             else:
-                if circuits_only:
-                    LOG.warning("No circuit configurations to remove")
-                else:
-                    LOG.warning("No circuit or interface configurations to remove")
+                LOG.info("No changes needed - all circuits/routes and interfaces already deconfigured (changed: %s)",
+                         result['changed'])
+
+            return result
 
         except Exception as e:
             LOG.error("Error in WAN circuits and interfaces deconfiguration: %s", str(e))

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/lag_interface_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/lag_interface_manager.py
@@ -3,6 +3,16 @@ LAG Interfaces Manager for Graphiant Playbooks.
 
 This module handles LAG (Link Aggregation Group) interface configuration management
 for Graphiant Edge/Gateway devices.
+
+Idempotency Support:
+    All operations in this module are idempotent and safe to run multiple times:
+    - configure (add): Creates new LAGs or updates existing ones. Handles duplicate
+      alias assignments by removing alias from payload when it matches existing.
+    - deconfigure: Skips LAGs that don't exist.
+    - add_lag_members: Skips members already present in the LAG.
+    - remove_lag_members: Skips members already removed from the LAG.
+    - update_lacp_configs: Skips if LACP mode/timer already match desired state.
+    - delete_lag_subinterfaces: Deletes specified subinterfaces.
 """
 
 from .base_manager import BaseManager
@@ -14,126 +24,251 @@ LOG = setup_logger()
 
 class LagInterfaceManager(BaseManager):
 
+    @staticmethod
+    def _get_existing_lag_info(gcs_device_info):
+        """
+        Get existing LAG interface information from device info.
+
+        LAG interfaces are regular interfaces in the device.interfaces array
+        that have the lag_interface property set. Subinterfaces are also captured
+        with their aliases (name format: LAG1.101).
+
+        Args:
+            gcs_device_info: Device info object from gsdk.get_device_info()
+
+        Returns:
+            dict: Dictionary mapping LAG name to its properties including subinterfaces
+                  e.g., {'LAG1': {'alias': 'LAG1', 'subinterfaces': {101: {'alias': 'LAG1-101'}}}}
+        """
+        existing_lags = {}
+        if not hasattr(gcs_device_info, 'device'):
+            return existing_lags
+
+        device = gcs_device_info.device
+
+        # First pass: Find all LAG main interfaces and their nested subinterfaces
+        if hasattr(device, 'interfaces') and device.interfaces:
+            # Debug: Log all interface names that contain 'LAG'
+            lag_related_names = [getattr(i, 'name', 'N/A') for i in device.interfaces
+                                 if 'LAG' in str(getattr(i, 'name', ''))]
+            LOG.info("_get_existing_lag_info: All LAG-related interface names: %s", lag_related_names)
+            for interface in device.interfaces:
+                if hasattr(interface, 'lag_interface') and interface.lag_interface:
+                    interface_name = getattr(interface, 'name', None)
+                    if interface_name:
+                        # Get LAG member IDs and LACP config if available
+                        lag_member_ids = set()
+                        lacp_config = {}
+                        lag_intf_obj = getattr(interface, 'lag_interface', None)
+                        if lag_intf_obj:
+                            if hasattr(lag_intf_obj, 'members') and lag_intf_obj.members:
+                                for member in lag_intf_obj.members:
+                                    # Members can be integers (the ID directly) or objects with an id attribute
+                                    if isinstance(member, int):
+                                        lag_member_ids.add(member)
+                                    else:
+                                        member_id = getattr(member, 'id', None) or getattr(member, 'interface_id', None)
+                                        if member_id:
+                                            lag_member_ids.add(member_id)
+                                LOG.info("_get_existing_lag_info: LAG '%s' has %d member(s): %s",
+                                         interface_name, len(lag_member_ids), list(lag_member_ids))
+                            # Get LACP config (mode, timer)
+                            lacp_cfg_obj = getattr(lag_intf_obj, 'lacp_config', None)
+                            if lacp_cfg_obj:
+                                lacp_config = {
+                                    'mode': getattr(lacp_cfg_obj, 'mode', None),
+                                    'timer': getattr(lacp_cfg_obj, 'timer', None)
+                                }
+                                LOG.info("_get_existing_lag_info: LAG '%s' LACP config: %s",
+                                         interface_name, lacp_config)
+                        existing_lags[interface_name] = {
+                            'alias': getattr(interface, 'alias', None),
+                            'id': getattr(interface, 'id', None),
+                            'subinterfaces': {},
+                            'member_ids': lag_member_ids,
+                            'lacp_config': lacp_config
+                        }
+                        # Debug: Log all attributes of the LAG interface to find subinterfaces
+                        lag_attrs = [attr for attr in dir(interface)
+                                     if not attr.startswith('_') and not callable(getattr(interface, attr, None))]
+                        LOG.debug("_get_existing_lag_info: LAG '%s' attributes: %s", interface_name, lag_attrs)
+                        # Check for subinterfaces as a nested property on the LAG interface
+                        # Note: The attribute is 'subinterfaces' (no underscore)
+                        subinterfaces_list = getattr(interface, 'subinterfaces', None)
+                        if subinterfaces_list:
+                            for sub_intf in subinterfaces_list:
+                                sub_vlan = getattr(sub_intf, 'vlan', None)
+                                sub_alias = getattr(sub_intf, 'alias', None)
+                                if sub_vlan is not None:
+                                    existing_lags[interface_name]['subinterfaces'][sub_vlan] = {
+                                        'alias': sub_alias,
+                                        'id': getattr(sub_intf, 'id', None),
+                                    }
+                                    LOG.info("_get_existing_lag_info: Found nested subinterface vlan %s "
+                                             "with alias '%s' on LAG '%s'",
+                                             sub_vlan, sub_alias, interface_name)
+
+            # Second pass: Find all LAG subinterfaces as separate entries (format: LAG1.101)
+            # Some APIs may return subinterfaces as separate interface entries
+            for interface in device.interfaces:
+                interface_name = getattr(interface, 'name', None)
+                if interface_name and '.' in interface_name:
+                    # This is a subinterface, check if parent is a LAG
+                    parent_name, vlan_str = interface_name.rsplit('.', 1)
+                    if parent_name in existing_lags:
+                        try:
+                            vlan = int(vlan_str)
+                            # Only add if not already found via nested property
+                            if vlan not in existing_lags[parent_name]['subinterfaces']:
+                                interface_alias = getattr(interface, 'alias', None)
+                                existing_lags[parent_name]['subinterfaces'][vlan] = {
+                                    'alias': interface_alias,
+                                    'id': getattr(interface, 'id', None),
+                                }
+                                LOG.info("_get_existing_lag_info: Found subinterface %s with alias '%s'",
+                                         interface_name, interface_alias)
+                        except ValueError:
+                            pass  # Not a valid vlan number
+
+        if existing_lags:
+            LOG.info("_get_existing_lag_info: Found existing LAGs: %s", list(existing_lags.keys()))
+
+        return existing_lags
+
     def configure(self, config_yaml_file: str) -> dict:  # pylint: disable=arguments-renamed
         """
-        Configure LAG interfaces for multiple devices concurrently.
-        This method calls the configure method to handle all configurations in a single API call per device.
+        Configure LAG interfaces for multiple devices concurrently (idempotent).
+
+        Creates new LAGs or updates existing ones. Automatically handles duplicate
+        alias assignments by removing alias from payload when it matches existing.
+        Subinterface aliases are also handled to prevent duplicate alias errors.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of configured device IDs.
+                - created_lags (list): LAGs that were newly created.
+                - updated_lags (list): LAGs that were updated.
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         return self.configure_lag_interfaces(config_yaml_file, action="add")
 
     def deconfigure(self, config_yaml_file: str) -> dict:  # pylint: disable=arguments-renamed
         """
-        Deconfigure LAG interfaces for multiple devices concurrently.
+        Deconfigure LAG interfaces for multiple devices concurrently (idempotent).
+
+        Deletes subinterfaces first, then removes the LAG. Skips LAGs that
+        don't exist on the device.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
-                - configured_devices (list): List of affected device IDs.
+                - deconfigured_devices (list): List of affected device IDs.
+                - deconfigured_lags (list): LAGs that were removed.
+                - skipped_lags (list): LAGs that were skipped (not found).
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         return self.deconfigure_lag_interfaces(config_yaml_file)
 
     def add_lag_members(self, config_yaml_file: str) -> dict:
         """
-        Add Interface members to an existing LAG for multiple devices concurrently.
+        Add interface members to an existing LAG for multiple devices (idempotent).
+
+        Skips members that are already present in the LAG. If all specified
+        members are already added, no API call is made for that LAG.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of affected device IDs.
+                - created_lags (list): Empty for this operation.
+                - updated_lags (list): LAGs that had members added.
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         return self.configure_lag_interfaces(config_yaml_file, action="add_lag_members")
 
     def remove_lag_members(self, config_yaml_file: str) -> dict:
         """
-        Remove Interface members from an existing LAG for multiple devices concurrently.
+        Remove interface members from an existing LAG for multiple devices (idempotent).
+
+        Skips members that are already removed from the LAG. If all specified
+        members are already absent, no API call is made for that LAG.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of affected device IDs.
+                - created_lags (list): Empty for this operation.
+                - updated_lags (list): LAGs that had members removed.
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         return self.configure_lag_interfaces(config_yaml_file, action="remove_lag_members")
 
     def update_lacp_configs(self, config_yaml_file: str) -> dict:
         """
-        Update LACP parameters(mode/timer) for one or more LAGs across devices concurrently.
+        Update LACP parameters (mode/timer) for LAGs across devices (idempotent).
+
+        Compares current LACP mode and timer with desired values. Skips LAGs
+        where the configuration already matches. Case-insensitive comparison
+        is used for mode and timer values.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of affected device IDs.
+                - created_lags (list): Empty for this operation.
+                - updated_lags (list): LAGs that had LACP config updated.
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         return self.configure_lag_interfaces(config_yaml_file, action="update_lacp_configs")
 
-    def add_lag_subinterfaces(self, config_yaml_file: str) -> dict:
-        """
-        Add/configure VLAN subinterfaces under a LAG for multiple devices concurrently.
-
-        Args:
-            config_yaml_file: Path to the YAML file containing LAG interface configurations.
-
-        Returns:
-            dict: Result dictionary. Typically includes:
-                - changed (bool): Whether changes were applied.
-                - configured_devices (list): List of affected device IDs.
-
-        Raises:
-            ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
-        """
-        return self.configure_lag_interfaces(config_yaml_file, action="add")
-
     def delete_lag_subinterfaces(self, config_yaml_file: str) -> dict:
         """
-        Delete VLAN subinterfaces under a LAG for multiple devices concurrently.
+        Delete VLAN subinterfaces under a LAG for multiple devices concurrently (idempotent).
+
+        Skips deletion if:
+        - The LAG does not exist.
+        - The subinterface does not exist.
+        - All specified subinterfaces are already deleted.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of affected device IDs.
+                - updated_lags (list): LAGs that had subinterfaces deleted.
 
         Raises:
             ConfigurationError: If configuration processing fails.
@@ -143,34 +278,44 @@ class LagInterfaceManager(BaseManager):
 
     def configure_lag_interfaces(self, config_yaml_file: str, action: str = "add") -> dict:
         """
-        Configure/update LAG interfaces for multiple devices concurrently.
+        Configure/update LAG interfaces for multiple devices concurrently (idempotent).
 
-        Supported actions (template-dependent):
-            - add
-            - add_lag_members
-            - remove_lag_members
-            - update_lacp_configs
-            - delete (typically used for subinterfaces)
+        This is the core method that handles all LAG configuration operations with
+        built-in idempotency checks:
+            - add: Creates or updates LAGs. Handles duplicate aliases automatically.
+            - add_lag_members: Skips already-present members.
+            - remove_lag_members: Skips already-absent members.
+            - update_lacp_configs: Skips if mode/timer already match.
+            - delete: Deletes subinterfaces under LAG.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
-            action: Action string passed through to the template renderer / config builder.
+            action: Action string passed through to the template renderer.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
                 - configured_devices (list): List of configured device IDs.
+                - created_lags (list): LAGs newly created (for 'add' action).
+                - updated_lags (list): LAGs updated or modified.
 
         Raises:
             ConfigurationError: If configuration processing fails.
-            DeviceNotFoundError: If any device cannot be found (via underlying SDK/helper).
+            DeviceNotFoundError: If any device cannot be found.
         """
         try:
-            result = {'changed': False, 'configured_devices': []}
+            result = {
+                'changed': False,
+                'configured_devices': [],
+                'created_lags': [],
+                'updated_lags': []
+            }
 
             config_data = self.render_config_file(config_yaml_file)
             output_config = {}
             device_configs = {}
+            # Cache for device info to avoid redundant API calls
+            device_info_cache = {}
 
             if 'lagInterfaces' not in config_data:
                 LOG.warning("No LAG interfaces configuration found in %s", config_yaml_file)
@@ -178,68 +323,287 @@ class LagInterfaceManager(BaseManager):
 
             for device_info in config_data.get("lagInterfaces"):
                 for device_name, config_list in device_info.items():
-                    device_configs[device_name] = config_list
+                    if device_name not in device_configs:
+                        device_configs[device_name] = []
+                    device_configs[device_name].extend(config_list)
 
             for device_name, configs in device_configs.items():
+                LOG.info("Processing device: %s (%d LAG config(s))", device_name, len(configs))
+
+                # Get device_id once per device
+                device_id = self.gsdk.get_device_id(device_name)
+                if device_id is None:
+                    raise ConfigurationError(
+                        f"Device '{device_name}' is not found in the current enterprise: "
+                        f"{self.gsdk.enterprise_info['company_name']}. "
+                        "Please check device name and enterprise credentials."
+                    )
+
+                # Get device info once per device (use cache if available)
+                if device_id not in device_info_cache:
+                    device_info_cache[device_id] = self.gsdk.get_device_info(device_id)
+                gcs_device_info = device_info_cache[device_id]
+
+                # Get existing LAG info once per device
+                existing_lags = self._get_existing_lag_info(gcs_device_info)
+
                 for config in configs:
                     try:
-                        device_id = self.gsdk.get_device_id(device_name)
-                        if device_id is None:
-                            raise ConfigurationError(
-                                f"Device '{device_name}' is not found in the current enterprise: "
-                                f"{self.gsdk.enterprise_info['company_name']}. "
-                                "Please check device name and enterprise credentials."
-                            )
-                        output_config[device_id] = {
-                            "device_id": device_id,
-                            "edge": {"lagInterfaces": {}}
-                        }
+                        lag_name = config.get('name')
+
+                        # If LAG already exists, check if alias needs to be removed to avoid
+                        # "cannot assign alias LAG1 to LAG1 as that alias is in use" error
+                        if lag_name in existing_lags:
+                            existing_lag_info = existing_lags[lag_name]
+                            existing_alias = existing_lag_info.get('alias')
+                            config_alias = config.get('alias')
+
+                            # If alias in config matches existing alias, remove it
+                            # to avoid the duplicate alias error during update
+                            if config_alias and config_alias == existing_alias:
+                                LOG.info("Removing unchanged alias '%s' from LAG '%s' config "
+                                         "to avoid duplicate alias error", config_alias, lag_name)
+                                config.pop('alias', None)
+
+                            # Also check subinterface aliases
+                            existing_subinterfaces = existing_lag_info.get('subinterfaces', {})
+                            LOG.info("Existing subinterfaces for LAG '%s': %s", lag_name, existing_subinterfaces)
+                            _subinterfaces = config.get('subinterfaces') or config.get('sub_interfaces')
+                            if _subinterfaces:
+                                LOG.info("Config subinterfaces for LAG '%s': %s", lag_name,
+                                         [{'vlan': s.get('vlan'), 'alias': s.get('alias')} for s in _subinterfaces])
+                                for subinterface in _subinterfaces:
+                                    vlan = subinterface.get('vlan')
+                                    # Convert vlan to int for comparison (existing_subinterfaces keys are ints)
+                                    try:
+                                        vlan_int = int(vlan) if vlan is not None else None
+                                    except (ValueError, TypeError):
+                                        vlan_int = None
+                                    if vlan_int and vlan_int in existing_subinterfaces:
+                                        existing_sub_alias = existing_subinterfaces[vlan_int].get('alias')
+                                        config_sub_alias = subinterface.get('alias')
+                                        if config_sub_alias and config_sub_alias == existing_sub_alias:
+                                            LOG.info("Removing unchanged alias '%s' from LAG '%s' "
+                                                     "subinterface vlan %s to avoid duplicate alias error",
+                                                     config_sub_alias, lag_name, vlan)
+                                            subinterface.pop('alias', None)
 
                         # Get the interface IDs for the interface members
-                        gcs_device_info = self.gsdk.get_device_info(device_id)
                         config['interfaceMemberIds'] = []
+                        lag_members_config = config.get('lagMembers', [])
+
+                        # Check if lagMembers is required but not specified
+                        if action in ("add_lag_members", "remove_lag_members") and not lag_members_config:
+                            LOG.warning("[%s] No 'lagMembers' specified for LAG '%s' on device '%s'. "
+                                        "Skipping LAG member operation.", action, lag_name, device_name)
+                            # For add action, we still process the LAG (just without members)
+                            # For add_lag_members/remove_lag_members, skip entirely
+                            if action in ("add_lag_members", "remove_lag_members"):
+                                continue
+
                         for interface_info in gcs_device_info.device.interfaces:
-                            if interface_info.name in config.get('lagMembers', []):
+                            if interface_info.name in lag_members_config:
                                 config['interfaceMemberIds'].append(interface_info.id)
+
+                        # Get existing member IDs for idempotency checks
+                        existing_member_ids = existing_lags.get(lag_name, {}).get('member_ids', set())
+
+                        # Idempotency check for add_lag_members:
+                        # Only include member IDs that are NOT already in the LAG
+                        if action == "add_lag_members" and lag_name in existing_lags:
+                            LOG.info("[add_lag_members] Existing member IDs in LAG '%s': %s",
+                                     lag_name, list(existing_member_ids))
+                            original_member_ids = config['interfaceMemberIds'][:]
+                            config['interfaceMemberIds'] = [
+                                mid for mid in config['interfaceMemberIds']
+                                if mid not in existing_member_ids
+                            ]
+                            skipped_ids = set(original_member_ids) - set(config['interfaceMemberIds'])
+                            if skipped_ids:
+                                LOG.info("[add_lag_members] Skipping already added members to LAG '%s' "
+                                         "on device '%s': %s", lag_name, device_name, list(skipped_ids))
+                            if not config['interfaceMemberIds']:
+                                LOG.info("[add_lag_members] All members already added to LAG '%s' "
+                                         "on device '%s', skipping", lag_name, device_name)
+                                continue  # Skip this LAG config, nothing to add
+
+                        # Idempotency check for remove_lag_members:
+                        # Only include member IDs that actually exist in the LAG
+                        if action == "remove_lag_members" and lag_name in existing_lags:
+                            LOG.info("[remove_lag_members] Existing member IDs in LAG '%s': %s",
+                                     lag_name, list(existing_member_ids))
+                            original_member_ids = config['interfaceMemberIds'][:]
+                            config['interfaceMemberIds'] = [
+                                mid for mid in config['interfaceMemberIds']
+                                if mid in existing_member_ids
+                            ]
+                            skipped_ids = set(original_member_ids) - set(config['interfaceMemberIds'])
+                            if skipped_ids:
+                                LOG.info("[remove_lag_members] Skipping already removed members from LAG '%s' "
+                                         "on device '%s': %s", lag_name, device_name, list(skipped_ids))
+                            if not config['interfaceMemberIds']:
+                                LOG.info("[remove_lag_members] All members already removed from LAG '%s' "
+                                         "on device '%s', skipping", lag_name, device_name)
+                                continue  # Skip this LAG config, nothing to remove
+
+                        # Idempotency check for update_lacp_configs:
+                        # Skip if LACP config (mode, timer) matches existing config
+                        if action == "update_lacp_configs" and lag_name in existing_lags:
+                            existing_lacp = existing_lags[lag_name].get('lacp_config', {})
+                            # Config uses lacpMode/lacpTimer (not nested lacpConfigs)
+                            desired_mode = config.get('lacpMode')
+                            desired_timer = config.get('lacpTimer')
+                            existing_mode = existing_lacp.get('mode')
+                            existing_timer = existing_lacp.get('timer')
+
+                            LOG.info("[update_lacp_configs] LAG '%s' - Existing LACP: mode=%s, timer=%s | "
+                                     "Desired LACP: mode=%s, timer=%s",
+                                     lag_name, existing_mode, existing_timer, desired_mode, desired_timer)
+
+                            # Check if both mode and timer match (case-insensitive comparison)
+                            # If desired is not specified (None), we can't compare, so don't skip
+                            if desired_mode is None and desired_timer is None:
+                                LOG.warning("[update_lacp_configs] No lacpMode/lacpTimer specified for LAG '%s' "
+                                            "on device '%s', skipping", lag_name, device_name)
+                                continue  # Skip - nothing to update
+
+                            mode_matches = (desired_mode is None or
+                                            (existing_mode and desired_mode.upper() == existing_mode.upper()))
+                            timer_matches = (desired_timer is None or
+                                             (existing_timer and desired_timer.upper() == existing_timer.upper()))
+
+                            if mode_matches and timer_matches:
+                                LOG.info("[update_lacp_configs] LACP config already matches for LAG '%s' "
+                                         "on device '%s', skipping", lag_name, device_name)
+                                continue  # Skip this LAG config, nothing to update
+
+                        # Idempotency check for delete action (delete_lag_subinterfaces):
+                        # Only delete subinterfaces that actually exist
+                        if action == "delete":
+                            # Check if LAG exists
+                            if lag_name not in existing_lags:
+                                LOG.info("[delete] LAG '%s' does not exist on device '%s', skipping",
+                                         lag_name, device_name)
+                                continue  # Skip - LAG doesn't exist
+
+                            # Check if subinterfaces exist
+                            existing_subinterfaces = existing_lags[lag_name].get('subinterfaces', {})
+                            _subinterfaces = config.get('subinterfaces') or config.get('sub_interfaces')
+
+                            if not _subinterfaces:
+                                LOG.warning("[delete] No 'subinterfaces' specified for LAG '%s' on device '%s'. "
+                                            "Skipping subinterface deletion.", lag_name, device_name)
+                                continue  # Skip - no subinterfaces to delete
+
+                            # Filter subinterfaces to only include those that exist
+                            subinterfaces_to_delete = []
+                            for subinterface in _subinterfaces:
+                                vlan = subinterface.get('vlan')
+                                try:
+                                    vlan_int = int(vlan) if vlan is not None else None
+                                except (ValueError, TypeError):
+                                    vlan_int = None
+
+                                if vlan_int and vlan_int in existing_subinterfaces:
+                                    subinterfaces_to_delete.append(subinterface)
+                                    LOG.info("[delete] Subinterface vlan %s exists on LAG '%s', will delete",
+                                             vlan_int, lag_name)
+                                else:
+                                    LOG.info("[delete] Subinterface vlan %s does not exist on LAG '%s', skipping",
+                                             vlan, lag_name)
+
+                            if not subinterfaces_to_delete:
+                                LOG.info("[delete] All subinterfaces already deleted from LAG '%s' "
+                                         "on device '%s', skipping", lag_name, device_name)
+                                continue  # Skip - nothing to delete
+
+                            # Update config to only include subinterfaces that exist
+                            config['subinterfaces'] = subinterfaces_to_delete
+
+                        # Only initialize output_config AFTER all skip checks pass
+                        # Also, only initialize if device_id not already present, otherwise it will be overwritten.
+                        if device_id not in output_config:
+                            output_config[device_id] = {
+                                "device_id": device_id,
+                                "edge": {"lagInterfaces": {}}
+                            }
 
                         self.config_utils.lag_interfaces(output_config[device_id]["edge"], action=action, **config)
 
-                        LOG.info("[configure] Processing device: %s (ID: %s)", device_name, device_id)
+                        # Track whether this is a create or update operation
+                        if lag_name in existing_lags:
+                            result['updated_lags'].append({
+                                'device': device_name,
+                                'lag': lag_name
+                            })
+                            LOG.info("[configure] Updating LAG '%s' on device: %s (ID: %s)",
+                                     lag_name, device_name, device_id)
+                        else:
+                            result['created_lags'].append({
+                                'device': device_name,
+                                'lag': lag_name
+                            })
+                            LOG.info("[configure] Creating LAG '%s' on device: %s (ID: %s)",
+                                     lag_name, device_name, device_id)
+
+                        if device_id not in result['configured_devices']:
+                            result['configured_devices'].append(device_id)
+                    except ConfigurationError:
+                        raise
                     except Exception as e:
                         LOG.error("Error configuring LAG interfaces: %s", str(e))
                         raise ConfigurationError(f"LAG interface configuration failed: {str(e)}")
+
             if output_config:
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
-                LOG.info("Successfully configured LAG interfaces for %s devices", len(output_config))
-            else:
-                LOG.warning("No LAG interface configurations to apply")
+                result['changed'] = True
+
+            LOG.info("LAG interface configuration completed: %s created, %s updated (changed: %s)",
+                     len(result['created_lags']), len(result['updated_lags']), result['changed'])
+
+            return result
+
+        except ConfigurationError:
+            raise
         except Exception as e:
             LOG.error("Error in LAG interface configuration: %s", str(e))
             raise ConfigurationError(f"LAG interface configuration failed: {str(e)}")
 
     def deconfigure_lag_interfaces(self, config_yaml_file: str) -> dict:
         """
-        Deletes all the subinterfaces and then Deconfigure (remove) LAG interfaces for multiple devices concurrently.
+        Deconfigure (remove) LAG interfaces for multiple devices concurrently (idempotent).
+
+        Performs a two-step deletion: first deletes all subinterfaces, then deletes
+        the main LAG interface. Skips LAGs that don't exist on the device.
 
         Args:
             config_yaml_file: Path to the YAML file containing LAG interface configurations.
 
         Returns:
-            dict: Result dictionary. Typically includes:
+            dict: Result dictionary containing:
                 - changed (bool): Whether changes were applied.
-                - configured_devices (list): List of affected device IDs.
+                - deconfigured_devices (list): List of affected device IDs.
+                - deconfigured_lags (list): LAGs that were successfully removed.
+                - skipped_lags (list): LAGs skipped because they don't exist.
 
         Raises:
-            ConfigurationError: If configuration processing fails
-            DeviceNotFoundError: If any device cannot be found
+            ConfigurationError: If configuration processing fails.
+            DeviceNotFoundError: If any device cannot be found.
         """
         try:
-            result = {'changed': False, 'configured_devices': []}
+            result = {
+                'changed': False,
+                'deconfigured_devices': [],
+                'deconfigured_lags': [],
+                'skipped_lags': []
+            }
 
             config_data = self.render_config_file(config_yaml_file)
-            output_config = {}
-            delete_lag_config = {}
+            del_lag_subinterfaces_config = {}
+            del_lag_interface_config = {}
             device_configs = {}
+            # Cache for device info to avoid redundant API calls
+            device_info_cache = {}
 
             if 'lagInterfaces' not in config_data:
                 LOG.warning("No LAG interfaces configuration found in %s", config_yaml_file)
@@ -247,51 +611,128 @@ class LagInterfaceManager(BaseManager):
 
             for device_info in config_data.get("lagInterfaces"):
                 for device_name, config_list in device_info.items():
-                    device_configs[device_name] = config_list
+                    if device_name not in device_configs:
+                        device_configs[device_name] = []
+                    device_configs[device_name].extend(config_list)
 
             for device_name, configs in device_configs.items():
+                LOG.info("Processing device: %s (%d LAG config(s) to be deconfigured)", device_name, len(configs))
+
+                # Get device_id once per device (outside inner loop)
+                device_id = self.gsdk.get_device_id(device_name)
+                if device_id is None:
+                    raise ConfigurationError(
+                        f"Device '{device_name}' is not found in the current enterprise: "
+                        f"{self.gsdk.enterprise_info['company_name']}. "
+                        "Please check device name and enterprise credentials."
+                    )
+
+                # Get device info once per device (use cache if available)
+                if device_id not in device_info_cache:
+                    device_info_cache[device_id] = self.gsdk.get_device_info(device_id)
+                gcs_device_info = device_info_cache[device_id]
+
+                # Get existing LAG info once per device
+                existing_lags = self._get_existing_lag_info(gcs_device_info)
+
+                '''
+                Note: To delete LAG main interface with subinterfaces, we need to delete the subinterfaces first
+                and then delete the main interface.
+
+                Example payload to delete subinterfaces:
+                {"edge":{"lagInterfaces":{"LAG1":{"interface":{"subinterfaces":{"101":{"interface":null},
+                "102":{"interface":null}}}}}},"description":"","configurationMetadata":{"name":""}}
+
+                Example payload to delete main interface:
+                {"edge":{"interfaces":{"LAG1":{"interface":null}}},"description":"","configurationMetadata":{"name":""}}
+                '''
+
                 for config in configs:
                     try:
-                        device_id = self.gsdk.get_device_id(device_name)
-                        if device_id is None:
-                            raise ConfigurationError(
-                                f"Device '{device_name}' is not found in the current enterprise: "
-                                f"{self.gsdk.enterprise_info['company_name']}. "
-                                "Please check device name and enterprise credentials."
-                            )
-                        output_config[device_id] = {
-                            "device_id": device_id,
-                            "edge": {"lagInterfaces": {}}
-                        }
+                        lag_name = config.get('name')
 
-                        delete_lag_config[device_id] = {
-                            "device_id": device_id,
-                            "edge": {"interfaces": {}}
-                        }
+                        # Check if LAG exists - skip if it doesn't (idempotent)
+                        if lag_name not in existing_lags:
+                            LOG.info(" ✓ LAG '%s' does not exist on device '%s' - skipping (idempotent)",
+                                     lag_name, device_name)
+                            result['skipped_lags'].append({
+                                'device': device_name,
+                                'lag': lag_name,
+                                'reason': 'does not exist'
+                            })
+                            continue
+
+                        # Only initialize if device_id not already present, otherwise it will be overwritten.
+                        if device_id not in del_lag_subinterfaces_config:
+                            del_lag_subinterfaces_config[device_id] = {
+                                "device_id": device_id,
+                                "edge": {"lagInterfaces": {}}
+                            }
+
+                        if device_id not in del_lag_interface_config:
+                            del_lag_interface_config[device_id] = {
+                                "device_id": device_id,
+                                "edge": {"interfaces": {}}
+                            }
+
                         # Get the interface IDs for the interface members
-                        gcs_device_info = self.gsdk.get_device_info(device_id)
                         config['interfaceMemberIds'] = []
                         for interface_info in gcs_device_info.device.interfaces:
                             if interface_info.name in config.get('lagMembers', []):
                                 config['interfaceMemberIds'].append(interface_info.id)
 
-                        self.config_utils.lag_interfaces(output_config[device_id]["edge"], action="delete", **config)
-                        self.config_utils.lag_interfaces(delete_lag_config[device_id]["edge"], action="delete_lag", **config)
+                        # Deconfigure deletes ALL existing subinterfaces (not just those in config)
+                        # This is a complete cleanup operation
+                        existing_subinterfaces = existing_lags[lag_name].get('subinterfaces', {})
 
-                        LOG.info("[deconfigure] Processing device: %s (ID: %s)", device_name, device_id)
+                        if existing_subinterfaces:
+                            # Build subinterfaces list from all existing subinterfaces
+                            subinterfaces_to_delete = []
+                            for vlan_int, subif_info in existing_subinterfaces.items():
+                                subinterfaces_to_delete.append({'vlan': vlan_int})
+                                LOG.info("[deconfigure] Subinterface vlan %s exists on LAG '%s', will delete",
+                                         vlan_int, lag_name)
+
+                            # Add all existing subinterfaces to config for deletion
+                            config['subinterfaces'] = subinterfaces_to_delete
+                            self.config_utils.lag_interfaces(del_lag_subinterfaces_config[device_id]["edge"], action="delete", **config)
+                        else:
+                            LOG.info("[deconfigure] LAG '%s' has no subinterfaces, skipping subinterface deletion step",
+                                     lag_name)
+
+                        # Delete the main LAG interface
+                        self.config_utils.lag_interfaces(del_lag_interface_config[device_id]["edge"], action="delete_lag", **config)
+
+                        result['deconfigured_lags'].append({
+                            'device': device_name,
+                            'lag': lag_name
+                        })
+                        if device_id not in result['deconfigured_devices']:
+                            result['deconfigured_devices'].append(device_id)
+
+                        LOG.info("[deconfigure] Processing LAG '%s' on device: %s (ID: %s)",
+                                 lag_name, device_name, device_id)
+                    except ConfigurationError:
+                        raise
                     except Exception as e:
                         LOG.error("Error deconfiguring LAG interfaces: %s", str(e))
                         raise ConfigurationError(f"LAG interface deconfiguration failed: {str(e)}")
-            if output_config:
-                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
-                LOG.info("Successfully deconfigured LAG interfaces and subinterfaces for %s devices", len(output_config))
-            else:
-                LOG.warning("No configurations to deconfigure")
-            if delete_lag_config:
-                self.execute_concurrent_tasks(self.gsdk.put_device_config, delete_lag_config)
-                LOG.info("Successfully deleted LAG interfaces for %s devices", len(delete_lag_config))
-            else:
-                LOG.warning("No LAG interface configurations to delete")
+
+            if del_lag_subinterfaces_config:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, del_lag_subinterfaces_config)
+                result['changed'] = True
+
+            if del_lag_interface_config:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, del_lag_interface_config)
+                result['changed'] = True
+
+            LOG.info("LAG interface deconfiguration completed: %s deleted, %s skipped (changed: %s)",
+                     len(result['deconfigured_lags']), len(result['skipped_lags']), result['changed'])
+
+            return result
+
+        except ConfigurationError:
+            raise
         except Exception as e:
             LOG.error("Error in LAG interface deconfiguration: %s", str(e))
             raise ConfigurationError(f"LAG interface deconfiguration failed: {str(e)}")

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/vrrp_interface_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/vrrp_interface_manager.py
@@ -4,6 +4,10 @@ VRRP on Interfaces Manager for Graphiant Playbooks.
 This module handles VRRP interface configuration management for Graphiant Playbooks.
 
 VRRP configuration is applied to both main interfaces and subinterfaces (VLANs).
+
+Idempotency Support:
+    - deconfigure: Checks if VRRP is already disabled before pushing config.
+      Skips interfaces where VRRP is already disabled (enabled=false).
 """
 
 from .base_manager import BaseManager
@@ -21,23 +25,315 @@ class VRRPInterfaceManager(BaseManager):
     including both main interfaces and VLAN subinterfaces.
     """
 
-    def configure(self, config_yaml_file: str) -> None:
+    @staticmethod
+    def _get_existing_vrrp_state(gcs_device_info, interface_name, vlan=None):
+        """
+        Get existing VRRP state for an interface from device info.
+
+        Args:
+            gcs_device_info: Device info object from gsdk.get_device_info()
+            interface_name: Name of the interface (e.g., 'GigabitEthernet7/0/0')
+            vlan: Optional VLAN ID for subinterface VRRP
+
+        Returns:
+            dict: Dictionary with VRRP state for ipv4 and ipv6:
+                  {'ipv4': {'enabled': bool, 'virtualRouterId': int},
+                   'ipv6': {'enabled': bool, 'virtualRouterId': int}}
+                  Returns None if interface not found or no VRRP configured.
+        """
+        vrrp_state = {'ipv4': None, 'ipv6': None}
+
+        if not hasattr(gcs_device_info, 'device'):
+            LOG.debug("_get_existing_vrrp_state: No 'device' attribute in gcs_device_info")
+            return vrrp_state
+
+        device = gcs_device_info.device
+        if not hasattr(device, 'interfaces') or not device.interfaces:
+            LOG.debug("_get_existing_vrrp_state: No interfaces found on device")
+            return vrrp_state
+
+        # Find the interface
+        target_interface = None
+        for interface in device.interfaces:
+            if getattr(interface, 'name', None) == interface_name:
+                target_interface = interface
+                break
+
+        if not target_interface:
+            LOG.debug("_get_existing_vrrp_state: Interface '%s' not found", interface_name)
+            return vrrp_state
+
+        # Get interface object - either main interface or subinterface
+        intf_obj = None
+        if vlan:
+            # Look for subinterface - check both integer and string vlan
+            vlan_int = int(vlan) if vlan else None
+            if hasattr(target_interface, 'subinterfaces') and target_interface.subinterfaces:
+                LOG.debug("_get_existing_vrrp_state: Found %d subinterfaces on %s",
+                          len(target_interface.subinterfaces), interface_name)
+                for subintf in target_interface.subinterfaces:
+                    subintf_vlan = getattr(subintf, 'vlan', None)
+                    LOG.debug("_get_existing_vrrp_state: Checking subinterface vlan=%s (looking for %s)",
+                              subintf_vlan, vlan_int)
+                    if subintf_vlan == vlan_int:
+                        intf_obj = subintf
+                        LOG.debug("_get_existing_vrrp_state: Found matching subinterface vlan=%s", vlan_int)
+                        break
+            else:
+                LOG.debug("_get_existing_vrrp_state: No subinterfaces on %s", interface_name)
+        else:
+            # Main interface
+            intf_obj = target_interface
+
+        if not intf_obj:
+            LOG.debug("_get_existing_vrrp_state: Interface object not found for %s%s",
+                      interface_name, f".{vlan}" if vlan else "")
+            return vrrp_state
+
+        # Check IPv4 VRRP - API returns 'vrrp_group' not 'vrrp'
+        ipv4_obj = getattr(intf_obj, 'ipv4', None)
+        if ipv4_obj:
+            # The API returns VRRP data directly as 'vrrp_group' (not nested under 'vrrp')
+            vrrp_group = getattr(ipv4_obj, 'vrrp_group', None)
+            LOG.debug("_get_existing_vrrp_state: %s%s - IPv4 vrrp_group exists: %s",
+                      interface_name, f".{vlan}" if vlan else "", vrrp_group is not None)
+            if vrrp_group:
+                enabled_value = getattr(vrrp_group, 'enabled', None)
+                vrrp_state['ipv4'] = {
+                    'enabled': enabled_value,
+                    'virtualRouterId': getattr(vrrp_group, 'virtual_router_id', None)
+                }
+                LOG.info("_get_existing_vrrp_state: %s%s - IPv4 VRRP state: enabled=%s",
+                         interface_name, f".{vlan}" if vlan else "", vrrp_state['ipv4']['enabled'])
+
+        # Check IPv6 VRRP - API returns 'vrrp_group' not 'vrrp'
+        ipv6_obj = getattr(intf_obj, 'ipv6', None)
+        if ipv6_obj:
+            vrrp_group = getattr(ipv6_obj, 'vrrp_group', None)
+            LOG.debug("_get_existing_vrrp_state: %s%s - IPv6 vrrp_group exists: %s",
+                      interface_name, f".{vlan}" if vlan else "", vrrp_group is not None)
+            if vrrp_group:
+                enabled_value = getattr(vrrp_group, 'enabled', None)
+                vrrp_state['ipv6'] = {
+                    'enabled': enabled_value,
+                    'virtualRouterId': getattr(vrrp_group, 'virtual_router_id', None)
+                }
+                LOG.info("_get_existing_vrrp_state: %s%s - IPv6 VRRP state: enabled=%s",
+                         interface_name, f".{vlan}" if vlan else "", vrrp_state['ipv6']['enabled'])
+
+        return vrrp_state
+
+    def configure(self, config_yaml_file: str) -> dict:
         """
         Configure VRRP interfaces (implements abstract method from BaseManager).
 
         Args:
             config_yaml_file: Path to the YAML file containing VRRP configurations
-        """
-        self.configure_vrrp_interfaces(config_yaml_file)
 
-    def deconfigure(self, config_yaml_file: str) -> None:
+        Returns:
+            dict: Result with 'changed' status and list of configured devices
+        """
+        return self.configure_vrrp_interfaces(config_yaml_file)
+
+    def deconfigure(self, config_yaml_file: str) -> dict:
         """
         Deconfigure VRRP interfaces (implements abstract method from BaseManager).
 
         Args:
             config_yaml_file: Path to the YAML file containing VRRP configurations
+
+        Returns:
+            dict: Result with 'changed' status, deconfigured and skipped devices/interfaces
         """
-        self.deconfigure_vrrp_interfaces(config_yaml_file)
+        return self.deconfigure_vrrp_interfaces(config_yaml_file)
+
+    def enable_vrrp_interfaces(self, vrrp_config_file: str) -> dict:
+        """
+        Enable existing VRRP interfaces for multiple devices concurrently (idempotent).
+
+        This operation only enables VRRP that is already configured. It does not create
+        new VRRP configurations. If VRRP is already enabled, the operation is skipped.
+
+        Args:
+            vrrp_config_file: Path to the YAML file containing VRRP interface references
+
+        Returns:
+            dict: Result with 'changed' status, enabled and skipped devices/interfaces
+
+        Raises:
+            ConfigurationError: If VRRP configuration doesn't exist or processing fails
+            DeviceNotFoundError: If any device cannot be found
+        """
+        result = {
+            'changed': False,
+            'enabled_devices': [],
+            'enabled_interfaces': [],
+            'skipped_interfaces': []
+        }
+
+        try:
+            # Load VRRP configurations
+            vrrp_config_data = self.render_config_file(vrrp_config_file)
+            output_config = {}
+
+            # Collect all device configurations first
+            device_configs = {}
+
+            # Collect VRRP configurations per device
+            for device_info in vrrp_config_data.get("vrrp_config"):
+                for device_name, config_list in device_info.items():
+                    if device_name not in device_configs:
+                        device_configs[device_name] = {"interfaces": []}
+                    device_configs[device_name]["interfaces"] = config_list
+
+            # Process each device's configurations
+            for device_name, configs in device_configs.items():
+                try:
+                    device_id = self.gsdk.get_device_id(device_name)
+                    if device_id is None:
+                        raise ConfigurationError(f"Device '{device_name}' is not found in the current enterprise: "
+                                                 f"{self.gsdk.enterprise_info['company_name']}. "
+                                                 f"Please check device name and enterprise credentials.")
+
+                    LOG.info("[enable] Processing device: %s (ID: %s)", device_name, device_id)
+
+                    # Get device info for idempotency check
+                    gcs_device_info = self.gsdk.get_device_info(device_id)
+
+                    # Process VRRP enable for this device
+                    vrrp_to_enable = 0
+                    vrrp_skipped = 0
+
+                    for config in configs.get("interfaces", []):
+                        interface_name = config.get('name')
+                        vlan = config.get('vlan')
+                        vrrp_ipv4 = config.get('vrrp_ipv4')
+                        vrrp_ipv6 = config.get('vrrp_ipv6')
+
+                        # Get existing VRRP state
+                        existing_vrrp = self._get_existing_vrrp_state(gcs_device_info, interface_name, vlan)
+
+                        # Check if any VRRP needs to be enabled
+                        needs_enable = False
+                        has_vrrp_config = False
+
+                        # Check IPv4 VRRP
+                        if vrrp_ipv4:
+                            if existing_vrrp['ipv4'] is None:
+                                raise ConfigurationError(
+                                    f"VRRP IPv4 configuration does not exist on {interface_name}"
+                                    f"{f'.{vlan}' if vlan else ''} for device '{device_name}'. "
+                                    "Please configure VRRP first before enabling it.")
+                            has_vrrp_config = True
+                            if existing_vrrp['ipv4'].get('enabled') is not True:
+                                needs_enable = True
+                                LOG.info(" ✓ IPv4 VRRP is disabled on %s%s, will enable",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            else:
+                                LOG.info(" ✗ IPv4 VRRP already enabled on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+
+                        # Check IPv6 VRRP
+                        if vrrp_ipv6:
+                            if existing_vrrp['ipv6'] is None:
+                                raise ConfigurationError(
+                                    f"VRRP IPv6 configuration does not exist on {interface_name}"
+                                    f"{f'.{vlan}' if vlan else ''} for device '{device_name}'. "
+                                    "Please configure VRRP first before enabling it.")
+                            has_vrrp_config = True
+                            if existing_vrrp['ipv6'].get('enabled') is not True:
+                                needs_enable = True
+                                LOG.info(" ✓ IPv6 VRRP is disabled on %s%s, will enable",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            else:
+                                LOG.info(" ✗ IPv6 VRRP already enabled on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+
+                        if not has_vrrp_config:
+                            LOG.warning(" ✗ No VRRP configuration specified for %s%s, skipping",
+                                        interface_name, f".{vlan}" if vlan else "")
+                            vrrp_skipped += 1
+                            result['skipped_interfaces'].append({
+                                'device': device_name,
+                                'interface': interface_name,
+                                'vlan': vlan,
+                                'reason': 'No VRRP config specified'
+                            })
+                            continue
+
+                        if needs_enable:
+                            # Initialize device config if not already
+                            if device_id not in output_config:
+                                output_config[device_id] = {
+                                    "device_id": device_id,
+                                    "edge": {"interfaces": {}}
+                                }
+
+                            # Build config dict for template (no virtualRouterId needed for enable)
+                            enable_config = {
+                                'name': interface_name
+                            }
+                            if vlan:
+                                enable_config['vlan'] = vlan
+
+                            # Add vrrp_ipv4/vrrp_ipv6 keys (empty dict is fine, template only needs the key)
+                            if vrrp_ipv4 and existing_vrrp['ipv4'] and existing_vrrp['ipv4'].get('enabled') is not True:
+                                enable_config['vrrp_ipv4'] = {}
+
+                            if vrrp_ipv6 and existing_vrrp['ipv6'] and existing_vrrp['ipv6'].get('enabled') is not True:
+                                enable_config['vrrp_ipv6'] = {}
+
+                            # Use template to generate payload (consistent with deconfigure)
+                            self.config_utils.vrrp_interfaces(
+                                output_config[device_id]["edge"],
+                                action="enable",
+                                **enable_config
+                            )
+
+                            vrrp_to_enable += 1
+                            result['enabled_interfaces'].append({
+                                'device': device_name,
+                                'interface': interface_name,
+                                'vlan': vlan
+                            })
+                        else:
+                            vrrp_skipped += 1
+                            result['skipped_interfaces'].append({
+                                'device': device_name,
+                                'interface': interface_name,
+                                'vlan': vlan,
+                                'reason': 'VRRP already enabled'
+                            })
+
+                    LOG.info("Device %s summary: %d VRRP interface(s) to enable, %d skipped (already enabled)",
+                             device_name, vrrp_to_enable, vrrp_skipped)
+
+                except DeviceNotFoundError:
+                    LOG.error("Device not found: %s", device_name)
+                    raise
+                except ConfigurationError:
+                    raise
+                except Exception as e:
+                    LOG.error("Error enabling VRRP on device %s: %s", device_name, str(e))
+                    raise ConfigurationError(f"Enable VRRP failed for {device_name}: {str(e)}")
+
+            if output_config:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
+                result['changed'] = True
+                result['enabled_devices'] = list(output_config.keys())
+                LOG.info("VRRP enable completed: %d device(s) updated, %d interface(s) enabled, "
+                         "%d interface(s) skipped (already enabled) (changed: %s)",
+                         len(output_config), len(result['enabled_interfaces']),
+                         len(result['skipped_interfaces']), result['changed'])
+            else:
+                LOG.info("No VRRP changes needed - all interfaces already enabled (changed: %s)",
+                         result['changed'])
+
+            return result
+
+        except Exception as e:
+            LOG.error("Error in VRRP interface enable: %s", str(e))
+            raise ConfigurationError(f"VRRP interface enable failed: {str(e)}")
 
     def configure_vrrp_interfaces(self, vrrp_config_file: str) -> dict:
         """
@@ -71,7 +367,7 @@ class VRRPInterfaceManager(BaseManager):
                 for device_name, config_list in device_info.items():
                     if device_name not in device_configs:
                         device_configs[device_name] = {"interfaces": []}
-                device_configs[device_name]["interfaces"] = config_list
+                    device_configs[device_name]["interfaces"] = config_list
 
             # Process each device's configurations
             for device_name, configs in device_configs.items():
@@ -90,8 +386,8 @@ class VRRPInterfaceManager(BaseManager):
                     referenced_interfaces = set()
                     for vrrp_config in configs.get("interfaces", []):
                         # Check main interface for interface reference
-                        if vrrp_config.get('interfaceName'):
-                            referenced_interfaces.add(vrrp_config['interfaceName'])
+                        if vrrp_config.get('name'):
+                            referenced_interfaces.add(vrrp_config['name'])
                         # Check subinterfaces for interface references
                         if vrrp_config.get('vlan'):
                             referenced_interfaces.add(vrrp_config['vlan'])
@@ -104,16 +400,16 @@ class VRRPInterfaceManager(BaseManager):
                     for config in configs.get("interfaces", []):
                         # Check if this interface has any VRRP configuration
                         if config.get('vrrp_ipv4') or config.get('vrrp_ipv6'):
-                            LOG.info(" ✓ Found VRRP configuration for interface: %s", config.get('interfaceName'))
+                            LOG.info(" ✓ Found VRRP configuration for interface: %s", config.get('name'))
                             self.config_utils.vrrp_interfaces(
                                 output_config[device_id]["edge"],
                                 action="add",
                                 **config
                             )
                             vrrp_configured += 1
-                            LOG.info(" ✓ To configure VRRP for interface: %s", config.get('interfaceName'))
+                            LOG.info(" ✓ To configure VRRP for interface: %s", config.get('name'))
                         else:
-                            LOG.info(" ✗ Skipping interface '%s' - no VRRP configuration", config.get('interfaceName'))
+                            LOG.info(" ✗ Skipping interface '%s' - no VRRP configuration", config.get('name'))
 
                     LOG.info("Device %s summary: %s VRRP interfaces to be configured", device_name, vrrp_configured)
                     LOG.info("Final config for %s: %s", device_name, output_config[device_id]['edge'])
@@ -129,31 +425,41 @@ class VRRPInterfaceManager(BaseManager):
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
                 result['changed'] = True
                 result['configured_devices'] = list(output_config.keys())
-                LOG.info("Successfully configured VRRP interfaces for %s devices", len(output_config))
+                LOG.info("VRRP configuration completed: %d device(s) configured (changed: %s)",
+                         len(output_config), result['changed'])
             else:
-                LOG.warning("No valid device configurations found")
+                LOG.info("No VRRP configurations to apply (changed: %s)", result['changed'])
 
             return result
-
+        except ConfigurationError:
+            raise
         except Exception as e:
             LOG.error("Error in VRRP interface configuration: %s", str(e))
             raise ConfigurationError(f"VRRP interface configuration failed: {str(e)}")
 
     def deconfigure_vrrp_interfaces(self, vrrp_config_file: str) -> dict:
         """
-        Deconfigure VRRP interfaces for multiple devices concurrently.
+        Deconfigure VRRP interfaces for multiple devices concurrently (idempotent).
+
+        Checks if VRRP is already disabled before pushing configuration.
+        Skips interfaces where VRRP is already disabled.
 
         Args:
             vrrp_config_file: Path to the YAML file containing VRRP configurations
 
         Returns:
-            dict: Result with 'changed' status and list of deconfigured devices
+            dict: Result with 'changed' status, deconfigured and skipped devices/interfaces
 
         Raises:
             ConfigurationError: If configuration processing fails
             DeviceNotFoundError: If any device cannot be found
         """
-        result = {'changed': False, 'deconfigured_devices': []}
+        result = {
+            'changed': False,
+            'deconfigured_devices': [],
+            'deconfigured_interfaces': [],
+            'skipped_interfaces': []
+        }
 
         try:
             # Load VRRP configurations
@@ -178,26 +484,84 @@ class VRRPInterfaceManager(BaseManager):
                         raise ConfigurationError(f"Device '{device_name}' is not found in the current enterprise: "
                                                  f"{self.gsdk.enterprise_info['company_name']}. "
                                                  f"Please check device name and enterprise credentials.")
-                    output_config[device_id] = {
-                        "device_id": device_id,
-                        "edge": {"interfaces": {}}
-                    }
 
                     LOG.info("[deconfigure] Processing device: %s (ID: %s)", device_name, device_id)
 
-                    # Process VRRP removal for this device
-                    vrrp_deconfigured = 0
-                    for config in configs.get("interfaces", []):
-                        LOG.info(" ✓ Removing VRRP configuration for interface: %s", config.get('interfaceName'))
-                        self.config_utils.vrrp_interfaces(
-                            output_config[device_id]["edge"],
-                            action="delete",
-                            **config
-                        )
-                        vrrp_deconfigured += 1
-                        LOG.info(" ✓ To deconfigure VRRP for interface: %s", config.get('interfaceName'))
+                    # Get device info for idempotency check
+                    gcs_device_info = self.gsdk.get_device_info(device_id)
 
-                    LOG.info("Device %s summary: %s VRRP interfaces to be deconfigured", device_name, vrrp_deconfigured)
+                    # Process VRRP removal for this device
+                    vrrp_to_deconfigure = 0
+                    vrrp_skipped = 0
+
+                    for config in configs.get("interfaces", []):
+                        interface_name = config.get('name')
+                        vlan = config.get('vlan')
+                        vrrp_ipv4 = config.get('vrrp_ipv4')
+                        vrrp_ipv6 = config.get('vrrp_ipv6')
+
+                        # Get existing VRRP state for idempotency check
+                        existing_vrrp = self._get_existing_vrrp_state(gcs_device_info, interface_name, vlan)
+
+                        # Check if any VRRP needs to be disabled
+                        needs_deconfigure = False
+
+                        # Check IPv4 VRRP
+                        if vrrp_ipv4:
+                            if existing_vrrp['ipv4'] and existing_vrrp['ipv4'].get('enabled') is True:
+                                needs_deconfigure = True
+                                LOG.info(" ✓ IPv4 VRRP is enabled on %s%s, will disable",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            elif existing_vrrp['ipv4'] and existing_vrrp['ipv4'].get('enabled') is False:
+                                LOG.info(" ✗ IPv4 VRRP already disabled on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            else:
+                                LOG.info(" ✗ No IPv4 VRRP configured on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+
+                        # Check IPv6 VRRP
+                        if vrrp_ipv6:
+                            if existing_vrrp['ipv6'] and existing_vrrp['ipv6'].get('enabled') is True:
+                                needs_deconfigure = True
+                                LOG.info(" ✓ IPv6 VRRP is enabled on %s%s, will disable",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            elif existing_vrrp['ipv6'] and existing_vrrp['ipv6'].get('enabled') is False:
+                                LOG.info(" ✗ IPv6 VRRP already disabled on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+                            else:
+                                LOG.info(" ✗ No IPv6 VRRP configured on %s%s, skipping",
+                                         interface_name, f".{vlan}" if vlan else "")
+
+                        if needs_deconfigure:
+                            # Initialize device config if not already
+                            if device_id not in output_config:
+                                output_config[device_id] = {
+                                    "device_id": device_id,
+                                    "edge": {"interfaces": {}}
+                                }
+
+                            self.config_utils.vrrp_interfaces(
+                                output_config[device_id]["edge"],
+                                action="delete",
+                                **config
+                            )
+                            vrrp_to_deconfigure += 1
+                            result['deconfigured_interfaces'].append({
+                                'device': device_name,
+                                'interface': interface_name,
+                                'vlan': vlan
+                            })
+                        else:
+                            vrrp_skipped += 1
+                            result['skipped_interfaces'].append({
+                                'device': device_name,
+                                'interface': interface_name,
+                                'vlan': vlan,
+                                'reason': 'VRRP already disabled or not configured'
+                            })
+
+                    LOG.info("Device %s summary: %d VRRP interface(s) to deconfigure, %d skipped (already disabled)",
+                             device_name, vrrp_to_deconfigure, vrrp_skipped)
 
                 except DeviceNotFoundError:
                     LOG.error("Device not found: %s", device_name)
@@ -210,12 +574,17 @@ class VRRPInterfaceManager(BaseManager):
                 self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
                 result['changed'] = True
                 result['deconfigured_devices'] = list(output_config.keys())
-                LOG.info("Successfully deconfigured VRRP interfaces for %s devices", len(output_config))
+                LOG.info("VRRP deconfiguration completed: %d device(s) updated, %d interface(s) deconfigured, "
+                         "%d interface(s) skipped (changed: %s)",
+                         len(output_config), len(result['deconfigured_interfaces']),
+                         len(result['skipped_interfaces']), result['changed'])
             else:
-                LOG.warning("No valid device configurations found")
+                LOG.info("No VRRP changes needed - all interfaces already disabled or not configured (changed: %s)",
+                         result['changed'])
 
             return result
-
+        except ConfigurationError:
+            raise
         except Exception as e:
             LOG.error("Error in VRRP interface deconfiguration: %s", str(e))
             raise ConfigurationError(f"VRRP interface deconfiguration failed: {str(e)}")

--- a/ansible_collections/graphiant/naas/templates/interface_template.yaml
+++ b/ansible_collections/graphiant/naas/templates/interface_template.yaml
@@ -1,21 +1,33 @@
 # yamllint disable-file
+# Template supports both API-aligned params (preferred) and legacy snake_case params for backward compatibility:
+#   - subinterfaces (API) / sub_interfaces (legacy)
+#   - maxTransmissionUnit (API) / mtu (legacy)
+#   - adminStatus (API) / enabled (legacy)
+#   - v4TcpMss (API) / v4_tcp_mss (legacy)
+#   - v6TcpMss (API) / v6_tcp_mss (legacy)
 {
     "interfaces": {
         "{{ name }}": {
             "interface": {
+                {# Resolve backward-compatible aliases at top level #}
+                {% set _subinterfaces = subinterfaces | default(sub_interfaces) | default(none) %}
+                {% set _mtu = maxTransmissionUnit | default(mtu) | default(none) %}
+                {% set _adminStatus = adminStatus | default(enabled) | default('true') %}
+                {% set _v4TcpMss = v4TcpMss | default(v4_tcp_mss) | default(none) %}
+                {% set _v6TcpMss = v6TcpMss | default(v6_tcp_mss) | default(none) %}
                 {% if action == "default_lan" or action == "delete" %}
                     {% if lan or circuit %}
                         "lan": "{{ default_lan }}",
                         "circuit": null,
                         "description": "",
-                        "alias": "{{ name }}"{% if sub_interfaces %},{% endif %}
+                        "alias": "{{ name }}"{% if _subinterfaces %},{% endif %}
                     {% endif %}
                 {% elif action == "add" %}
                     {% if circuit or lan %}
-                        "adminStatus": {{ enabled | default('true') }},
+                        "adminStatus": {{ _adminStatus }},
                         "loopback": {{ loopback | default(null) }},
-                        {% if mtu is defined %}
-                            "maxTransmissionUnit": {{ mtu }},
+                        {% if _mtu is not none %}
+                            "maxTransmissionUnit": {{ _mtu }},
                         {% endif %}
                         {% if circuit %}
                             "circuit": "{{ circuit }}",
@@ -25,14 +37,14 @@
                             "lan": "{{ lan }}",
                             "description": "{{ description | default(lan) }}",
                             "alias": "{{ alias | default(lan) }}",
-                            {% if v4_tcp_mss is defined %}
+                            {% if _v4TcpMss is not none %}
                                 "v4TcpMss": {
-                                    "tcpMssV4": {{ v4_tcp_mss }}
+                                    "tcpMssV4": {{ _v4TcpMss }}
                                 },
                             {% endif %}
-                            {% if v6_tcp_mss is defined %}
+                            {% if _v6TcpMss is not none %}
                                 "v6TcpMss": {
-                                    "tcpMssV6": {{ v6_tcp_mss }}
+                                    "tcpMssV6": {{ _v6TcpMss }}
                                 },
                             {% endif %}
                         {% endif %}
@@ -57,12 +69,16 @@
                                     "dhcpClient": {{ dhcp | default(true) }}
                                 }
                             {% endif %}
-                        }{% if sub_interfaces %},{% endif %}
+                        }{% if _subinterfaces %},{% endif %}
                     {% endif %}
                 {% endif %}
-                {% if sub_interfaces and (action == "default_lan" or action == "add" or action == "delete") %}
+                {% if _subinterfaces and (action == "default_lan" or action == "add" or action == "delete") %}
                     "subinterfaces": {
-                            {% for sub_interface in sub_interfaces %}
+                            {% for sub_interface in _subinterfaces %}
+                                {# Resolve backward-compatible aliases for subinterface #}
+                                {% set _sub_adminStatus = sub_interface.adminStatus | default(sub_interface.enabled) | default('true') %}
+                                {% set _sub_v4TcpMss = sub_interface.v4TcpMss | default(sub_interface.v4_tcp_mss) | default(none) %}
+                                {% set _sub_v6TcpMss = sub_interface.v6TcpMss | default(sub_interface.v6_tcp_mss) | default(none) %}
                                 "{{ sub_interface.vlan }}": {
                                     {% if action == "default_lan" %}
                                         "interface": {
@@ -84,16 +100,16 @@
                                             "vlan": {{ sub_interface.vlan }},
                                             "description": "{{ sub_interface.description | default(sub_interface.vlan ~ '_' ~ sub_interface.lan, true) }}",
                                             "alias": "{{ sub_interface.alias | default(sub_interface.vlan ~ '_' ~ sub_interface.lan, true) }}",
-                                            "adminStatus": {{ sub_interface.enabled | default('true') }},
+                                            "adminStatus": {{ _sub_adminStatus }},
                                             "loopback": {{ sub_interface.loopback | default(null) }},
-                                            {% if sub_interface.v4_tcp_mss is defined %}
+                                            {% if _sub_v4TcpMss is not none %}
                                                 "v4TcpMss": {
-                                                    "tcpMssV4": {{ sub_interface.v4_tcp_mss }}
+                                                    "tcpMssV4": {{ _sub_v4TcpMss }}
                                                 },
                                             {% endif %}
-                                            {% if sub_interface.v6_tcp_mss is defined %}
+                                            {% if _sub_v6TcpMss is not none %}
                                                 "v6TcpMss": {
-                                                    "tcpMssV6": {{ sub_interface.v6_tcp_mss }}
+                                                    "tcpMssV6": {{ _sub_v6TcpMss }}
                                                 },
                                             {% endif %}
                                             "ipv4": {

--- a/ansible_collections/graphiant/naas/templates/lag_interfaces_template.yaml
+++ b/ansible_collections/graphiant/naas/templates/lag_interfaces_template.yaml
@@ -9,10 +9,12 @@
         "lagInterfaces": {
             "{{ name }}": {
                 "interface": {
-                    {% if action == "add" and segment %}
+                    {% if action == "add" %}
                         "segment": "{{ segment }}",
+                        {% if alias is defined %}
                         "alias": "{{ alias }}",
-                        "adminStatus": {{ enabled | default('true') }},
+                        {% endif %}
+                        "adminStatus": {{ adminStatus | default('true') }},
                         "mtu": {{ mtu | default(1500) }},
                         "ipv4": {
                             {% if ipv4 %}
@@ -36,8 +38,12 @@
                                 }
                             {% endif %}
                         },
+                        "lacp": {
+                            "mode": "{{ lacpMode | default('ACTIVE') }}",
+                            "timer": "{{ lacpTimer | default('SLOW') }}"
+                        },
                     {% endif %}
-                    {% if action == "add" or action == "update_lacp_configs" %}
+                    {% if action == "update_lacp_configs" %}
                         "lacp": {
                             {% if lacpMode %}
                                 "mode": "{{ lacpMode }}",
@@ -68,8 +74,10 @@
                                         "interface": {
                                             "vlan": {{ subInterface.vlan }},
                                             "description": "{{ subInterface.description | default(subInterface.vlan ~ '_' ~ subInterface.segment, true) }}",
-                                            "alias": "{{ subInterface.alias | default(subInterface.vlan ~ '_' ~ subInterface.segment, true) }}",
-                                            "adminStatus": {{ subInterface.enabled | default('true') }},
+                                            {% if subInterface.alias is defined %}
+                                            "alias": "{{ subInterface.alias }}",
+                                            {% endif %}
+                                            "adminStatus": {{ subInterface.adminStatus | default(subInterface.enabled) | default('true') }},
                                             "segment": "{{ subInterface.segment | default(null) }}",
                                             "ipv4": {
                                                 {% if subInterface.ipv4 %}

--- a/ansible_collections/graphiant/naas/templates/vrrp_interfaces_template.yaml
+++ b/ansible_collections/graphiant/naas/templates/vrrp_interfaces_template.yaml
@@ -1,7 +1,7 @@
 # yamllint disable-file
 {
     "interfaces": {
-        "{{ interfaceName }}": {
+        "{{ name }}": {
             "interface": {
                 {% if vlan is defined %}
                 "subinterfaces": {
@@ -13,8 +13,7 @@
                             ,"ipv4": {
                                 "vrrp": {
                                     "group": {
-                                        "enabled": false,
-                                        "virtualRouterId": {{ vrrp_ipv4.virtualRouterId }}
+                                        "enabled": false
                                     }
                                 }
                             }
@@ -23,8 +22,26 @@
                             ,"ipv6": {
                                 "vrrp": {
                                     "group": {
-                                        "enabled": false,
-                                        "virtualRouterId": {{ vrrp_ipv6.virtualRouterId }}
+                                        "enabled": false
+                                    }
+                                }
+                            }
+                            {% endif %}
+                            {% elif action == "enable" %}
+                            {% if vrrp_ipv4 is defined %}
+                            ,"ipv4": {
+                                "vrrp": {
+                                    "group": {
+                                        "enabled": true
+                                    }
+                                }
+                            }
+                            {% endif %}
+                            {% if vrrp_ipv6 is defined %}
+                            ,"ipv6": {
+                                "vrrp": {
+                                    "group": {
+                                        "enabled": true
                                     }
                                 }
                             }
@@ -37,7 +54,7 @@
                                         "enabled": {{ vrrp_ipv4.enabled | default(true) }},
                                         "allowInterOperability": {{ vrrp_ipv4.allowInterOperability | default(false) | lower }},
                                         "virtualRouterId": {{ vrrp_ipv4.virtualRouterId }}, 
-                                        "description": "{{ vrrp_ipv4.description | default(interfaceName ~ ' VRRP group ' ~ vrrp_ipv4.virtualRouterId) }}",
+                                        "description": "{{ vrrp_ipv4.description | default(name ~ ' VRRP group ' ~ vrrp_ipv4.virtualRouterId) }}",
                                         "priority": {{ vrrp_ipv4.priority | default(100) }},
                                         "virtualIp": "{{ vrrp_ipv4.virtualIp }}",
                                         "preempt": {{ vrrp_ipv4.preempt | default(false) | lower }}
@@ -62,7 +79,7 @@
                                         "enabled": {{ vrrp_ipv6.enabled | default(true) }},
                                         "allowInterOperability": {{ vrrp_ipv6.allowInterOperability | default(false) | lower }},
                                         "virtualRouterId": {{ vrrp_ipv6.virtualRouterId }},
-                                        "description": "{{ vrrp_ipv6.description | default(interfaceName ~ ' VRRP group ' ~ vrrp_ipv6.virtualRouterId) }}",
+                                        "description": "{{ vrrp_ipv6.description | default(name ~ ' VRRP group ' ~ vrrp_ipv6.virtualRouterId) }}",
                                         "priority": {{ vrrp_ipv6.priority | default(100) }},
                                         "virtualIp": "{{ vrrp_ipv6.virtualIp }}",
                                         "preempt": {{ vrrp_ipv6.preempt | default(false) | lower }}
@@ -90,8 +107,7 @@
                 "ipv4": {
                     "vrrp": {
                         "group": {
-                            "enabled": false,
-                            "virtualRouterId": {{ vrrp_ipv4.virtualRouterId }}
+                            "enabled": false
                         }
                     }
                 }
@@ -100,8 +116,26 @@
                 {% if vrrp_ipv4 is defined %},{% endif %}"ipv6": {
                     "vrrp": {
                         "group": {
-                            "enabled": false,
-                            "virtualRouterId": {{ vrrp_ipv6.virtualRouterId }}
+                            "enabled": false
+                        }
+                    }
+                }
+                {% endif %}
+                {% elif action == "enable" %}
+                {% if vrrp_ipv4 is defined %}
+                "ipv4": {
+                    "vrrp": {
+                        "group": {
+                            "enabled": true
+                        }
+                    }
+                }
+                {% endif %}
+                {% if vrrp_ipv6 is defined %}
+                {% if vrrp_ipv4 is defined %},{% endif %}"ipv6": {
+                    "vrrp": {
+                        "group": {
+                            "enabled": true
                         }
                     }
                 }
@@ -114,7 +148,7 @@
                             "enabled": {{ vrrp_ipv4.enabled | default(true) }},
                             "allowInterOperability": {{ vrrp_ipv4.allowInterOperability | default(false) | lower }},
                             "virtualRouterId": {{ vrrp_ipv4.virtualRouterId }},
-                            "description": "{{ vrrp_ipv4.description | default(interfaceName ~ ' VRRP group ' ~ vrrp_ipv4.virtualRouterId) }}",
+                            "description": "{{ vrrp_ipv4.description | default(name ~ ' VRRP group ' ~ vrrp_ipv4.virtualRouterId) }}",
                             "priority": {{ vrrp_ipv4.priority | default(100) }},
                             "virtualIp": "{{ vrrp_ipv4.virtualIp }}",
                             "preempt": {{ vrrp_ipv4.preempt | default(false) | lower }}
@@ -139,7 +173,7 @@
                             "enabled": {{ vrrp_ipv6.enabled | default(true) }},
                             "allowInterOperability": {{ vrrp_ipv6.allowInterOperability | default(false) | lower }},
                             "virtualRouterId": {{ vrrp_ipv6.virtualRouterId }},
-                            "description": "{{ vrrp_ipv6.description | default(interfaceName ~ ' VRRP group ' ~ vrrp_ipv6.virtualRouterId) }}",
+                            "description": "{{ vrrp_ipv6.description | default(name ~ ' VRRP group ' ~ vrrp_ipv6.virtualRouterId) }}",
                             "priority": {{ vrrp_ipv6.priority | default(100) }},
                             "virtualIp": "{{ vrrp_ipv6.virtualIp }}",
                             "preempt": {{ vrrp_ipv6.preempt | default(false) | lower }}

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -178,10 +178,16 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.configure_wan_circuits_interfaces(
+        result = graphiant_config.interfaces.configure_wan_circuits_interfaces(
             circuit_config_file="sample_circuit_config.yaml",
             interface_config_file="sample_interface_config.yaml"
         )
+        LOG.info("Configure WAN circuits and interfaces result: %s", result)
+        result = graphiant_config.interfaces.configure_wan_circuits_interfaces(
+            circuit_config_file="sample_circuit_config.yaml",
+            interface_config_file="sample_interface_config.yaml"
+        )
+        LOG.info("Configure WAN circuits and interfaces result (rerun check): %s", result)
 
     def test_configure_circuits(self):
         """
@@ -189,9 +195,14 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.configure_circuits(
+        result = graphiant_config.interfaces.configure_circuits(
             circuit_config_file="sample_circuit_config.yaml",
             interface_config_file="sample_interface_config.yaml")
+        LOG.info("Configure Circuits result: %s", result)
+        result = graphiant_config.interfaces.configure_circuits(
+            circuit_config_file="sample_circuit_config.yaml",
+            interface_config_file="sample_interface_config.yaml")
+        LOG.info("Configure Circuits result (rerun check): %s", result)
 
     def test_deconfigure_circuits(self):
         """
@@ -199,9 +210,15 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.deconfigure_circuits(
+        result = graphiant_config.interfaces.deconfigure_circuits(
             interface_config_file="sample_interface_config.yaml",
             circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Deconfigure Circuits result: %s", result)
+        result = graphiant_config.interfaces.deconfigure_circuits(
+            interface_config_file="sample_interface_config.yaml",
+            circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Deconfigure Circuits result (rerun check): %s", result)
+        assert result['changed'] is False, "Deconfigure circuits idempotency failed"
 
     def test_deconfigure_wan_circuits_interfaces(self):
         """
@@ -209,10 +226,17 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.deconfigure_wan_circuits_interfaces(
+        result = graphiant_config.interfaces.deconfigure_wan_circuits_interfaces(
             interface_config_file="sample_interface_config.yaml",
             circuit_config_file="sample_circuit_config.yaml"
         )
+        LOG.info("Deconfigure WAN circuits and interfaces result: %s", result)
+        result = graphiant_config.interfaces.deconfigure_wan_circuits_interfaces(
+            interface_config_file="sample_interface_config.yaml",
+            circuit_config_file="sample_circuit_config.yaml"
+        )
+        LOG.info("Deconfigure WAN circuits and interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Deconfigure WAN circuits and interfaces idempotency failed"
 
     def test_configure_lan_interfaces(self):
         """
@@ -220,7 +244,10 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.configure_lan_interfaces("sample_interface_config.yaml")
+        result = graphiant_config.interfaces.configure_lan_interfaces("sample_interface_config.yaml")
+        LOG.info("Configure LAN interfaces result: %s", result)
+        result = graphiant_config.interfaces.configure_lan_interfaces("sample_interface_config.yaml")
+        LOG.info("Configure LAN interfaces result (rerun check): %s", result)
 
     def test_deconfigure_lan_interfaces(self):
         """
@@ -228,7 +255,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.deconfigure_lan_interfaces("sample_interface_config.yaml")
+        result = graphiant_config.interfaces.deconfigure_lan_interfaces("sample_interface_config.yaml")
+        LOG.info("Deconfigure LAN interfaces result: %s", result)
+        result = graphiant_config.interfaces.deconfigure_lan_interfaces("sample_interface_config.yaml")
+        LOG.info("Deconfigure LAN interfaces result (rerun check): %s", result)
+        assert result['changed'] is False, "Deconfigure LAN interfaces idempotency failed"
 
     def test_configure_interfaces(self):
         """
@@ -236,9 +267,14 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.configure_interfaces(
+        result = graphiant_config.interfaces.configure_interfaces(
             interface_config_file="sample_interface_config.yaml",
             circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Configure Interfaces result: %s", result)
+        result = graphiant_config.interfaces.configure_interfaces(
+            interface_config_file="sample_interface_config.yaml",
+            circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Configure Interfaces result (rerun check): %s", result)
 
     def test_deconfigure_interfaces(self):
         """
@@ -246,9 +282,15 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.interfaces.deconfigure_interfaces(
+        result = graphiant_config.interfaces.deconfigure_interfaces(
             interface_config_file="sample_interface_config.yaml",
             circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Deconfigure Interfaces result: %s", result)
+        result = graphiant_config.interfaces.deconfigure_interfaces(
+            interface_config_file="sample_interface_config.yaml",
+            circuit_config_file="sample_circuit_config.yaml")
+        LOG.info("Deconfigure Interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Deconfigure Interfaces idempotency failed"
 
     def test_configure_vrrp_interfaces(self):
         """
@@ -256,7 +298,10 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.vrrp_interfaces.configure("sample_vrrp_config.yaml")
+        result = graphiant_config.vrrp_interfaces.configure("sample_vrrp_config.yaml")
+        LOG.info("Configure VRRP interfaces result: %s", result)
+        result = graphiant_config.vrrp_interfaces.configure("sample_vrrp_config.yaml")
+        LOG.info("Configure VRRP interfaces result (rerun check): %s", result)
 
     def test_deconfigure_vrrp_interfaces(self):
         """
@@ -264,7 +309,23 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.vrrp_interfaces.deconfigure("sample_vrrp_config.yaml")
+        result = graphiant_config.vrrp_interfaces.deconfigure("sample_vrrp_config.yaml")
+        LOG.info("Deconfigure VRRP interfaces result: %s", result)
+        result = graphiant_config.vrrp_interfaces.deconfigure("sample_vrrp_config.yaml")
+        LOG.info("Deconfigure VRRP interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Deconfigure VRRP interfaces idempotency failed"
+
+    def test_enable_vrrp_interfaces(self):
+        """
+        Enable existing VRRP (Virtual Router Redundancy Protocol) configurations on interfaces for multiple devices.
+        """
+        base_url, username, password = read_config()
+        graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
+        result = graphiant_config.vrrp_interfaces.enable_vrrp_interfaces("sample_vrrp_config.yaml")
+        LOG.info("Enable VRRP interfaces result: %s", result)
+        result = graphiant_config.vrrp_interfaces.enable_vrrp_interfaces("sample_vrrp_config.yaml")
+        LOG.info("Enable VRRP interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Enable VRRP interfaces idempotency failed"
 
     def test_configure_lag_interfaces(self):
         """
@@ -272,7 +333,10 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.configure("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.configure("sample_lag_interface_config.yaml")
+        LOG.info("Configure LAG interfaces result: %s", result)
+        result = graphiant_config.lag_interfaces.configure("sample_lag_interface_config.yaml")
+        LOG.info("Configure LAG interfaces result (rerun check): %s", result)
 
     def test_update_lacp_configs(self):
         """
@@ -280,7 +344,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.update_lacp_configs("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.update_lacp_configs("sample_lag_interface_config.yaml")
+        LOG.info("Update LACP configurations result: %s", result)
+        result = graphiant_config.lag_interfaces.update_lacp_configs("sample_lag_interface_config.yaml")
+        LOG.info("Update LACP configurations result (idempotency check): %s", result)
+        assert result['changed'] is False, "Update LACP configurations idempotency failed"
 
     def test_add_lag_members(self):
         """
@@ -288,7 +356,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.add_lag_members("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.add_lag_members("sample_lag_interface_config.yaml")
+        LOG.info("Add LAG members result: %s", result)
+        result = graphiant_config.lag_interfaces.add_lag_members("sample_lag_interface_config.yaml")
+        LOG.info("Add LAG members result (idempotency check): %s", result)
+        assert result['changed'] is False, "Add LAG members idempotency failed"
 
     def test_remove_lag_members(self):
         """
@@ -296,15 +368,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.remove_lag_members("sample_lag_interface_config.yaml")
-
-    def test_add_lag_subinterfaces(self):
-        """
-        Configure LAG subinterfaces for multiple devices.
-        """
-        base_url, username, password = read_config()
-        graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.add_lag_subinterfaces("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.remove_lag_members("sample_lag_interface_config.yaml")
+        LOG.info("Remove LAG members result: %s", result)
+        result = graphiant_config.lag_interfaces.remove_lag_members("sample_lag_interface_config.yaml")
+        LOG.info("Remove LAG members result (idempotency check): %s", result)
+        assert result['changed'] is False, "Remove LAG members idempotency failed"
 
     def test_delete_lag_subinterfaces(self):
         """
@@ -312,7 +380,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.delete_lag_subinterfaces("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.delete_lag_subinterfaces("sample_lag_interface_config.yaml")
+        LOG.info("Delete LAG subinterfaces result: %s", result)
+        result = graphiant_config.lag_interfaces.delete_lag_subinterfaces("sample_lag_interface_config.yaml")
+        LOG.info("Delete LAG subinterfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Delete LAG subinterfaces idempotency failed"
 
     def test_deconfigure_lag_interfaces(self):
         """
@@ -320,7 +392,11 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         """
         base_url, username, password = read_config()
         graphiant_config = GraphiantConfig(base_url=base_url, username=username, password=password)
-        graphiant_config.lag_interfaces.deconfigure("sample_lag_interface_config.yaml")
+        result = graphiant_config.lag_interfaces.deconfigure("sample_lag_interface_config.yaml")
+        LOG.info("Deconfigure LAG interfaces result: %s", result)
+        result = graphiant_config.lag_interfaces.deconfigure("sample_lag_interface_config.yaml")
+        LOG.info("Deconfigure LAG interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Deconfigure LAG interfaces idempotency failed"
 
     def test_configure_global_config_prefix_lists(self):
         """
@@ -619,25 +695,29 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_configure_syslog_service'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_ipfix_service'))
 
-    # LAG Interface Configuration Management
-    suite.addTest(TestGraphiantPlaybooks('test_configure_lag_interfaces'))
-    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_lag_interfaces'))
-
-    '''
     # Device Interface Configuration Management
     suite.addTest(TestGraphiantPlaybooks('test_configure_lan_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_lan_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_wan_circuits_interfaces'))
-    suite.addTest(TestGraphiantPlaybooks('test_configure_circuits'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_circuits'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_circuits'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_wan_circuits_interfaces'))
-    # To configure all interfaces
     suite.addTest(TestGraphiantPlaybooks('test_configure_interfaces'))
+    # suite.addTest(TestGraphiantPlaybooks('test_deconfigure_interfaces'))
+
     # VRRP Interface Configuration Management
     suite.addTest(TestGraphiantPlaybooks('test_configure_vrrp_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vrrp_interfaces'))
-    # To deconfigure all interfaces (reset parent interface to default lan and delete subinterfaces)
-    # suite.addTest(TestGraphiantPlaybooks('test_deconfigure_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_enable_vrrp_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vrrp_interfaces'))
+
+    # LAG Interface Configuration Management
+    suite.addTest(TestGraphiantPlaybooks('test_configure_lag_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_update_lacp_configs'))
+    suite.addTest(TestGraphiantPlaybooks('test_remove_lag_members'))
+    suite.addTest(TestGraphiantPlaybooks('test_add_lag_members'))
+    suite.addTest(TestGraphiantPlaybooks('test_delete_lag_subinterfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_lag_interfaces'))
 
     # Global Configuration Management and BGP Peering
     suite.addTest(TestGraphiantPlaybooks('test_configure_global_config_prefix_lists'))
@@ -671,11 +751,10 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_delete_data_exchange_services'))
 
     # To deconfigure all interfaces
-    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_circuits'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_interfaces'))
 
     # Device Configuration Management Tests
     suite.addTest(TestGraphiantPlaybooks('test_show_validated_payload_for_device_config'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_device_config'))
-    '''
+
     runner = unittest.TextTestRunner(verbosity=2).run(suite)

--- a/scripts/validate_collection.py
+++ b/scripts/validate_collection.py
@@ -51,6 +51,8 @@ def check_structure(base_path):
     # Graphiant collection specific files
     collection_files = [
         'plugins/modules/graphiant_interfaces.py',
+        'plugins/modules/graphiant_lag_interfaces.py',
+        'plugins/modules/graphiant_vrrp.py',
         'plugins/modules/graphiant_bgp.py',
         'plugins/modules/graphiant_global_config.py',
         'plugins/modules/graphiant_sites.py',


### PR DESCRIPTION
TE-4366 Fix idempotent in the interface related modules operations (part1) and add tests

## Description

TE-4366 Fix idempotent in the interface related modules operations (part1) and add tests

Fix idempotent in interface modules (interfaces, vrrp, lag). Mostly on the deconfigure workflows. For configure workflows's (involving device config update API) "changed" status will be True always but configure workflows can be run multiple times though.

Updated tests and test configuration.

Adjusted IP Addresses test config not to overlap with Data Exchange feature examples

Added parameter alias to graphiant_interfaces module to closely match to API payload

Create lan segment perquisites for lag_interfaces testing

Ensured misc consistency in interfaces module (key ‘name’ for interface, config file name to match module name)

Added enabled operation in the vrrp module. Removed redundant add_lag_subinterface operation in the lag module

Addressed minor issues in vrrp & lag modules.


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x ] Documentation update
- [x ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x ] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x] **Testing**
  - [ ] Local tests pass
  - [x] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)
[test.py_run_results.log](https://github.com/user-attachments/files/24869794/test.py_run_results.log)

- [ ] **Documentation**
  - [ ] Updated README.md if needed
  - [x] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [ ] **CI/CD**
  - [x] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

<!-- Describe the testing you performed to verify your changes -->

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->

Configure workflows, which involves device config update APIs, idempotent will be addressed in next PR . However all those configure workflows can be run multiple times though but the changed flag will be True always. 
---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
