### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint Collection
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/10](https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/10)

In general, the fix is to explicitly declare `permissions` in the workflow so that the `GITHUB_TOKEN` is limited to the least privilege required. For this workflow, all jobs only read repository contents and install dependencies; they do not write to the repo, open PRs, or modify issues. The safest, least-privilege setting is therefore `permissions: contents: read`. You can place this `permissions` block at the top level of the workflow (alongside `name` and `on`) so it applies to all jobs, or you can set it per-job. Since all jobs here are lint/check-style jobs, the best single change is to add a root-level `permissions:` block with `contents: read`.

Concretely, edit `.github/workflows/lint.yml` near the top of the file. After the `name: Lint Collection` line and before the `on:` block, insert:

```yaml
permissions:
  contents: read
```

This requires no additional imports or other code changes. It does not change any job behavior except for constraining the token’s permissions, and it satisfies CodeQL’s recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
