### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:
     # Run nightly at 2 AM UTC
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests (ansible-core ${{ matrix.ansible_core }})


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/8](https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/8)

In general, the fix is to explicitly declare a minimal `permissions` block for the workflow or for each job, instead of relying on repository defaults. Since neither job writes to the repository or uses GitHub APIs that require write permissions, we can safely restrict the `GITHUB_TOKEN` to read-only access to repository contents.

The best way to fix this without changing behavior is to add a top-level `permissions` block applying to all jobs in this workflow, right after the `name:` (or after the `on:` block). Setting `contents: read` is sufficient for `actions/checkout` and other read-only operations. No other scopes (like `pull-requests` or `issues`) appear necessary based on the shown steps, and the jobs only use repository code and secrets, not GitHub APIs that need write access.

Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

at the top workflow level (aligned with `name:` and `on:`), e.g. between line 1 and 3 or between line 18 and 19. This single change tightens permissions for both `test` and `e2e-integration-test` jobs; no additional imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
