### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build Collection
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/3](https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/3)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal scopes required for this workflow. For a build-only workflow that checks out code and uploads an artifact, `contents: read` is sufficient, and defining it at the top level (root of the workflow) will apply to all jobs that don’t override it.

The best minimally invasive fix is to add a root-level `permissions:` block right after the `name:` line, setting `contents: read`. This keeps the workflow behavior the same (checkout will still work, and no step requires write access to repo contents or other scopes) while constraining the `GITHUB_TOKEN`. No changes are needed within the `jobs:` block or individual steps. The only file to edit is `.github/workflows/build.yml`, and the only region to change is the top of the file around line 1, inserting the `permissions` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
