### PR TITLE
Fix CodeQL false positives for edge services skip logging.

### DIFF
--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
@@ -19,7 +19,7 @@ pushed only when none is configured; with force, requires password from YAML, va
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Iterator, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from .base_manager import BaseManager
 from .device_config_common import (
@@ -406,6 +406,11 @@ class EdgeServicesManager(BaseManager):
                 f"Device '{device_name}' has role 'core'; edge services apply to Edge/Gateway (CPE) devices only."
             )
 
+    @staticmethod
+    def _log_no_edge_changes(device_name: str, device_id: int) -> None:
+        """Log idempotent skip without referencing device config dicts (avoids secret taint in log sinks)."""
+        LOG.info("%s No changes needed for %s (ID: %s), skipping", _LOG_PREFIX, device_name, device_id)
+
     def _compute_after_snapshot(self, cfg: Dict[str, Any], before: Dict[str, Any]) -> Dict[str, Any]:
         after: Dict[str, Any] = {
             "localWebServerPasswordConfigured": before.get("localWebServerPasswordConfigured", False),
@@ -565,21 +570,6 @@ class EdgeServicesManager(BaseManager):
 
         return edge
 
-    def _iter_devices(
-        self, by_name: Dict[str, Dict[str, Any]]
-    ) -> Iterator[Tuple[int, str, Dict[str, Any], Dict[str, Any], Dict[str, Any], Dict[str, Any]]]:
-        enterprise = self.gsdk.enterprise_info["company_name"]
-        for device_name, cfg in by_name.items():
-            device_id, d = fetch_device_by_name(self.gsdk, device_name, enterprise)
-            self._assert_edge_device(device_name, d)
-
-            before = self._edge_services_snapshot(d)
-            if cfg.get("lldp"):
-                self._validate_lldp_entries(device_name, cfg["lldp"], d)
-            edge_payload = self._build_edge_payload(device_name, cfg, d)
-            after = self._compute_after_snapshot(cfg, before)
-            yield device_id, device_name, cfg, before, after, edge_payload
-
     def _inject_vault_lws_passwords(
         self, by_name: Dict[str, Dict[str, Any]], vault_lws: Optional[Dict[str, Any]]
     ) -> None:
@@ -625,10 +615,19 @@ class EdgeServicesManager(BaseManager):
         to_push: Dict[int, Dict[str, Any]] = {}
         configured: List[str] = []
         diff_plan: List[Dict[str, Any]] = []
+        enterprise = self.gsdk.enterprise_info["company_name"]
 
-        for device_id, device_name, _cfg, before, after, edge_payload in self._iter_devices(by_name):
+        for device_name, cfg in by_name.items():
+            device_id, d = fetch_device_by_name(self.gsdk, device_name, enterprise)
+            self._assert_edge_device(device_name, d)
+
+            before = self._edge_services_snapshot(d)
+            if cfg.get("lldp"):
+                self._validate_lldp_entries(device_name, cfg["lldp"], d)
+            edge_payload = self._build_edge_payload(device_name, cfg, d)
+            after = self._compute_after_snapshot(cfg, before)
             if not edge_payload:
-                LOG.info("%s No changes needed for %s (ID: %s), skipping", _LOG_PREFIX, device_name, device_id)
+                self._log_no_edge_changes(device_name, device_id)
                 result["skipped_devices"].append(device_name)
                 continue
 


### PR DESCRIPTION
CodeQL alerts #14 and #15 reported clear-text password logging on the idempotent skip path in EdgeServicesManager. The log line only prints device name and ID; the alert came from taint flowing through _iter_devices yield into the same scope as LOG.info. Inline the device loop in apply_edge_services and log skips via _log_no_edge_changes() so secret-bearing cfg is not bundled with log arguments. No behavior change.

## Description

To address
https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/14

https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/15

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x ] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x ] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [ ] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [ ] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

ran relevant portion of test.py

## Related Issues

https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/14

https://github.com/Graphiant-Inc/graphiant-playbooks/security/code-scanning/15

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
