### PR TITLE
fix(naas): mask secret API fields in library log output

### DIFF
--- a/ansible_collections/graphiant/naas/README.md
+++ b/ansible_collections/graphiant/naas/README.md
@@ -594,7 +594,7 @@ Config file paths are resolved in the following order:
 
 Similarly, template paths use `GRAPHIANT_TEMPLATES_PATH` environment variable.
 
-Check `logs/log_<date>.log` for the actual path used during execution.
+Check `logs/log_<date>.log` under the playbook working directory (for example `playbooks/logs/`). Secrets are already masked in Ansible output (`no_log` on modules and tasks, plus vault). Outside Ansible, collection log output masks API keys listed in `_SENSITIVE_LOG_KEYS` in `device_config_common.py` (see [Credential Management Guide](docs/guides/CREDENTIAL_MANAGEMENT_GUIDE.md#logging)). Do not commit log files.
 
 Data Exchange configurations are in `configs/de_workflows_configs/`.
 

--- a/ansible_collections/graphiant/naas/changelogs/changelog.yaml
+++ b/ansible_collections/graphiant/naas/changelogs/changelog.yaml
@@ -8,6 +8,8 @@ releases:
   "26.5.0":
     release_date: "2026-05-27"
     changes:
+      security_fixes:
+        - "Mask API keys in ``_SENSITIVE_LOG_KEYS`` (``device_config_common``) in ``gcsdk_client`` ``put_device_config`` / ``put_device_config_raw`` and ``show_validated_payload`` log output"
       minor_changes:
         - "Collection version bumped to 26.5.0"
         - "New ``graphiant_backbone`` module and ``backbone_management.yml`` playbook for managing Graphiant Core (backbone) device configuration; samples ``sample_backbone_config.yaml`` and ``sample_backbone_direct_peer_config.yaml``"

--- a/ansible_collections/graphiant/naas/docs/guides/CREDENTIAL_MANAGEMENT_GUIDE.md
+++ b/ansible_collections/graphiant/naas/docs/guides/CREDENTIAL_MANAGEMENT_GUIDE.md
@@ -163,6 +163,12 @@ Keys must match portal hostnames in `sample_edge_services.yaml`. Without `localW
 3. **Use service accounts** with minimal permissions
 4. **Environment-specific credentials** for different environments
 
+## Logging
+
+Secrets are already masked in Ansible: sensitive module options use ``no_log``, related playbook tasks use ``no_log``, and vault encrypts files at rest—playbook output shows ``********`` instead of plaintext.
+
+With ``detailed_logs: true``, the collection also writes device config payloads to ``logs/log_<timestamp>.log`` under the playbook working directory (for example ``playbooks/logs/``). That path is outside Ansible (library logging), so keep secrets out of those files by listing API field names in ``_SENSITIVE_LOG_KEYS`` in ``plugins/module_utils/libs/device_config_common.py``. ``gcsdk_client`` redacts those keys (currently ``localWebServerPassword``, ``presharedKey``, ``md5Password``) to ``********`` in log output only. Add new secret API keys there when you introduce sensitive config fields. Do not commit log files.
+
 ## Additional Resources
 
 - [Ansible Vault Documentation](https://docs.ansible.com/ansible/latest/vault_guide/index.html)

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -44,7 +44,7 @@ Config file paths are resolved in the following order:
 
 Similarly, template paths use `GRAPHIANT_TEMPLATES_PATH` environment variable.
 
-Check `logs/log_<date>.log` for the actual path used during execution.
+Check `logs/log_<date>.log` under the playbook working directory (for example `playbooks/logs/`). Secrets are already masked in Ansible output (`no_log` on modules and tasks, plus vault). Outside Ansible, collection logs mask API keys in `_SENSITIVE_LOG_KEYS` (`device_config_common.py`)—see [CREDENTIAL_MANAGEMENT_GUIDE.md](CREDENTIAL_MANAGEMENT_GUIDE.md#logging). Do not commit log files.
 
 
 ## Device system settings (name, region, site)

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/device_config_common.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/device_config_common.py
@@ -16,6 +16,38 @@ from .logger import setup_logger
 
 LOG = setup_logger()
 
+# API payload keys redacted in library log output (non-Ansible paths).
+# Add names here for new secret fields; see CREDENTIAL_MANAGEMENT_GUIDE.md.
+_SENSITIVE_LOG_KEYS = frozenset(
+    {
+        "localWebServerPassword",
+        "presharedKey",
+        "md5Password",
+    }
+)
+
+
+def redact_sensitive_for_log(value: Any) -> Any:
+    """
+    Return a deep copy of ``value`` with known secret field names replaced for logging.
+
+    Redaction is by JSON key name (Graphiant API / config fields), not by vault values.
+    Does not modify the original object; safe to use on ``to_dict()`` output before ``LOG.info``.
+    """
+    if isinstance(value, dict):
+        return {
+            key: ("********" if key in _SENSITIVE_LOG_KEYS else redact_sensitive_for_log(item))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_sensitive_for_log(item) for item in value]
+    return value
+
+
+def format_config_payload_for_log(payload: Any) -> str:
+    """Format a config payload dict for ``LOG.info`` without logging secret values."""
+    return json.dumps(redact_sensitive_for_log(payload), indent=2)
+
 
 def coerce_str(val: Any) -> str:
     """Normalize optional scalars to a stripped string (empty when None)."""

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/gcsdk_client.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/gcsdk_client.py
@@ -75,6 +75,7 @@ PydanticValidationError = _pydantic_validation_error_type()
 from .logger import setup_logger  # noqa: E402
 from .poller import poller  # noqa: E402
 from .exceptions import APIError  # noqa: E402
+from .device_config_common import format_config_payload_for_log  # noqa: E402
 
 LOG = setup_logger()
 
@@ -467,7 +468,7 @@ class GraphiantPortalClient:
             LOG.info(
                 "[check_mode] put_device_config would push config for device_id=%s: %s",
                 device_id,
-                json.dumps(device_config_put_request.to_dict(), indent=2),
+                format_config_payload_for_log(device_config_put_request.to_dict()),
             )
             return None
         try:
@@ -476,7 +477,7 @@ class GraphiantPortalClient:
             LOG.info(
                 "put_device_config : config to be pushed for %s: \n%s",
                 device_id,
-                json.dumps(device_config_put_request.to_dict(), indent=2),
+                format_config_payload_for_log(device_config_put_request.to_dict()),
             )
             response = self.api.v1_devices_device_id_config_put(
                 authorization=self.bearer_token,
@@ -539,7 +540,7 @@ class GraphiantPortalClient:
             LOG.info(
                 "[check_mode] put_device_config_raw would push config for device_id=%s: %s",
                 device_id,
-                json.dumps(device_config_put_request.to_dict(), indent=2),
+                format_config_payload_for_log(device_config_put_request.to_dict()),
             )
             return None
         try:
@@ -548,7 +549,7 @@ class GraphiantPortalClient:
             LOG.info(
                 "put_device_config_raw : config to be pushed for %s: \n%s",
                 device_id,
-                json.dumps(device_config_put_request.to_dict(), indent=2),
+                format_config_payload_for_log(device_config_put_request.to_dict()),
             )
             response = self.api.v1_devices_device_id_config_put(
                 authorization=self.bearer_token,
@@ -609,7 +610,7 @@ class GraphiantPortalClient:
         LOG.info(
             "show_validated_payload : validated config for %s: \n%s",
             device_id,
-            json.dumps(validated_payload_dict, indent=2),
+            format_config_payload_for_log(validated_payload_dict),
         )
 
         LOG.info("show_validated_payload: Successfully showed validated payload for %s", device_id)

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_device_config_common.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_device_config_common.py
@@ -13,8 +13,10 @@ from ansible_collections.graphiant.naas.plugins.module_utils.libs.device_config_
     coerce_str,
     device_not_found_message,
     fetch_device_by_name,
+    format_config_payload_for_log,
     load_device_list_yaml_config,
     normalized_device_type,
+    redact_sensitive_for_log,
 )
 from ansible_collections.graphiant.naas.plugins.module_utils.libs.exceptions import (
     ConfigurationError,
@@ -85,3 +87,24 @@ def test_ansible_diff_from_plan() -> None:
     d = ansible_diff_from_plan(diff_plan)
     assert "edge-1" in d["before"] and "edge-1" in d["after"]
     assert '"a"' in d["before"] and '"b"' in d["after"]
+
+
+def test_redact_sensitive_for_log_by_key_name() -> None:
+    payload = {
+        "edge": {
+            "localWebServerPassword": "ReplaceMe1",
+            "dns": {"mode": "DNSModeCloudflare"},
+        },
+        "siteToSiteVpn": {"vpn-1": {"presharedKey": "secret-psk"}},
+    }
+    redacted = redact_sensitive_for_log(payload)
+    assert redacted["edge"]["localWebServerPassword"] == "********"
+    assert redacted["edge"]["dns"]["mode"] == "DNSModeCloudflare"
+    assert redacted["siteToSiteVpn"]["vpn-1"]["presharedKey"] == "********"
+    assert payload["edge"]["localWebServerPassword"] == "ReplaceMe1"
+
+
+def test_format_config_payload_for_log() -> None:
+    text = format_config_payload_for_log({"localWebServerPassword": "ReplaceMe1"})
+    assert "ReplaceMe1" not in text
+    assert '"localWebServerPassword": "********"' in text


### PR DESCRIPTION
Mask secret API fields in collection library log files (non-Ansible workflow; Ansible no_log unaffected)

Fixes [Graphiant-Inc/graphiant-playbooks#90](https://github.com/Graphiant-Inc/graphiant-playbooks/issues/90)

## Description

Redact localWebServerPassword, presharedKey, and md5Password in gcsdk_client device config logging for non-Ansible workflows (SDK integration tests and logs/log_*.log). 

Ansible no_log behavior is unchanged.

- Add `_SENSITIVE_LOG_KEYS` and `redact_sensitive_for_log()` / `format_config_payload_for_log()` in `device_config_common.py`
- Use redacted logging in `gcsdk_client` for `put_device_config`, `put_device_config_raw`, and `show_validated_payload`
- Unit tests for key-name redaction

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x ] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [ x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x ] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [x ] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [x] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

Non-Ansible (`python ansible_collections/graphiant/naas/tests/test.py`):
- Edge services: `grep ReplaceMe1 logs/*` → no matches; `"localWebServerPassword": "********"` in payload logs
- Site-to-Site VPN: `grep presharedKey logs/*` / `grep md5Password logs/*` → only `"********"`

## Related Issues

[<!-- Link to related issues using #issue_number -->](https://github.com/Graphiant-Inc/graphiant-playbooks/issues/90)

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
