### PR TITLE
DPI Application and Prefix & Port list Support

### DIFF
--- a/ansible_collections/graphiant/naas/README.md
+++ b/ansible_collections/graphiant/naas/README.md
@@ -31,6 +31,8 @@ This collection provides Ansible modules to automate:
 - Raw device configuration deployment (Edge, Gateway, and Core devices)
 - Edge services (DHCP subnets, DNS mode, LLDP, local web server password) on Edge/Gateway devices
 - NTP Service Configuration
+- Traffic Policy configuration on Edge Devices
+- Prefix and Port List configuration on Edge Devices
 
 ### Key Features
 
@@ -77,6 +79,7 @@ This collection provides Ansible modules to automate:
 | `graphiant_device_config` | Push raw device configurations to Edge, Gateway, and Core devices |
 | `graphiant_ntp` | Manage NTP objects |
 | `graphiant_traffic_policy` | Manage device traffic policy rulesets and LAN segment attachments (configure workflow: rulesets + attach; deconfigure workflow: detach + delete) |
+| `graphiant_prefix_port_list` | Manage Prefix & Port Lists on Edge devices | 
 
 ## Installation
 
@@ -352,6 +355,8 @@ The collection includes ready-to-use example playbooks in the `playbooks/` direc
 | `device_system_management.yml` | Device name, region, and site configuration |
 | `edge_services_management.yml` | Edge DHCP, DNS, LLDP, local web server password (Vault-supported) |
 | `test_collection.yml` | Collection validation and testing |
+| `traffic_policies_management.yml` | Traffic policies and LAN-segment attachments |
+| `prefix_port_list_management.yml` | Prefix and port lists | 
 
 #### Data Exchange Workflows
 
@@ -395,6 +400,7 @@ ansible-doc graphiant.naas.graphiant_data_exchange
 ansible-doc graphiant.naas.graphiant_data_exchange_info
 ansible-doc graphiant.naas.graphiant_device_config
 ansible-doc graphiant.naas.graphiant_backbone
+ansible-doc graphiant.naas.graphiant_prefix_port_list.py
 ```
 
 ## Documentation
@@ -455,13 +461,13 @@ Use `ansible-playbook ... --check` or set `check_mode: true` on a task to run wi
 
 | Support | Modules | Behavior |
 |--------|---------|----------|
-| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
-| **Partial** | `graphiant_bgp`, `graphiant_device_config`, `graphiant_backbone` | Writes are still skipped, but `changed` is not computed from a full live diff: BGP reports `changed: true` for configure/deconfigure/detach in check mode; `graphiant_device_config` returns `changed: false` for `show_validated_payload` and `changed: true` for `configure`; `graphiant_backbone` reports `changed: true` whenever the supplied config file contains matching backbone resources (no live diff against current Core device state). See each module's `attributes.check_mode` details. |
+| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
+| **Partial** | `graphiant_bgp`, `graphiant_device_config`, `graphiant_backbone`                                                                                                                                                                                                                                                                    | Writes are still skipped, but `changed` is not computed from a full live diff: BGP reports `changed: true` for configure/deconfigure/detach in check mode; `graphiant_device_config` returns `changed: false` for `show_validated_payload` and `changed: true` for `configure`; `graphiant_backbone` reports `changed: true` whenever the supplied config file contains matching backbone resources (no live diff against current Core device state). See each module's `attributes.check_mode` details. |
 | **Read-only** | `graphiant_macsec_info` | Always read-only; check mode has no side effects. |
 
 **Full-mode nuances:** `graphiant_device_system`, `graphiant_edge_services`, and `graphiant_macsec` read device state in check mode and set `changed` from whether an apply would be needed. For LWS, omit `localWebServerPasswordForce` after a successful set—force re-pushes every run because the portal stores a hash. `graphiant_data_exchange_info` and `graphiant_macsec_info` are always read-only. `graphiant_data_exchange` skips mutating writes in check mode; see that module's `attributes.check_mode` for details.
 
-**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, and `graphiant_macsec` document `diff_mode`; use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan` when an edge branch would change.
+**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_prefix_port_list` and `graphiant_macsec` document `diff_mode`; use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan` when an edge branch would change.
 
 **Example: run playbooks in check mode (dry run)**
 
@@ -608,6 +614,7 @@ Configuration files use YAML format with optional Jinja2 templating. Sample file
 - `sample_device_config_with_template.yaml` - Device config with user-defined template (`device_config_template.yaml`)
 - `sample_backbone_config.yaml` - Core (backbone) device configuration covering interfaces (loopback, core_link, ipsec_tunnel, p2mp_tunnel, isp_circuit, direct_peer, disabled), site info, and per-VRF syslog targets
 - `sample_sites.yaml` - Site configurations
+- `sample_prefix_and_port_list.yaml` - Network Prefix and Port configuration
 
 ### Config File Path Resolution
 

--- a/ansible_collections/graphiant/naas/configs/sample_device_traffic_policies.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_device_traffic_policies.yaml
@@ -211,7 +211,6 @@ trafficPolicyObject:
                 ipsecLabel: ipsec_label_2
               backupCircuitLabel:
                 ipsecLabel: ipsec_label_3
-              state: absent
 
             - seq: 200
               ipProtocol: udp  # any, icmp, igmp, tcp, udp, esp, or ah.
@@ -229,7 +228,6 @@ trafficPolicyObject:
               slaClass: Gold  # Default, Bronze, Silver, or Gold.
               egress: dia  # overlay, dia, or ipsec; dia/ipsec usually require circuit labels.
               primaryCircuitLabel: "internet_dia_2"
-              state: absent
 
             - seq: 400
               applicationBuiltin: YouTube

--- a/ansible_collections/graphiant/naas/configs/sample_edge_services.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_edge_services.yaml
@@ -40,6 +40,21 @@
 #           ipRange:
 #             - start: "10.1.11.100"
 #               end: "10.1.11.200"
+#  Prerequisite for DPI list references: graphiant_prefix_port_list / sample_prefix_and_port_list.yaml
+#   dpiApplications:  # PUT edge.trafficPolicy.dpiApplications (map keyed by application name)
+#     my-app:          # map key → application.name in API (omit name in YAML)
+#       state: present # default; use absent to remove (application: null)
+#     my-app:
+#       application:
+#         ipProtocol: tcp              # UnknownIPProtocol | icmp | tcp | udp
+#         sourceNetwork: null          # optional; null/omitted = unset (portal cannot clear via null)
+#         sourceNetworkList: null      # edge.trafficPolicy.networkLists name
+#         sourcePort: null             # 1-65535 (tcp/udp when not using sourcePortList)
+#         sourcePortList: null         # edge.trafficPolicy.portLists name
+#         destinationNetwork: null     # prefix, e.g. "192.0.66.180/32"
+#         destinationNetworkList: null # edge.trafficPolicy.networkLists name
+#         destinationPort: null        # 1-65535 (tcp/udp when not using destinationPortList)
+#         destinationPortList: null    # edge.trafficPolicy.portLists name
 
 edge_services:
   - edge-1-sdktest:
@@ -90,6 +105,51 @@ edge_services:
               ipRange:
                 - start: "10.1.17.100"
                   end: "10.1.17.200"
+      dpiApplications:
+        whitehouse.gov:
+          application:
+            ipProtocol: tcp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "192.0.66.180/32"
+            destinationNetworkList: null
+            destinationPort: null
+            destinationPortList: web_ports
+        graphiant_dia_ping_via_IP:
+          application:
+            ipProtocol: UnknownIPProtocol
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "8.8.8.8/32"
+            destinationNetworkList: null
+            destinationPort: null
+            destinationPortList: null
+        graphiant_dia_ping:
+          application:
+            ipProtocol: icmp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: null
+            destinationNetworkList: graphiant_dia_prefix
+            destinationPort: null
+            destinationPortList: null
+        testing_dpi_application:
+          application:
+            ipProtocol: tcp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "10.1.1.0/24"
+            destinationNetworkList: null
+            destinationPort: null
+            destinationPortList: testing_port_list
 
   - edge-2-sdktest:
       dns:
@@ -114,6 +174,54 @@ edge_services:
             domainNameServer:
               primary: "8.8.8.8"
               secondary: "8.8.4.4"
+      dpiApplications:
+        whitehouse.gov:
+          application:
+            ipProtocol: tcp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "192.0.66.180/32"
+            destinationNetworkList: null
+            destinationPort: null
+            destinationPortList: web_ports
+        graphiant_dia_ping:
+          application:
+            name: graphiant_dia_ping
+            description: null
+            ipProtocol: icmp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: null
+            destinationNetworkList: graphiant_dia_prefix
+            destinationPort: null
+            destinationPortList: null
+        graphiant_dia_ping_via_IP:
+          application:
+            ipProtocol: UnknownIPProtocol
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "8.8.8.8/32"
+            destinationNetworkList: null
+            destinationPort: null
+            destinationPortList: null
+        testing_dpi_application:
+          application:
+            ipProtocol: tcp
+            sourceNetwork: null
+            sourceNetworkList: null
+            sourcePort: null
+            sourcePortList: null
+            destinationNetwork: "10.2.1.0/24"
+            destinationNetworkList: null
+            destinationPort: 80
+            destinationPortList: null
+          state: absent
 
   - edge-3-sdktest:
       dns:

--- a/ansible_collections/graphiant/naas/configs/sample_prefix_and_port_list.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_prefix_and_port_list.yaml
@@ -1,0 +1,56 @@
+# Prefix and port lists under edge.trafficPolicy (per device).
+# On create_* operations, use state: absent on a list entry to remove that name only (list: null).
+# delete_* operations ignore per-entry state and remove every name listed for that section.
+networkLists:
+  - edge-1-sdktest:
+    - name: graphiant_dia_prefix
+      networks:
+        - 1.1.1.1/32
+        - 8.8.8.8/32
+    - name: testing_prefix_list
+      networks:
+        - 10.1.1.0/24
+        - 10.1.2.0/24
+      state: absent
+  - edge-2-sdktest:
+    - name: graphiant_dia_prefix
+      networks:
+        - 1.1.1.1/32
+        - 8.8.8.8/32
+    - name: testing_prefix_list
+      networks:
+        - 10.2.1.0/24
+        - 10.2.2.0/24
+        - 10.2.4.0/24
+      state: absent
+  - edge-3-sdktest:
+    - name: graphiant_dia_prefix
+      networks:
+        - 4.4.4.4/32
+        - 8.8.8.8/32
+
+portLists:
+  - edge-1-sdktest:
+    - name: web_ports
+      ports:
+        - 80
+        - 443
+    - name: testing_port_list
+      ports:
+        - 123
+  - edge-2-sdktest:
+    - name: web_ports
+      ports:
+        - 80
+        - 443
+    - name: testing_port_list
+      ports:
+        - 123
+        - 789
+  - edge-3-sdktest:
+    - name: web_ports
+      ports:
+        - 80
+        - 443
+        - 123
+      state: absent

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -345,7 +345,7 @@ LWS via module params or vault (omit `localWebServerPasswordForce` for first-tim
   no_log: true
 ```
 
-There is no `deconfigure` operation or `state: absent` for the module as a whole. To revert settings, use module parameters per device: set `dns.mode` to `DNSModeDynamic`, set listed `lldp` interfaces to `false`, and use `dhcpSubnets` with `state: absent` for each pool (see `tests/test.py` `test_deconfigure_edge_services`).
+There is no `deconfigure` operation for the module as a whole. To revert settings, use module parameters per device: set `dns.mode` to `DNSModeDynamic`, set listed `lldp` interfaces to `false`, use `dhcpSubnets` with `state: absent` for each pool, and set each `dpiApplications` map key you want removed to `state: absent` (sends `application: null`). See `tests/test.py` `_edge_services_deconfigure_module_params` and `test_deconfigure_edge_services`.
 
 ## Interface Management
 

--- a/ansible_collections/graphiant/naas/playbooks/edge_services_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/edge_services_management.yml
@@ -3,7 +3,7 @@
 # =================================
 #
 # Configures Edge/Gateway services via graphiant_edge_services:
-# DHCP subnets, DNS mode, LLDP on LAN interfaces, local web server password.
+# DHCP subnets, DNS mode, LLDP on LAN interfaces, local web server password, DPI applications.
 #
 # Local web server passwords can come from Ansible Vault (vault_devices_lws_password in
 # configs/vault_secrets.yml) — same pattern as site_to_site_vpn.yml.
@@ -195,6 +195,7 @@
         dns: "{{ item.dns | default(omit) }}"
         lldp: "{{ item.lldp | default(omit) }}"
         dhcpSubnets: "{{ item.dhcpSubnets | default(omit) }}"
+        dpiApplications: "{{ item.dpiApplications | default(omit) }}"
       loop: "{{ edge_module_param_examples }}"
       loop_control:
         label: "{{ item.device }}"

--- a/ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml
+++ b/ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml
@@ -1,0 +1,131 @@
+- name: Manage Graphiant Prefix and Port List Configuration
+  hosts: localhost
+  gather_facts: false
+  vars:
+    # graphiant_host: "https://api.graphiant.com"
+    # graphiant_username: "{{ vault_graphiant_username }}"
+    # graphiant_password: "{{ vault_graphiant_password }}"
+
+    # Use YAML anchors to avoid repetition.
+    # Auth: either set GRAPHIANT_ACCESS_TOKEN (e.g. graphiant login; source ~/.graphiant/env.sh)
+    # or set GRAPHIANT_USERNAME / GRAPHIANT_PASSWORD for password login. Token is tried first.
+    graphiant_client_params: &graphiant_client_params
+      host: "{{ graphiant_host | default(lookup('env', 'GRAPHIANT_HOST')) }}"
+      username: "{{ graphiant_username | default(lookup('env', 'GRAPHIANT_USERNAME')) }}"
+      password: "{{ graphiant_password | default(lookup('env', 'GRAPHIANT_PASSWORD')) }}"
+      access_token: "{{ graphiant_access_token | default(lookup('env', 'GRAPHIANT_ACCESS_TOKEN')) }}"
+
+  tasks:
+    - name: Create prefix and port lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: create_prefix_port_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: present
+      register: create_result
+      tags: ['create_prefix_port_lists']
+
+    - name: Display create result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ create_result.msg }}"
+          - "configured_devices={{ create_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ create_result.skipped_devices | default([]) }}"
+      when: create_result is defined and create_result.msg is defined
+      tags: ['create_prefix_port_lists']
+
+    - name: Delete prefix and port lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: delete_prefix_port_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: absent
+      register: delete_result
+      tags: ['delete_prefix_port_lists']
+
+    - name: Display delete result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ delete_result.msg }}"
+          - "configured_devices={{ delete_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ delete_result.skipped_devices | default([]) }}"
+      when: delete_result is defined and delete_result.msg is defined
+      tags: ['delete_prefix_port_lists']
+
+    - name: Create prefix lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: create_prefix_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: present
+      register: create_result
+      tags: ['create_prefix_lists']
+
+    - name: Display create result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ create_result.msg }}"
+          - "configured_devices={{ create_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ create_result.skipped_devices | default([]) }}"
+      when: create_result is defined and create_result.msg is defined
+      tags: ['create_prefix_lists']
+
+    - name: Delete prefix lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: delete_prefix_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: absent
+      register: delete_result
+      tags: ['delete_prefix_lists']
+
+    - name: Display delete result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ delete_result.msg }}"
+          - "configured_devices={{ delete_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ delete_result.skipped_devices | default([]) }}"
+      when: delete_result is defined and delete_result.msg is defined
+      tags: ['delete_prefix_lists']
+
+    - name: Create port lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: create_port_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: present
+      register: create_result
+      tags: ['create_port_lists']
+
+    - name: Display create result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ create_result.msg }}"
+          - "configured_devices={{ create_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ create_result.skipped_devices | default([]) }}"
+      when: create_result is defined and create_result.msg is defined
+      tags: ['create_port_lists']
+
+    - name: Delete port lists
+      graphiant.naas.graphiant_prefix_port_list:
+        <<: *graphiant_client_params
+        operation: delete_port_lists
+        prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+        detailed_logs: true
+        state: absent
+      register: delete_result
+      tags: ['delete_port_lists']
+
+    - name: Display delete result message (includes detailed logs)
+      ansible.builtin.debug:
+        msg:
+          - "{{ delete_result.msg }}"
+          - "configured_devices={{ delete_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ delete_result.skipped_devices | default([]) }}"
+      when: delete_result is defined and delete_result.msg is defined
+      tags: ['delete_port_lists']

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
@@ -7,6 +7,7 @@ Configures edge-only services on ``PUT /v1/devices/{device_id}/config``:
 - Edge-level DNS mode (``DNSModeStatic``, ``DNSModeCloudflare``, ``DNSModeDynamic``)
 - LAN interface ``lldpEnabled``
 - LAN segment ``dhcpSubnets`` (key ``{interface}-{ipPrefix}``)
+- Edge traffic policy ``dpiApplications`` (``edge.trafficPolicy.dpiApplications``)
 
 YAML uses the ``edge_services`` list-of-single-key-dicts pattern (same as ``device_system``).
 Configure-only; DHCP subnet removal uses ``state: absent`` (``subnet: null`` in the API payload).
@@ -44,17 +45,42 @@ _ALLOWED = frozenset(
         "dns",
         "lldp",
         "dhcpSubnets",
+        "dpiApplications",
     }
 )
 _DNS_MODES = frozenset({"DNSModeStatic", "DNSModeCloudflare", "DNSModeDynamic"})
 _LWS_PASSWORD_RE = re.compile(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}$")
+_TRAFFIC_POLICY_KEYS = ("trafficPolicy", "traffic_policy")
+_DPI_PROTOCOLS = frozenset({"UnknownIPProtocol", "icmp", "tcp", "udp"})
+_DPI_APP_FIELDS = (
+    "name",
+    "description",
+    "ipProtocol",
+    "sourceNetwork",
+    "sourceNetworkList",
+    "sourcePort",
+    "sourcePortList",
+    "destinationNetwork",
+    "destinationNetworkList",
+    "destinationPort",
+    "destinationPortList",
+)
 
 
 class EdgeServicesManager(BaseManager):
-    """Manage edge DHCP, DNS, LLDP, and local web server settings via the device config API."""
+    """Manage edge DHCP, DNS, LLDP, DPI applications, and local web server settings via the device config API."""
 
     _str = staticmethod(coerce_str)
     _as_dict = staticmethod(as_dict)
+
+    @staticmethod
+    def _first_present(mapping: Dict[str, Any], keys: tuple) -> Any:
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            if key in mapping:
+                return mapping.get(key)
+        return None
 
     @classmethod
     def _dhcp_subnet_key(cls, interface: Any, ip_prefix: Any) -> str:
@@ -256,12 +282,274 @@ class EdgeServicesManager(BaseManager):
         return out
 
     @classmethod
+    def _traffic_policy_from_device(cls, d: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve ``trafficPolicy`` from unwrapped device GET (``device.edge`` or ``device``)."""
+        edge = cls._as_dict(d.get("edge"))
+        merged: Dict[str, Any] = {}
+        for container in (edge, d):
+            tp = cls._as_dict(cls._first_present(container, _TRAFFIC_POLICY_KEYS))
+            if tp:
+                merged.update(tp)
+        return merged
+
+    @classmethod
+    def _list_names_from_traffic_policy(cls, tp: Dict[str, Any], list_keys: tuple) -> frozenset:
+        raw = cls._first_present(tp, list_keys)
+        if not raw:
+            return frozenset()
+        names: set[str] = set()
+        if isinstance(raw, dict):
+            for key, entry in raw.items():
+                if not isinstance(entry, dict):
+                    continue
+                body = entry.get("list") if "list" in entry else entry
+                if isinstance(body, dict) and body.get("name"):
+                    names.add(cls._str(body.get("name")))
+                elif body is not None:
+                    names.add(cls._str(key))
+        elif isinstance(raw, list):
+            for item in raw:
+                if isinstance(item, dict) and item.get("name"):
+                    names.add(cls._str(item.get("name")))
+        return frozenset(n for n in names if n)
+
+    @classmethod
+    def _normalize_dpi_optional_str(cls, value: Any) -> Optional[str]:
+        s = cls._str(value)
+        return s if s else None
+
+    @classmethod
+    def _normalize_dpi_port(cls, value: Any) -> Optional[int]:
+        if value is None or value == "":
+            return None
+        try:
+            port = int(value)
+        except (TypeError, ValueError) as exc:
+            raise ConfigurationError(f"Invalid DPI port value {value!r}") from exc
+        # Portal GET may return 0 for unset ports on icmp/any apps; treat as unset for compare/PUT.
+        return None if port == 0 else port
+
+    @classmethod
+    def _normalize_dpi_application(cls, app: Dict[str, Any], app_key: Optional[str] = None) -> Dict[str, Any]:
+        name = cls._str(app.get("name")) or cls._str(app_key)
+        proto = cls._str(app.get("ipProtocol"))
+        out: Dict[str, Any] = {
+            "name": name,
+            "description": app.get("description"),
+            "ipProtocol": proto or None,
+            "sourceNetwork": cls._normalize_dpi_optional_str(app.get("sourceNetwork")),
+            "sourceNetworkList": cls._normalize_dpi_optional_str(app.get("sourceNetworkList")),
+            "sourcePort": cls._normalize_dpi_port(app.get("sourcePort")),
+            "sourcePortList": cls._normalize_dpi_optional_str(app.get("sourcePortList")),
+            "destinationNetwork": cls._normalize_dpi_optional_str(app.get("destinationNetwork")),
+            "destinationNetworkList": cls._normalize_dpi_optional_str(app.get("destinationNetworkList")),
+            "destinationPort": cls._normalize_dpi_port(app.get("destinationPort")),
+            "destinationPortList": cls._normalize_dpi_optional_str(app.get("destinationPortList")),
+        }
+        if out["description"] is not None and not cls._str(out["description"]):
+            out["description"] = None
+        return out
+
+    @classmethod
+    def _dpi_canonical_for_compare(cls, norm: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Compare only meaningful fields so sparse portal GET (omitted nulls) matches YAML with explicit nulls.
+        """
+        if not norm:
+            return {}
+        out: Dict[str, Any] = {}
+        for key, value in norm.items():
+            if key in ("name", "ipProtocol"):
+                if value is not None:
+                    out[key] = value
+                continue
+            if value is None:
+                continue
+            out[key] = value
+        return out
+
+    @classmethod
+    def _dpi_compare_field_keys(cls, desired_app: Dict[str, Any]) -> frozenset:
+        """Fields to compare: name/protocol always; other non-null keys present in YAML."""
+        keys: set = {"name", "ipProtocol"}
+        for field in _DPI_APP_FIELDS:
+            if field in keys:
+                continue
+            if field in desired_app and desired_app.get(field) is not None:
+                keys.add(field)
+        return frozenset(keys)
+
+    @classmethod
+    def _dpi_canonical_subset(cls, norm: Dict[str, Any], keys: frozenset) -> Dict[str, Any]:
+        canon = cls._dpi_canonical_for_compare(norm)
+        return {key: canon[key] for key in keys if key in canon}
+
+    @classmethod
+    def _dpi_applications_equal(
+        cls, before: Optional[Dict[str, Any]], desired_app: Dict[str, Any], app_key: str
+    ) -> bool:
+        norm_before = cls._normalize_dpi_application(before or {}, app_key=app_key) if before else {}
+        norm_desired = cls._normalize_dpi_application(desired_app, app_key=app_key)
+        keys = cls._dpi_compare_field_keys(desired_app)
+        before_sub = cls._dpi_canonical_subset(norm_before, keys)
+        desired_sub = cls._dpi_canonical_subset(norm_desired, keys)
+        if before_sub == desired_sub:
+            return True
+        # Portal GET often omits ipProtocol after PUT even when YAML/API used UnknownIPProtocol.
+        if norm_desired.get("ipProtocol") == "UnknownIPProtocol" and "ipProtocol" not in before_sub:
+            keys_without_proto = frozenset(key for key in keys if key != "ipProtocol")
+            return cls._dpi_canonical_subset(norm_before, keys_without_proto) == cls._dpi_canonical_subset(
+                norm_desired, keys_without_proto
+            )
+        return False
+
+    @classmethod
+    def _extract_dpi_application_from_entry(
+        cls, entry: Dict[str, Any], app_key: Optional[str] = None
+    ) -> Optional[Dict[str, Any]]:
+        """Unwrap ``application`` or flat field dict; inject map key as name when omitted."""
+        app = cls._as_dict(entry.get("application"))
+        if not app and any(k in entry for k in _DPI_APP_FIELDS):
+            app = dict(entry)
+        if not app:
+            return None
+        if app_key and not cls._str(app.get("name")):
+            app = dict(app)
+            app["name"] = app_key
+        return app
+
+    @classmethod
+    def _dpi_application_for_put(cls, app: Dict[str, Any], app_key: str) -> Dict[str, Any]:
+        """Send non-null application fields listed in YAML (partial PUT delta)."""
+        norm = cls._normalize_dpi_application(app, app_key=app_key)
+        put: Dict[str, Any] = {"name": norm["name"], "ipProtocol": norm["ipProtocol"]}
+        for field in _DPI_APP_FIELDS:
+            if field in ("name", "ipProtocol"):
+                continue
+            if field in app and norm.get(field) is not None:
+                put[field] = norm[field]
+        return put
+
+    @classmethod
+    def _dpi_snapshot_from_device(cls, d: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        """Portal GET returns ``dpiApplications`` as a map or flat list under ``trafficPolicy``."""
+        tp = cls._traffic_policy_from_device(d)
+        raw = cls._first_present(tp, ("dpiApplications", "dpi_applications"))
+        out: Dict[str, Dict[str, Any]] = {}
+        if isinstance(raw, list):
+            for entry in raw:
+                if not isinstance(entry, dict):
+                    continue
+                app_key = cls._str(entry.get("name"))
+                if not app_key:
+                    continue
+                out[app_key] = cls._normalize_dpi_application(entry, app_key=app_key)
+            return out
+        if isinstance(raw, dict):
+            for key, entry in raw.items():
+                if not isinstance(entry, dict):
+                    continue
+                app = cls._as_dict(entry.get("application")) or entry
+                app_key = cls._str(key) or cls._str(app.get("name"))
+                if app_key:
+                    out[app_key] = cls._normalize_dpi_application(app, app_key=app_key)
+        return out
+
+    @classmethod
+    def _coerce_dpi_applications_map(cls, raw: Any) -> Dict[str, Optional[Dict[str, Any]]]:
+        """
+        Normalize YAML/module input to ``{app_name: application_dict}`` or ``{app_name: None}`` for removal.
+        """
+        if raw is None:
+            return {}
+        out: Dict[str, Optional[Dict[str, Any]]] = {}
+        if isinstance(raw, list):
+            for item in raw:
+                if not isinstance(item, dict):
+                    raise ConfigurationError("Each dpiApplications list entry must be a dict.")
+                app = cls._extract_dpi_application_from_entry(item)
+                if not app:
+                    raise ConfigurationError("dpiApplications list entries require an 'application' dict.")
+                name = cls._str(app.get("name"))
+                if not name:
+                    raise ConfigurationError("dpiApplications application requires 'name'.")
+                out[name] = app
+            return out
+        if not isinstance(raw, dict):
+            raise ConfigurationError("dpiApplications must be a dict (map) or list of applications.")
+        for app_key, body in raw.items():
+            key = cls._str(app_key)
+            if not key:
+                raise ConfigurationError("dpiApplications map keys must be non-empty application names.")
+            if body is None:
+                out[key] = None
+                continue
+            if not isinstance(body, dict):
+                raise ConfigurationError(f"dpiApplications entry {key!r} must be a dict.")
+            state = cls._str(body.get("state") or "present").lower()
+            if state == "absent":
+                out[key] = None
+                continue
+            app = cls._extract_dpi_application_from_entry(body, app_key=key)
+            if not app:
+                raise ConfigurationError(
+                    f"dpiApplications entry {key!r} requires an 'application' dict or application fields."
+                )
+            out[key] = app
+        return out
+
+    @classmethod
+    def _validate_dpi_application(cls, app_key: str, app: Dict[str, Any]) -> None:
+        explicit_name = cls._str(app.get("name"))
+        if explicit_name and explicit_name != app_key:
+            raise ConfigurationError(
+                f"dpiApplications map key {app_key!r} must match application.name {explicit_name!r}."
+            )
+        norm = cls._normalize_dpi_application(app, app_key=app_key)
+        proto = norm.get("ipProtocol")
+        if proto not in _DPI_PROTOCOLS:
+            raise ConfigurationError(
+                f"dpiApplications {app_key!r}: ipProtocol must be one of {sorted(_DPI_PROTOCOLS)}."
+            )
+
+    @classmethod
+    def _validate_dpi_list_references(
+        cls,
+        device_name: str,
+        desired: Dict[str, Optional[Dict[str, Any]]],
+        current_device: Dict[str, Any],
+    ) -> None:
+        desired = cls._coerce_dpi_applications_map(desired)
+        tp = cls._traffic_policy_from_device(current_device)
+        network_lists = cls._list_names_from_traffic_policy(tp, ("networkLists", "network_lists"))
+        port_lists = cls._list_names_from_traffic_policy(tp, ("portLists", "port_lists"))
+        for app_key, app in desired.items():
+            if app is None:
+                continue
+            norm = cls._normalize_dpi_application(app, app_key=app_key)
+            for field, known, label in (
+                ("sourceNetworkList", network_lists, "networkLists"),
+                ("destinationNetworkList", network_lists, "networkLists"),
+                ("sourcePortList", port_lists, "portLists"),
+                ("destinationPortList", port_lists, "portLists"),
+            ):
+                ref = norm.get(field)
+                if ref and ref not in known:
+                    known_str = ", ".join(sorted(known)) if known else "(none on device)"
+                    raise ConfigurationError(
+                        f"Device '{device_name}': dpiApplications {app_key!r} references "
+                        f"{field}={ref!r} which is not in edge.trafficPolicy.{label}. "
+                        f"Known names: {known_str}. Configure lists first (graphiant_prefix_port_list)."
+                    )
+
+    @classmethod
     def _edge_services_snapshot(cls, d: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "localWebServerPasswordConfigured": bool(cls._str(d.get("localWebServerPassword"))),
             "dns": cls._dns_snapshot_from_device(d),
             "lldp": cls._lldp_snapshot_from_device(d),
             "dhcpSubnets": cls._dhcp_snapshot_from_device(d),
+            "dpiApplications": cls._dpi_snapshot_from_device(d),
         }
 
     @classmethod
@@ -362,6 +650,12 @@ class EdgeServicesManager(BaseManager):
             for entry in out["dhcpSubnets"]:
                 if not isinstance(entry, dict):
                     raise ConfigurationError("Each dhcpSubnets entry must be a dict.")
+        if out.get("dpiApplications") is not None:
+            desired_dpi = self._coerce_dpi_applications_map(out["dpiApplications"])
+            for app_key, app in desired_dpi.items():
+                if app is not None:
+                    self._validate_dpi_application(app_key, app)
+            out["dpiApplications"] = desired_dpi
         return out
 
     @staticmethod
@@ -381,6 +675,10 @@ class EdgeServicesManager(BaseManager):
                 merged_dns = dict(merged["dns"])
                 merged_dns.update(v)
                 merged["dns"] = merged_dns
+            elif k == "dpiApplications" and isinstance(merged.get("dpiApplications"), dict) and isinstance(v, dict):
+                merged_dpi = dict(merged["dpiApplications"])
+                merged_dpi.update(v)
+                merged["dpiApplications"] = merged_dpi
             else:
                 merged[k] = v
         return merged
@@ -417,6 +715,7 @@ class EdgeServicesManager(BaseManager):
             "dns": dict(before.get("dns") or {}),
             "lldp": dict(before.get("lldp") or {}),
             "dhcpSubnets": dict(before.get("dhcpSubnets") or {}),
+            "dpiApplications": dict(before.get("dpiApplications") or {}),
         }
         if cfg.get("localWebServerPassword") is not None:
             after["localWebServerPasswordConfigured"] = True
@@ -439,6 +738,15 @@ class EdgeServicesManager(BaseManager):
             merged = dict(after["dhcpSubnets"].get(key) or {})
             merged.update(subnet)
             after["dhcpSubnets"][key] = merged
+        desired_dpi = cfg.get("dpiApplications")
+        if isinstance(desired_dpi, dict):
+            merged_dpi = dict(after["dpiApplications"])
+            for app_key, app in desired_dpi.items():
+                if app is None:
+                    merged_dpi.pop(app_key, None)
+                else:
+                    merged_dpi[app_key] = self._normalize_dpi_application(app, app_key=app_key)
+            after["dpiApplications"] = merged_dpi
         return after
 
     @classmethod
@@ -568,6 +876,24 @@ class EdgeServicesManager(BaseManager):
             if dhcp_delta:
                 edge.update(self._build_dhcp_put(dhcp_delta))
 
+        if cfg.get("dpiApplications"):
+            desired_dpi = self._coerce_dpi_applications_map(cfg["dpiApplications"])
+            self._validate_dpi_list_references(device_name, desired_dpi, current_device)
+            before_dpi = self._dpi_snapshot_from_device(current_device)
+            dpi_delta: Dict[str, Any] = {}
+            for app_key, app in desired_dpi.items():
+                if app is None:
+                    if app_key in before_dpi:
+                        dpi_delta[app_key] = {"application": None}
+                    continue
+                if not self._dpi_applications_equal(before_dpi.get(app_key), app, app_key):
+                    dpi_delta[app_key] = {"application": self._dpi_application_for_put(app, app_key)}
+            if dpi_delta:
+                if edge.get("trafficPolicy"):
+                    edge["trafficPolicy"]["dpiApplications"] = dpi_delta
+                else:
+                    edge["trafficPolicy"] = {"dpiApplications": dpi_delta}
+
         return edge
 
     def _inject_vault_lws_passwords(
@@ -631,8 +957,7 @@ class EdgeServicesManager(BaseManager):
                 result["skipped_devices"].append(device_name)
                 continue
 
-            payload = {"edge": edge_payload}
-            to_push[device_id] = {"device_id": device_id, "payload": payload}
+            to_push[device_id] = {"device_id": device_id, "payload": {"edge": edge_payload}}
             configured.append(device_name)
             diff_plan.append({"device": device_name, "branch": "edge", "before": before, "after": after})
 
@@ -665,5 +990,6 @@ class EdgeServicesManager(BaseManager):
     def deconfigure(self, config_yaml_file: str) -> dict:
         raise ConfigurationError(
             "Deconfigure is not supported for edge services. "
-            "Use configure with desired values, or dhcpSubnets state: absent to remove a subnet."
+            "Use configure with desired values, dhcpSubnets state: absent to remove a subnet, "
+            "or dpiApplications state: absent (application: null) to remove a DPI application."
         )

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
@@ -20,6 +20,7 @@ from .ntp_manager import NtpManager
 from .traffic_policy_manager import TrafficPolicyManager
 from .device_system_manager import DeviceSystemManager
 from .edge_services_manager import EdgeServicesManager
+from .prefix_and_port_list import PrefixAndPortListManager
 from .macsec_manager import MacsecManager
 from .logger import setup_logger
 from .exceptions import GraphiantPlaybookError
@@ -90,6 +91,7 @@ class GraphiantConfig:
             self.traffic_policy = TrafficPolicyManager(self.config_utils)
             self.device_system = DeviceSystemManager(self.config_utils)
             self.edge_services = EdgeServicesManager(self.config_utils)
+            self.prefix_port_list = PrefixAndPortListManager(self.config_utils)
             self.macsec = MacsecManager(self.config_utils)
 
             LOG.info("GraphiantConfig class initialized successfully with all managers")
@@ -122,5 +124,6 @@ class GraphiantConfig:
             "traffic_policy": hasattr(self, "traffic_policy") and self.traffic_policy is not None,
             "device_system": hasattr(self, "device_system") and self.device_system is not None,
             "edge_services": hasattr(self, "edge_services") and self.edge_services is not None,
+            "prefix_port_list": hasattr(self, "prefix_port_list") and self.prefix_port_list is not None,
             "macsec": hasattr(self, "macsec") and self.macsec is not None,
         }

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/prefix_and_port_list.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/prefix_and_port_list.py
@@ -1,0 +1,509 @@
+"""
+Prefix and Port List Manager for Graphiant Playbooks.
+
+Prefix and port lists are configured under:
+  edge.trafficPolicy.networkLists
+  edge.trafficPolicy.portLists
+
+Idempotency: create operations compare intended lists to current device state and skip
+push when already matched.
+
+Delete sets ``list: null`` per listed object (API nullable wrapper shape).
+
+Per-list ``state: absent`` on create operations (``create_*``) also sends ``list: null`` for that
+name only, so one YAML can mix present and absent entries.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
+
+from .base_manager import BaseManager
+from .device_config_common import (
+    as_dict,
+    fetch_device_by_name,
+    new_apply_result,
+    push_device_config_raw,
+    unwrap_device,
+)
+from .exceptions import ConfigurationError
+from .logger import setup_logger
+
+LOG = setup_logger()
+
+_LOG_PREFIX = "[prefix-port-list]"
+_TRAFFIC_POLICY_KEYS = ("trafficPolicy", "traffic_policy")
+_NETWORK_LISTS_KEYS = ("networkLists", "network_lists")
+_PORT_LISTS_KEYS = ("portLists", "port_lists")
+_LIST_KINDS = frozenset({"both", "network", "port"})
+
+
+class PrefixAndPortListManager(BaseManager):
+    """Manage device-level network and L4 port lists via raw device-config payloads."""
+
+    @classmethod
+    def _device_dict(cls, device_info_dict: Any) -> Dict[str, Any]:
+        return unwrap_device(as_dict(device_info_dict))
+
+    @staticmethod
+    def _first_present(mapping: Dict[str, Any], keys: Tuple[str, ...]) -> Any:
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            if key in mapping:
+                return mapping.get(key)
+        return None
+
+    @staticmethod
+    def _validate_device_cfg(device_name: str, cfg: Any) -> Any:
+        if cfg is None:
+            return []
+        if isinstance(cfg, (list, dict)):
+            return cfg
+        raise ConfigurationError(f"Device '{device_name}' config must be a list or dict of list objects")
+
+    def _load_section(self, config_yaml_file: str, yaml_key: str) -> Dict[str, Any]:
+        """
+        Load ``{yaml_key: [{device_name: list_objects}, ...]}``.
+
+        Device values are usually a list of prefix/port list dicts. The shared
+        ``load_device_list_yaml_config`` helper only keeps dict-shaped device rows,
+        so load this section directly.
+        """
+        cfg = self.render_config_file(config_yaml_file) or {}
+        raw = cfg.get(yaml_key)
+        by_name: Dict[str, Any] = {}
+        if raw is None:
+            return by_name
+        if not isinstance(raw, list):
+            raise ConfigurationError(f"'{yaml_key}' must be a list of device entries")
+        for entry in raw:
+            if not isinstance(entry, dict) or not entry:
+                raise ConfigurationError(
+                    f"Each entry in '{yaml_key}' must be a non-empty dict keyed by portal device name"
+                )
+            for device_name, device_cfg in entry.items():
+                by_name[device_name] = self._validate_device_cfg(device_name, device_cfg)
+        return by_name
+
+    @staticmethod
+    def _merge_partial_list_items(raw: List[Any]) -> List[Dict[str, Any]]:
+        """
+        Support YAML where a device entry is a list of partial dicts, e.g.::
+
+            - name: demo_prefix_list_1
+            - networks: [1.1.1.1/32]
+        """
+        merged: Dict[str, Any] = {}
+        items: List[Dict[str, Any]] = []
+        for part in raw:
+            if not isinstance(part, dict):
+                raise ConfigurationError("Each list entry must be a dict")
+            if len(part) == 1 and "name" in part and len(merged) == 1 and "name" in merged:
+                items.append(merged)
+                merged = dict(part)
+                continue
+            if set(part.keys()).issubset({"name"}) and len(part) == 1:
+                if merged:
+                    items.append(merged)
+                merged = dict(part)
+                continue
+            merged.update(part)
+        if merged:
+            items.append(merged)
+        return items
+
+    @classmethod
+    def _normalize_list_items(cls, raw: Any, *, value_field: str) -> List[Dict[str, Any]]:
+        if raw is None:
+            return []
+        if isinstance(raw, dict):
+            if raw.get("name") is not None or raw.get(value_field) is not None:
+                return [dict(raw)]
+            out: List[Dict[str, Any]] = []
+            for name, body in raw.items():
+                entry = {"name": str(name).strip()}
+                if isinstance(body, dict):
+                    entry.update(body)
+                elif body is not None:
+                    entry[value_field] = body
+                out.append(entry)
+            return out
+        if isinstance(raw, list):
+            if not raw:
+                return []
+            if all(isinstance(x, dict) and ("name" in x or value_field in x) for x in raw):
+                if any(len(x) == 1 for x in raw):
+                    return cls._merge_partial_list_items(raw)
+                return [dict(x) for x in raw]
+            raise ConfigurationError("List entries must be dicts with 'name' and/or list values")
+        raise ConfigurationError("List config must be a list or dict")
+
+    @staticmethod
+    def _item_state(item: Dict[str, Any]) -> str:
+        raw = item.get("state")
+        if raw is None:
+            return "present"
+        return str(raw).strip().lower()
+
+    @classmethod
+    def _item_is_absent(cls, item: Dict[str, Any]) -> bool:
+        return cls._item_state(item) == "absent"
+
+    @staticmethod
+    def _norm_networks(networks: Any) -> List[str]:
+        if networks is None:
+            return []
+        if not isinstance(networks, list):
+            raise ConfigurationError("'networks' must be a list of prefix strings")
+        out: List[str] = []
+        for net in networks:
+            if net is None:
+                continue
+            s = str(net).strip()
+            if s:
+                out.append(s)
+        return sorted(out)
+
+    @staticmethod
+    def _norm_ports(ports: Any) -> List[int]:
+        if ports is None:
+            return []
+        if not isinstance(ports, list):
+            raise ConfigurationError("'ports' must be a list of integers")
+        out: List[int] = []
+        for port in ports:
+            if port is None:
+                continue
+            try:
+                out.append(int(port))
+            except (TypeError, ValueError) as exc:
+                raise ConfigurationError(f"Invalid port value {port!r}") from exc
+        return sorted(out)
+
+    @classmethod
+    def _network_lists_from_yaml(cls, items: List[Dict[str, Any]], operation: str) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for item in items:
+            name = item.get("name")
+            if not name:
+                raise ConfigurationError("Network list missing 'name'")
+            key = str(name).strip()
+            if not key:
+                raise ConfigurationError("Network list 'name' must be non-empty")
+            if operation == "delete" or cls._item_is_absent(item):
+                out[key] = {"list": None}
+                continue
+            networks = cls._norm_networks(item.get("networks"))
+            out[key] = {"list": {"name": key, "networks": networks}}
+        return out
+
+    @classmethod
+    def _port_lists_from_yaml(cls, items: List[Dict[str, Any]], operation: str) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        for item in items:
+            name = item.get("name")
+            if not name:
+                raise ConfigurationError("Port list missing 'name'")
+            key = str(name).strip()
+            if not key:
+                raise ConfigurationError("Port list 'name' must be non-empty")
+            if operation == "delete" or cls._item_is_absent(item):
+                out[key] = {"list": None}
+                continue
+            ports = cls._norm_ports(item.get("ports"))
+            out[key] = {"list": {"name": key, "ports": ports}}
+        return out
+
+    @classmethod
+    def _coerce_lists_map(cls, lists: Any, *, value_field: str) -> Dict[str, Any]:
+        if not lists:
+            return {}
+        if isinstance(lists, dict):
+            out: Dict[str, Any] = {}
+            for key, entry in lists.items():
+                if not isinstance(entry, dict):
+                    continue
+                body = entry.get("list") if "list" in entry else entry
+                name = None
+                if isinstance(body, dict):
+                    name = body.get("name") or key
+                elif body is None:
+                    name = key
+                if name:
+                    out[str(name).strip()] = entry
+            return out
+        if isinstance(lists, list):
+            out = {}
+            for item in lists:
+                if not isinstance(item, dict):
+                    continue
+                name = item.get("name")
+                if name:
+                    out[str(name).strip()] = {"list": item}
+            return out
+        return {}
+
+    def _extract_lists_from_device(self, device_info_dict: Any, list_keys: Tuple[str, ...]) -> Dict[str, Any]:
+        d = self._device_dict(device_info_dict)
+        edge = as_dict(d.get("edge"))
+        for container in (edge, d):
+            tp = as_dict(self._first_present(container, _TRAFFIC_POLICY_KEYS))
+            raw = self._first_present(tp, list_keys)
+            if raw is not None:
+                value_field = "networks" if list_keys == _NETWORK_LISTS_KEYS else "ports"
+                return self._coerce_lists_map(raw, value_field=value_field)
+        return {}
+
+    @staticmethod
+    def _existing_list_body(entry: Any) -> Any:
+        if not isinstance(entry, dict):
+            return None
+        if "list" in entry:
+            return entry.get("list")
+        if any(k in entry for k in ("name", "networks", "ports")):
+            return entry
+        return None
+
+    @classmethod
+    def _normalized_network_list(cls, body: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(body, dict):
+            return None
+        name = body.get("name")
+        if not name:
+            return None
+        return {"name": str(name).strip(), "networks": cls._norm_networks(body.get("networks"))}
+
+    @classmethod
+    def _normalized_port_list(cls, body: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(body, dict):
+            return None
+        name = body.get("name")
+        if not name:
+            return None
+        return {"name": str(name).strip(), "ports": cls._norm_ports(body.get("ports"))}
+
+    def _network_lists_need_update(self, desired: Dict[str, Any], device_info_dict: Any) -> bool:
+        existing = self._extract_lists_from_device(device_info_dict, _NETWORK_LISTS_KEYS)
+        for key, desired_entry in desired.items():
+            desired_body = self._existing_list_body(desired_entry)
+            existing_entry = existing.get(key) if isinstance(existing, dict) else None
+            existing_body = self._existing_list_body(existing_entry)
+
+            if desired_body is None:
+                if existing_body is not None:
+                    return True
+                continue
+
+            desired_norm = self._normalized_network_list(desired_body)
+            existing_norm = self._normalized_network_list(existing_body)
+            if desired_norm != existing_norm:
+                return True
+        return False
+
+    def _port_lists_need_update(self, desired: Dict[str, Any], device_info_dict: Any) -> bool:
+        existing = self._extract_lists_from_device(device_info_dict, _PORT_LISTS_KEYS)
+        for key, desired_entry in desired.items():
+            desired_body = self._existing_list_body(desired_entry)
+            existing_entry = existing.get(key) if isinstance(existing, dict) else None
+            existing_body = self._existing_list_body(existing_entry)
+
+            if desired_body is None:
+                if existing_body is not None:
+                    return True
+                continue
+
+            desired_norm = self._normalized_port_list(desired_body)
+            existing_norm = self._normalized_port_list(existing_body)
+            if desired_norm != existing_norm:
+                return True
+        return False
+
+    @classmethod
+    def _snapshot_normalized_list_entry(cls, entry: Any, *, list_type: str) -> Optional[Dict[str, Any]]:
+        body = cls._existing_list_body(entry)
+        if body is None:
+            return None
+        if list_type == "network":
+            return cls._normalized_network_list(body)
+        return cls._normalized_port_list(body)
+
+    def _traffic_policy_lists_diff(
+        self, device_dict: Dict[str, Any], payload: Dict[str, Any]
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """Build before/after snapshots for lists touched by this payload (for ``diff_plan`` / ``--diff``)."""
+        desired_tp = as_dict(as_dict(payload.get("edge")).get("trafficPolicy"))
+        before: Dict[str, Any] = {}
+        after: Dict[str, Any] = {}
+
+        desired_nl = desired_tp.get("networkLists")
+        if isinstance(desired_nl, dict) and desired_nl:
+            existing = self._extract_lists_from_device({"device": device_dict}, _NETWORK_LISTS_KEYS)
+            before_nl: Dict[str, Any] = {}
+            after_nl: Dict[str, Any] = {}
+            for key in sorted(desired_nl.keys()):
+                existing_entry = existing.get(key) if isinstance(existing, dict) else None
+                before_nl[key] = self._snapshot_normalized_list_entry(existing_entry, list_type="network")
+                after_nl[key] = self._snapshot_normalized_list_entry(desired_nl[key], list_type="network")
+            before["networkLists"] = before_nl
+            after["networkLists"] = after_nl
+
+        desired_pl = desired_tp.get("portLists")
+        if isinstance(desired_pl, dict) and desired_pl:
+            existing = self._extract_lists_from_device({"device": device_dict}, _PORT_LISTS_KEYS)
+            before_pl: Dict[str, Any] = {}
+            after_pl: Dict[str, Any] = {}
+            for key in sorted(desired_pl.keys()):
+                existing_entry = existing.get(key) if isinstance(existing, dict) else None
+                before_pl[key] = self._snapshot_normalized_list_entry(existing_entry, list_type="port")
+                after_pl[key] = self._snapshot_normalized_list_entry(desired_pl[key], list_type="port")
+            before["portLists"] = before_pl
+            after["portLists"] = after_pl
+
+        return before, after
+
+    def _payload_differs(self, desired_payload: Dict[str, Any], device_info_dict: Any) -> bool:
+        desired_tp = as_dict((desired_payload or {}).get("edge")).get("trafficPolicy") or {}
+        if not isinstance(desired_tp, dict):
+            desired_tp = {}
+
+        desired_nl = desired_tp.get("networkLists")
+        if isinstance(desired_nl, dict) and desired_nl:
+            if self._network_lists_need_update(desired_nl, device_info_dict):
+                return True
+
+        desired_pl = desired_tp.get("portLists")
+        if isinstance(desired_pl, dict) and desired_pl:
+            if self._port_lists_need_update(desired_pl, device_info_dict):
+                return True
+
+        return False
+
+    def _device_names_for_kind(self, config_yaml_file: str, list_kind: str) -> Set[str]:
+        names: Set[str] = set()
+        if list_kind in ("both", "network"):
+            names.update(self._load_section(config_yaml_file, "networkLists").keys())
+        if list_kind in ("both", "port"):
+            names.update(self._load_section(config_yaml_file, "portLists").keys())
+        return names
+
+    def _build_device_payload(
+        self,
+        device_name: str,
+        config_yaml_file: str,
+        operation: str,
+        list_kind: str,
+    ) -> Optional[Dict[str, Any]]:
+        traffic_policy: Dict[str, Any] = {}
+
+        if list_kind in ("both", "network"):
+            network_cfg = self._load_section(config_yaml_file, "networkLists").get(device_name)
+            if network_cfg is not None:
+                items = self._normalize_list_items(network_cfg, value_field="networks")
+                network_map = self._network_lists_from_yaml(items, operation=operation)
+                if network_map:
+                    traffic_policy["networkLists"] = network_map
+
+        if list_kind in ("both", "port"):
+            port_cfg = self._load_section(config_yaml_file, "portLists").get(device_name)
+            if port_cfg is not None:
+                items = self._normalize_list_items(port_cfg, value_field="ports")
+                port_map = self._port_lists_from_yaml(items, operation=operation)
+                if port_map:
+                    traffic_policy["portLists"] = port_map
+
+        if not traffic_policy:
+            return None
+        return {"edge": {"trafficPolicy": traffic_policy}}
+
+    def _iter_device_payloads(
+        self,
+        config_yaml_file: str,
+        operation: str,
+        list_kind: str,
+    ) -> Iterator[Tuple[int, str, Dict[str, Any], Dict[str, Any]]]:
+        if operation not in ("create", "delete"):
+            raise ConfigurationError(f"Unsupported operation '{operation}'")
+        if list_kind not in _LIST_KINDS:
+            raise ConfigurationError(f"Unsupported list_kind '{list_kind}'")
+
+        device_names = self._device_names_for_kind(config_yaml_file, list_kind)
+        if not device_names:
+            LOG.info("%s No devices to process in %s", _LOG_PREFIX, config_yaml_file)
+            return
+
+        enterprise = self.gsdk.enterprise_info["company_name"]
+        for device_name in sorted(device_names):
+            payload = self._build_device_payload(device_name, config_yaml_file, operation, list_kind)
+            if not payload:
+                LOG.info("%s No list entries for %s, skipping", _LOG_PREFIX, device_name)
+                continue
+            device_id, device_dict = fetch_device_by_name(self.gsdk, device_name, enterprise)
+            yield device_id, device_name, payload, device_dict
+
+    def apply_lists(self, config_yaml_file: str, operation: str, *, list_kind: str = "both") -> dict:
+        result = new_apply_result()
+        to_push: Dict[int, Dict[str, Any]] = {}
+        configured_devices: List[str] = []
+        diff_plan: List[Dict[str, Any]] = []
+
+        for device_id, device_name, payload, device_dict in self._iter_device_payloads(
+            config_yaml_file,
+            operation=operation,
+            list_kind=list_kind,
+        ):
+            if not self._payload_differs(payload, {"device": device_dict}):
+                LOG.info("%s ✓ No changes needed for %s (ID: %s), skipping", _LOG_PREFIX, device_name, device_id)
+                result["skipped_devices"].append(device_name)
+                continue
+
+            before_tp, after_tp = self._traffic_policy_lists_diff(device_dict, payload)
+            to_push[device_id] = {"device_id": device_id, "payload": payload}
+            configured_devices.append(device_name)
+            diff_plan.append(
+                {
+                    "device": device_name,
+                    "branch": "edge.trafficPolicy",
+                    "before": before_tp,
+                    "after": after_tp,
+                }
+            )
+
+        result["diff_plan"] = diff_plan
+        if not to_push:
+            return result
+
+        push_device_config_raw(
+            self.execute_concurrent_tasks,
+            self.gsdk.put_device_config_raw,
+            to_push,
+            log_prefix=_LOG_PREFIX,
+        )
+
+        result["changed"] = True
+        result["configured_devices"] = configured_devices
+        return result
+
+    def create_prefix_port_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="create", list_kind="both")
+
+    def delete_prefix_port_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="delete", list_kind="both")
+
+    def create_prefix_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="create", list_kind="network")
+
+    def delete_prefix_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="delete", list_kind="network")
+
+    def create_port_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="create", list_kind="port")
+
+    def delete_port_lists(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="delete", list_kind="port")
+
+    def configure(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="create", list_kind="both")
+
+    def deconfigure(self, config_yaml_file: str) -> dict:
+        return self.apply_lists(config_yaml_file, operation="delete", list_kind="both")

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_edge_services.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_edge_services.py
@@ -11,13 +11,14 @@ Ansible module for Graphiant edge services (DHCP, DNS, LLDP, local web server pa
 DOCUMENTATION = r"""
 ---
 module: graphiant_edge_services
-short_description: Configure edge services (DHCP, DNS, LLDP, LWS password)
+short_description: Configure edge services (DHCP, DNS, LLDP, DPI, LWS password)
 description:
   - >-
     Configures Edge Services on the Edge/Gateway devices
     C(PUT /v1/devices/{device_id}/config): LAN segment C(dhcpSubnets), device
-    C(localWebServerPassword), LAN interface C(lldpEnabled), and edge C(dns) mode
-    (C(DNSModeStatic), C(DNSModeCloudflare), or C(DNSModeDynamic)).
+    C(localWebServerPassword), LAN interface C(lldpEnabled), edge C(dns) mode
+    (C(DNSModeStatic), C(DNSModeCloudflare), or C(DNSModeDynamic)), and edge
+    C(trafficPolicy.dpiApplications).
   - >-
     Edge/Gateway only; core devices are rejected. Complements M(graphiant.naas.graphiant_global_config)
     (syslog, IPFIX, SNMP) and M(graphiant.naas.graphiant_ntp) (NTP). For unstructured payloads,
@@ -46,8 +47,19 @@ description:
     C(include_vars).
   - Idempotent merge for DNS mode, LLDP, and DHCP fields. Configure-only (no deconfigure operation).
   - >-
-    Module parameters use camelCase names aligned with the API (C(dhcpSubnets), C(localWebServerPassword),
-    C(localWebServerPasswordForce)). Legacy snake_case aliases (C(dhcp_subnets), etc.) are still accepted.
+    Module parameters use camelCase names aligned with the API (C(dhcpSubnets), C(dpiApplications),
+    C(localWebServerPassword), C(localWebServerPasswordForce)). Legacy snake_case aliases
+    (C(dhcp_subnets), C(dpi_applications), etc.) are still accepted.
+  - >-
+    DPI applications are pushed under C(edge.trafficPolicy.dpiApplications) as a map keyed by application
+    name. The map key is used as C(application.name) in the PUT payload when C(name) is omitted in YAML.
+    Each value wraps C(application) fields (C(ipProtocol), networks, ports, and optional references
+    to C(sourceNetworkList), C(destinationNetworkList), C(sourcePortList), C(destinationPortList) names
+    defined under C(edge.trafficPolicy) via M(graphiant.naas.graphiant_prefix_port_list)). Use
+    C(state: absent) on a map entry to remove an application (sends C(application: null)).
+    Idempotency compares non-null fields present in YAML; omitted keys and explicit C(null) are
+    ignored (the portal does not clear nested match fields via null). Portal-only fields such as
+    C(description) are ignored unless set in YAML.
 notes:
   - "Configuration files support Jinja2 templating syntax for dynamic value substitution."
   - >-
@@ -119,13 +131,31 @@ options:
     required: false
     aliases:
       - dhcp_subnets
+  dpiApplications:
+    description:
+      - >-
+        Map of DPI application name to C(application) settings
+        (API C(edge.trafficPolicy.dpiApplications)).
+      - >-
+        The map key is the application name in the API; C(application.name) in YAML is optional and
+        defaults to the key. If set, it must match the key. C(ipProtocol) (C(any), C(icmp), C(tcp), or C(udp))
+        and optional network/port fields or list name references are required per app.
+      - >-
+        Use C(state: absent) on an entry to remove an application. Legacy list-of-C(application) YAML is
+        also accepted and normalized to this map shape.
+    type: dict
+    required: false
+    aliases:
+      - dpi_applications
   vault_devices_lws_password:
     description:
-      - Map of portal device hostname to local web server password (from Ansible Vault via
+      - >-
+        Map of portal device hostname to local web server password (from Ansible Vault via
         C(include_vars)). Keys must match device names in C(edge_services_config_file) or C(device).
         Injected as C(localWebServerPassword) before apply when YAML does not already set
         C(localWebServerPassword) for that device. YAML may set C(localWebServerPasswordForce).
-      - Do not reference Ansible/playbook variables inside the config file; pass this dict as this
+      - >-
+        Do not reference Ansible/playbook variables inside the config file; pass this dict as this
         module parameter after C(include_vars). Self-contained Jinja2 in the config file is supported.
     type: dict
     required: false
@@ -306,6 +336,7 @@ _SERVICE_PARAM_KEYS = (
     "dns",
     "lldp",
     "dhcpSubnets",
+    "dpiApplications",
 )
 
 
@@ -347,6 +378,8 @@ def _module_params_from_ansible(params: Dict[str, Any]) -> Dict[str, Any]:
         mp["lldp"] = params["lldp"]
     if params.get("dhcpSubnets") is not None:
         mp["dhcpSubnets"] = params["dhcpSubnets"]
+    if params.get("dpiApplications") is not None:
+        mp["dpiApplications"] = params["dpiApplications"]
     return mp
 
 
@@ -368,6 +401,7 @@ def main():
         dns=dict(type="dict", required=False, default=None),
         lldp=dict(type="dict", required=False, default=None),
         dhcpSubnets=dict(type="list", required=False, default=None, elements="dict", aliases=["dhcp_subnets"]),
+        dpiApplications=dict(type="dict", required=False, default=None, aliases=["dpi_applications"]),
         vault_devices_lws_password=dict(type="dict", required=False, default={}, no_log=True),
         operation=dict(type="str", required=False, default="configure", choices=["configure"]),
         state=dict(type="str", required=False, default="present", choices=["present"]),
@@ -404,8 +438,8 @@ def main():
             module.fail_json(
                 msg=(
                     "When edge_services_config_file is omitted, at least one of localWebServerPassword, "
-                    "dns, lldp, or dhcpSubnets is required, or vault_devices_lws_password must include "
-                    "the target device."
+                    "dns, lldp, dhcpSubnets, or dpiApplications is required, or vault_devices_lws_password "
+                    "must include the target device."
                 ),
                 operation=operation,
             )

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_prefix_port_list.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_prefix_port_list.py
@@ -1,0 +1,463 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Graphiant Team <support@graphiant.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Ansible module for managing Graphiant prefix and port lists under:
+  edge.trafficPolicy.networkLists
+  edge.trafficPolicy.portLists
+"""
+
+DOCUMENTATION = r"""
+---
+module: graphiant_prefix_port_list
+short_description: >-
+  Manage Graphiant prefix and port lists (edge.trafficPolicy.networkLists,
+  edge.trafficPolicy.portLists)
+description:
+  - >-
+    Create or delete prefix and port lists under edge traffic policy
+    (edge.trafficPolicy.networkLists, edge.trafficPolicy.portLists).
+  - Reads a structured YAML config file and builds the raw device-config payload in Python.
+  - All operations are idempotent and safe to run multiple times.
+notes:
+  - "Prefix and Port List Operations:"
+  - "  - Create_prefix_port_lists: Create prefix and port lists listed in the config."
+  - "  - Delete_prefix_port_lists: Delete prefix and port lists listed in the config."
+  - "  - Create_prefix_lists: Create prefix lists listed in the config."
+  - "  - Delete_prefix_lists: Delete prefix lists listed in the config."
+  - "  - Create_port_lists: Create port lists listed in the config."
+  - "  - Delete_port_lists: Delete port lists listed in the config."
+  - "Configuration files support Jinja2 templating syntax for dynamic configuration generation."
+  - "The module automatically resolves device names to IDs."
+  - "YAML schema uses CamelCase keys (for example: C(networkLists), C(portLists))."
+  - >-
+    Create idempotency: compares intended prefix and port lists to existing device state;
+    skips push when already matched (V(changed)=V(false)).
+  - >-
+    On C(create_*) operations, each list entry may use C(state: absent) to remove that name only
+    (sends C(list: null)) while other entries in the same file are created or updated. Default is
+    C(state: present).
+  - "Delete deletes only the prefix and port lists listed in the YAML."
+  - >-
+    Delete payload uses C(networkLists: null) and C(portLists: null); this module preserves nulls in the final
+    payload pushed to the API.
+  - >-
+    With C(ansible-playbook --check), writes are skipped but C(changed) reflects whether an apply would update
+    at least one device. Use C(--diff) to preview C(details.diff_plan) and Ansible C(diff).
+version_added: "26.2.0"
+extends_documentation_fragment:
+  - graphiant.naas.graphiant_portal_auth
+options:
+  prefix_port_list_config_file:
+    description:
+      - Path to the prefix and port list YAML file.
+      - Can be an absolute path or relative to the configured config_path.
+      - Expected top-level key is C(networkLists) and C(portLists) (list of devices).
+    type: str
+    required: true
+  operation:
+    description:
+      - Specific operation to perform.
+      - C(create_prefix_port_lists) builds full prefix and port list objects.
+      - >-
+        C(delete_prefix_port_lists) deletes listed prefix and port lists by setting
+        networkLists=null and portLists=null.
+      - C(create_prefix_lists) builds full prefix list objects.
+      - C(delete_prefix_lists) deletes listed prefix lists by setting networkLists=null.
+      - C(create_port_lists) builds full port list objects.
+      - C(delete_port_lists) deletes listed port lists by setting portLists=null.
+    type: str
+    required: false
+    choices:
+      - create_prefix_port_lists
+      - delete_prefix_port_lists
+      - create_prefix_lists
+      - delete_prefix_lists
+      - create_port_lists
+      - delete_port_lists
+  state:
+    description:
+      - Desired state for prefix and port lists.
+      - >-
+        C(present) maps to C(create_prefix_port_lists); C(absent) maps to C(delete_prefix_port_lists),
+        C(create_prefix_lists), C(delete_prefix_lists), C(create_port_lists), C(delete_port_lists) if
+        operation not set.
+    type: str
+    required: false
+    default: present
+    choices: [ present, absent ]
+  detailed_logs:
+    description:
+      - Enable detailed logging.
+    type: bool
+    default: false
+attributes:
+  check_mode:
+    description: Supports check mode.
+    support: full
+    details: >
+      In check mode, no configuration is pushed to devices, but the module still reads current
+      device state to determine whether changes would be made. Payloads that would be pushed are
+      logged with a C([check_mode]) prefix.
+  diff_mode:
+    description: Supports Ansible's C(--diff) for pending traffic policy list updates.
+    support: full
+    details: >
+      When the playbook runs with C(--diff) and a device would change, the module returns a C(diff)
+      dictionary (C(before) / C(after) strings). Structured entries are also in C(details.diff_plan).
+
+requirements:
+  - python >= 3.7
+  - graphiant-sdk >= 26.4.0
+
+author:
+  - Graphiant Team (@graphiant)
+"""
+
+EXAMPLES = r"""
+- name: Configure prefix and port lists
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: create_prefix_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: present
+  register: create_prefix_port_lists_result
+  no_log: true
+
+- name: Display result message (includes detailed logs)
+  ansible.builtin.debug:
+    msg: "{{ prefix_port_list_result.msg }}"
+
+- name: Deconfigure prefix and port lists (deletes only prefixes and port lists listed in YAML)
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: delete_prefix_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: absent
+  register: delete_prefix_port_lists_result
+  no_log: true
+
+- name: Create prefix lists
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: create_prefix_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: present
+  register: create_prefix_lists_result
+  no_log: true
+
+- name: Display create prefix lists result message (includes detailed logs)
+  ansible.builtin.debug:
+    msg: "{{ create_prefix_lists_result.msg }}"
+  no_log: true
+
+- name: Delete prefix lists
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: delete_prefix_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: absent
+  register: delete_prefix_lists_result
+  no_log: true
+
+- name: Display delete prefix lists result message (includes detailed logs)
+  ansible.builtin.debug:
+    msg: "{{ delete_prefix_lists_result.msg }}"
+  no_log: true
+
+- name: Create port lists
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: create_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: present
+  register: create_port_lists_result
+  no_log: true
+
+- name: Display create port lists result message (includes detailed logs)
+  ansible.builtin.debug:
+    msg: "{{ create_port_lists_result.msg }}"
+  no_log: true
+
+- name: Delete port lists
+  graphiant.naas.graphiant_prefix_port_list:
+    operation: delete_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: absent
+  register: delete_port_lists_result
+  no_log: true
+
+- name: Display delete port lists result message (includes detailed logs)
+  ansible.builtin.debug:
+    msg: "{{ delete_port_lists_result.msg }}"
+  no_log: true
+"""
+
+RETURN = r"""
+msg:
+  description:
+    - Result message from the operation, including detailed logs when O(detailed_logs) is enabled.
+  type: str
+  returned: always
+  sample: "Prefix and port lists already match desired state; no changes needed"
+changed:
+  description:
+    - Whether the operation made changes.
+    - V(true) when config would be pushed to at least one device; V(false) when intended state already matched.
+    - In check mode (C(--check)), no configuration is pushed, but V(changed) reflects whether changes would be made.
+  type: bool
+  returned: always
+  sample: false
+operation:
+  description: The operation performed.
+  type: str
+  returned: always
+  sample: "create_prefix_port_lists"
+prefix_port_list_config_file:
+  description: The prefix and port list config file used for the operation.
+  type: str
+  returned: always
+  sample: "sample_prefix_and_port_list.yaml"
+configured_devices:
+  description: Device names where configuration was pushed (when changed=true).
+  type: list
+  elements: str
+  returned: when supported
+  sample: ["edge-1-sdktest"]
+skipped_devices:
+  description: Device names that were skipped because desired state already matched.
+  type: list
+  elements: str
+  returned: when supported
+  sample: ["edge-1-sdktest"]
+details:
+  description: Raw manager result details (includes C(diff_plan), configured/skipped device lists).
+  type: dict
+  returned: when supported
+diff:
+  description: Ansible diff output when the playbook runs with C(--diff) and at least one device would change.
+  type: dict
+  returned: when diff mode is enabled and C(details.diff_plan) is non-empty
+"""
+
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ansible_collections.graphiant.naas.plugins.module_utils.graphiant_utils import (  # noqa: E402
+    ansible_module_log,
+    graphiant_portal_auth_argument_spec,
+    get_graphiant_connection,
+    handle_graphiant_exception,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.device_config_common import (  # noqa: E402
+    ansible_diff_from_plan,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.logging_decorator import (  # noqa: E402
+    capture_library_logs,
+)
+
+
+@capture_library_logs
+def execute_with_logging(module, func, *args, **kwargs):
+    success_msg = kwargs.pop("success_msg", "Operation completed successfully")
+    no_change_msg = kwargs.pop("no_change_msg", "No changes needed")
+    try:
+        result = func(*args, **kwargs)
+    except Exception as e:
+        if module.params.get("detailed_logs"):
+            name = getattr(func, "__name__", str(func))
+            ansible_module_log(
+                module,
+                f"graphiant_prefix_port_list: manager {name!s} failed: {type(e).__name__}: {e!s}",
+            )
+        raise
+    if isinstance(result, dict) and "changed" in result:
+        changed = bool(result.get("changed"))
+        configured = result.get("configured_devices") or []
+        skipped = result.get("skipped_devices") or []
+
+        if changed:
+            msg = success_msg
+        else:
+            # Make "ok/no-change" messaging explicit and useful.
+            msg = no_change_msg
+            if skipped:
+                msg += f" (skipped {len(skipped)} device(s))"
+
+        return {
+            "changed": changed,
+            "result_msg": msg,
+            "details": result,
+            "configured_devices": configured,
+            "skipped_devices": skipped,
+        }
+    return {"changed": True, "result_msg": success_msg, "details": result}
+
+
+def main():
+    argument_spec = dict(
+        **graphiant_portal_auth_argument_spec(),
+        prefix_port_list_config_file=dict(type="str", required=True),
+        operation=dict(
+            type="str",
+            required=False,
+            choices=[
+                "create_prefix_port_lists",
+                "delete_prefix_port_lists",
+                "create_prefix_lists",
+                "delete_prefix_lists",
+                "create_port_lists",
+                "delete_port_lists",
+            ],
+        ),
+        state=dict(type="str", required=False, default="present", choices=["present", "absent"]),
+        detailed_logs=dict(type="bool", required=False, default=False),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    params = module.params
+    operation = params.get("operation")
+    state = params.get("state", "present")
+    cfg_file = params["prefix_port_list_config_file"]
+
+    if not operation:
+        operation = "create_prefix_port_lists" if state == "present" else "delete_prefix_port_lists"
+
+    try:
+        if params.get("detailed_logs"):
+            ansible_module_log(
+                module,
+                (
+                    f"graphiant_prefix_port_list: start operation={operation!r} "
+                    f"prefix_port_list_config_file={cfg_file!r} check_mode={module.check_mode!r}"
+                ),
+            )
+        # In check_mode, connection runs all logic but gsdk skips API writes and logs payloads only.
+        connection = get_graphiant_connection(params, check_mode=module.check_mode)
+        graphiant_config = connection.graphiant_config
+        if params.get("detailed_logs"):
+            ansible_module_log(
+                module,
+                "graphiant_prefix_port_list: GraphiantConfig obtained; dispatching to prefix_port_list manager",
+            )
+
+        # Execute the requested operation
+        changed = False
+        result_msg = ""
+
+        if operation == "create_prefix_port_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.create_prefix_port_lists,
+                cfg_file,
+                success_msg="Successfully created prefix and port lists",
+                no_change_msg="Prefix and Port lists already match desired state; no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        elif operation == "delete_prefix_port_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.delete_prefix_port_lists,
+                cfg_file,
+                success_msg="Successfully deleted prefix and port lists",
+                no_change_msg="Prefix and Port lists already absent (or already removed); no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        elif operation == "create_prefix_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.create_prefix_lists,
+                cfg_file,
+                success_msg="Successfully created prefix lists",
+                no_change_msg="Prefix lists already match desired state; no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        elif operation == "delete_prefix_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.delete_prefix_lists,
+                cfg_file,
+                success_msg="Successfully deleted prefix lists",
+                no_change_msg="Prefix lists already absent (or already removed); no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        elif operation == "create_port_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.create_port_lists,
+                cfg_file,
+                success_msg="Successfully created port lists",
+                no_change_msg="Port lists already match desired state; no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        elif operation == "delete_port_lists":
+            result = execute_with_logging(
+                module,
+                graphiant_config.prefix_port_list.delete_port_lists,
+                cfg_file,
+                success_msg="Successfully deleted port lists",
+                no_change_msg="Port lists already absent (or already removed); no changes needed",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+        else:
+            supported_ops = (
+                "create_prefix_port_lists, delete_prefix_port_lists, create_prefix_lists, "
+                "delete_prefix_lists, create_port_lists, delete_port_lists"
+            )
+            module.fail_json(
+                msg=f"Unsupported operation '{operation}'. Supported operations: {supported_ops}.",
+                operation=operation,
+            )
+            return
+
+        if params.get("detailed_logs"):
+            preview = result_msg if len(result_msg) <= 200 else (result_msg[:200] + "…")
+            ansible_module_log(
+                module,
+                f"graphiant_prefix_port_list: success changed={changed!r} result_msg_preview={preview!r}",
+            )
+        details = result.get("details") or {}
+        exit_payload = dict(
+            changed=changed,
+            msg=result_msg,
+            operation=operation,
+            prefix_port_list_config_file=cfg_file,
+            configured_devices=result.get("configured_devices", []),
+            skipped_devices=result.get("skipped_devices", []),
+            details=details,
+        )
+        diff_plan = details.get("diff_plan") or []
+        if getattr(module, "_diff", False) and diff_plan:
+            exit_payload["diff"] = ansible_diff_from_plan(diff_plan)
+        module.exit_json(**exit_payload)
+
+    except Exception as e:
+        if module.params.get("detailed_logs"):
+            import traceback
+
+            ansible_module_log(
+                module,
+                f"graphiant_prefix_port_list: {type(e).__name__}: {e!s}\n{traceback.format_exc()}",
+            )
+        else:
+            ansible_module_log(
+                module,
+                f"graphiant_prefix_port_list: failed {type(e).__name__}: {e!s}",
+            )
+        error_msg = handle_graphiant_exception(e, operation)
+        module.fail_json(msg=error_msg, operation=operation)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -1342,9 +1342,15 @@ class TestGraphiantPlaybooks(unittest.TestCase):
 
     @staticmethod
     def _edge_services_deconfigure_module_params(device_name, cfg):
-        """Build module_params to revert edge services (no deconfigure op on graphiant_edge_services)."""
+        """
+        Build module_params to revert edge services (configure-only module; no deconfigure operation).
+
+        Reverts DNS to dynamic, listed LLDP interfaces to false, DHCP pools to absent, and each
+        dpiApplications map key from the device config to absent (application: null on PUT).
+        """
         lldp_cfg = cfg.get("lldp") if isinstance(cfg.get("lldp"), dict) else {}
         dhcp_cfg = cfg.get("dhcpSubnets") if isinstance(cfg.get("dhcpSubnets"), list) else []
+        dpi_cfg = cfg.get("dpiApplications") if isinstance(cfg.get("dpiApplications"), dict) else {}
 
         dhcp_absent = []
         for entry in dhcp_cfg:
@@ -1364,12 +1370,17 @@ class TestGraphiantPlaybooks(unittest.TestCase):
                 }
             )
 
-        return {
+        dpi_absent = {app_key: {"state": "absent"} for app_key in dpi_cfg if app_key}
+
+        params = {
             "device": device_name,
             "dns": {"mode": "DNSModeDynamic"},
             "lldp": {if_name: False for if_name in lldp_cfg},
             "dhcpSubnets": dhcp_absent,
         }
+        if dpi_absent:
+            params["dpiApplications"] = dpi_absent
+        return params
 
     def test_configure_edge_services(self):
         """
@@ -1407,7 +1418,8 @@ class TestGraphiantPlaybooks(unittest.TestCase):
     def test_deconfigure_edge_services(self):
         """
         Revert edge services via module_params (module has no deconfigure operation):
-        dns.mode -> DNSModeDynamic, lldp -> false, dhcpSubnets -> state absent.
+        dns.mode -> DNSModeDynamic, lldp -> false, dhcpSubnets -> state absent,
+        and each dpiApplications map key from YAML -> state absent.
         """
         graphiant_config = graphiant_config_from_read_config()
         by_name = self._load_edge_services_from_yaml(graphiant_config, "sample_edge_services.yaml")
@@ -1636,6 +1648,75 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         LOG.info("Rotate MACsec keys result (idempotency check): %s", result)
         assert result.get("changed") is False, "Rotate MACsec keys idempotency failed"
 
+    def test_configure_prefix_and_port_list(self):
+        """
+        Configure prefix and port list.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.create_prefix_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure prefix and port list result: %s", result)
+        result = graphiant_config.prefix_port_list.create_prefix_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure prefix and port list result (idempotency check): %s", result)
+
+    def test_deconfigure_prefix_and_port_list(self):
+        """
+        Deconfigure prefix and port list.
+
+        Second run should be idempotent (changed=False) when lists are already absent.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.delete_prefix_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure prefix and port list result: %s", result)
+        result2 = graphiant_config.prefix_port_list.delete_prefix_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure prefix and port list result (idempotency check): %s", result2)
+        assert result2["changed"] is False, "Deconfigure prefix and port list idempotency failed"
+
+    def test_configure_prefix_lists(self):
+        """
+        Configure prefix lists.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.create_prefix_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure prefix lists result: %s", result)
+        result = graphiant_config.prefix_port_list.create_prefix_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure prefix lists result (idempotency check): %s", result)
+
+    def test_deconfigure_prefix_lists(self):
+        """
+        Deconfigure prefix lists.
+
+        Second run should be idempotent (changed=False) when lists are already absent.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.delete_prefix_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure prefix lists result: %s", result)
+        result2 = graphiant_config.prefix_port_list.delete_prefix_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure prefix lists result (idempotency check): %s", result2)
+        assert result2["changed"] is False, "Deconfigure prefix lists idempotency failed"
+
+    def test_configure_port_lists(self):
+        """
+        Configure port lists.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.create_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure port lists result: %s", result)
+        result = graphiant_config.prefix_port_list.create_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Configure port lists result (idempotency check): %s", result)
+
+    def test_deconfigure_port_lists(self):
+        """
+        Deconfigure port lists.
+
+        Second run should be idempotent (changed=False) when lists are already absent.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.prefix_port_list.delete_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure port lists result: %s", result)
+        result2 = graphiant_config.prefix_port_list.delete_port_lists("sample_prefix_and_port_list.yaml")
+        LOG.info("Deconfigure port lists result (idempotency check): %s", result2)
+        assert result2["changed"] is False, "Deconfigure port lists idempotency failed"
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
@@ -1757,11 +1838,26 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_rotate_macsec_keys'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_lag_interfaces'))
 
-    # Edge Services (graphiant_edge_services) — after LAN/WAN interfaces; prereq: interface_management
+    # Prefix and Port List Management Tests
+    # Configure and delete prefix lists
+    suite.addTest(TestGraphiantPlaybooks('test_configure_prefix_lists'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_prefix_lists'))
+    # Configure and delete port lists
+    suite.addTest(TestGraphiantPlaybooks('test_configure_port_lists'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_port_lists'))
+    # Configure and delete prefix and port lists
+    suite.addTest(TestGraphiantPlaybooks('test_configure_prefix_and_port_list'))
+
+    # Edge Services (graphiant_edge_services) — after LAN/WAN interfaces.
+    # Prereq: interface_management and prefix/port lists for DPI applications.
+    suite.addTest(TestGraphiantPlaybooks('test_configure_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_edge_services_lws_force_requires_password'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_edge_services'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_edge_services_lws_vault'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_edge_services'))
+
+    # Deconfigure prefix and port list
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_prefix_and_port_list'))
 
     # Global Configuration Management and BGP Peering
     suite.addTest(TestGraphiantPlaybooks('test_configure_global_config_prefix_lists'))
@@ -1826,15 +1922,20 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_configure_device_ntp'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_device_ntp'))
 
-    # Device-level traffic policy tests (attach/detach segments before ruleset deconfigure)
+    # Device-level traffic policy tests (attach/detach segments before ruleset deconfigure).
+    # Prereq: prefix/port lists and edge services (DPI applications).
     suite.addTest(TestGraphiantPlaybooks('test_configure_global_lan_segments'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_vpn_profiles'))
     suite.addTest(TestGraphiantPlaybooks('test_create_site_to_site_vpn'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_prefix_and_port_list'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_edge_services'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_device_traffic_policy'))
     suite.addTest(TestGraphiantPlaybooks('test_attach_traffic_policy_lan_segments'))
     suite.addTest(TestGraphiantPlaybooks('test_detach_traffic_policy_lan_segments'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_device_traffic_policy'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_edge_services'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_prefix_and_port_list'))
     suite.addTest(TestGraphiantPlaybooks('test_delete_site_to_site_vpn'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vpn_profiles'))
 

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_edge_services_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_edge_services_manager.py
@@ -244,3 +244,395 @@ def test_lldp_snapshot_skips_wan() -> None:
     )
     assert "GigabitEthernet2/0/0" not in snap
     assert snap["GigabitEthernet5/0/0"] is False
+
+
+def test_dpi_snapshot_from_device_edge_traffic_policy() -> None:
+    """DPI snapshot reads dpiApplications from device.edge.trafficPolicy like other edge services."""
+    device = {
+        "dns": {"mode": "DNSModeStatic"},
+        "edge": {
+            "trafficPolicy": {
+                "dpiApplications": {
+                    "app1": {"application": {"name": "app1", "ipProtocol": "tcp"}},
+                }
+            }
+        },
+    }
+    snap = EdgeServicesManager._dpi_snapshot_from_device(device)
+    assert snap["app1"]["name"] == "app1"
+    assert snap["app1"]["ipProtocol"] == "tcp"
+
+
+def test_coerce_dpi_applications_list_to_map() -> None:
+    raw = [
+        {
+            "application": {
+                "name": "whitehouse.gov",
+                "ipProtocol": "tcp",
+                "destinationNetwork": "192.0.66.180/32",
+            }
+        }
+    ]
+    out = EdgeServicesManager._coerce_dpi_applications_map(raw)
+    assert "whitehouse.gov" in out
+    assert out["whitehouse.gov"]["name"] == "whitehouse.gov"
+
+
+def test_build_edge_payload_dpi_injects_name_from_map_key() -> None:
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "edge": {
+            "trafficPolicy": {
+                "portLists": {"web_ports": {"list": {"name": "web_ports", "ports": [80, 443]}}},
+                "networkLists": {
+                    "graphiant_dia_prefix": {"list": {"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}}
+                },
+            }
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "whitehouse.gov": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationPortList": "web_ports",
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    app = edge["trafficPolicy"]["dpiApplications"]["whitehouse.gov"]["application"]
+    assert app["name"] == "whitehouse.gov"
+    assert app["ipProtocol"] == "tcp"
+    assert app["destinationPortList"] == "web_ports"
+
+
+def test_build_edge_payload_skips_dpi_yaml_nulls_vs_sparse_get() -> None:
+    """Explicit nulls in YAML must match portal GET that omits unset application fields."""
+    mgr = _make_manager()
+    get_app = {
+        "name": "whitehouse.gov",
+        "ipProtocol": "tcp",
+        "destinationNetwork": "192.0.66.180/32",
+        "destinationPortList": "web_ports",
+    }
+    current = {
+        "role": "cpe",
+        "edge": {
+            "trafficPolicy": {
+                "dpiApplications": {"whitehouse.gov": {"application": get_app}},
+                "portLists": {"web_ports": {"list": {"name": "web_ports", "ports": [80, 443]}}},
+            }
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "whitehouse.gov": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "sourceNetwork": None,
+                    "sourceNetworkList": None,
+                    "sourcePort": None,
+                    "sourcePortList": None,
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationNetworkList": None,
+                    "destinationPort": None,
+                    "destinationPortList": "web_ports",
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_updates_source_when_yaml_nulls_destination() -> None:
+    """Non-null source fields are pushed; explicit null destination fields are omitted from PUT."""
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "trafficPolicy": {
+            "dpiApplications": [
+                {
+                    "name": "graphiant_dia_ping_via_IP",
+                    "ipProtocol": "tcp",
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationPortList": "web_ports",
+                },
+            ],
+            "portLists": [{"name": "web_ports", "ports": [80, 443]}],
+            "networkLists": [{"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}],
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "graphiant_dia_ping_via_IP": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "sourceNetwork": None,
+                    "sourceNetworkList": "graphiant_dia_prefix",
+                    "sourcePort": 80,
+                    "sourcePortList": None,
+                    "destinationNetwork": None,
+                    "destinationNetworkList": None,
+                    "destinationPort": None,
+                    "destinationPortList": None,
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    app = edge["trafficPolicy"]["dpiApplications"]["graphiant_dia_ping_via_IP"]["application"]
+    assert app["sourceNetworkList"] == "graphiant_dia_prefix"
+    assert app["sourcePort"] == 80
+    assert "destinationNetwork" not in app
+    assert "destinationPortList" not in app
+
+
+def test_build_edge_payload_skips_dpi_when_only_null_field_changes() -> None:
+    """Explicit nulls alone do not trigger updates (portal cannot clear nested fields via null)."""
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "trafficPolicy": {
+            "dpiApplications": [
+                {
+                    "name": "graphiant_dia_ping_via_IP",
+                    "ipProtocol": "tcp",
+                    "sourceNetworkList": "graphiant_dia_prefix",
+                    "sourcePort": 80,
+                    "destinationNetwork": "8.8.8.8/32",
+                },
+            ],
+            "networkLists": [{"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}],
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "graphiant_dia_ping_via_IP": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "sourceNetwork": None,
+                    "sourceNetworkList": None,
+                    "sourcePort": None,
+                    "sourcePortList": None,
+                    "destinationNetwork": "8.8.8.8/32",
+                    "destinationNetworkList": None,
+                    "destinationPort": None,
+                    "destinationPortList": None,
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_dpi_put_only_sends_changed_fields() -> None:
+    """Explicit nulls in YAML must not be re-sent when portal already has the field unset."""
+    mgr = _make_manager()
+    get_app = {
+        "name": "whitehouse.gov",
+        "ipProtocol": "tcp",
+        "destinationNetwork": "192.0.66.180/32",
+        "destinationPortList": "web_ports",
+    }
+    current = {
+        "role": "cpe",
+        "trafficPolicy": {
+            "dpiApplications": [{"name": "whitehouse.gov", **{k: v for k, v in get_app.items() if k != "name"}}],
+            "portLists": [{"name": "web_ports", "ports": [80, 443]}],
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "whitehouse.gov": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "sourceNetwork": None,
+                    "sourceNetworkList": None,
+                    "sourcePort": None,
+                    "sourcePortList": None,
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationNetworkList": None,
+                    "destinationPort": None,
+                    "destinationPortList": "web_ports",
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_skips_dpi_when_get_returns_zero_ports() -> None:
+    mgr = _make_manager()
+    get_app = {
+        "name": "graphiant_dia_ping",
+        "ipProtocol": "icmp",
+        "sourcePort": 0,
+        "destinationPort": 0,
+        "destinationNetworkList": "graphiant_dia_prefix",
+    }
+    current = {
+        "role": "cpe",
+        "edge": {
+            "trafficPolicy": {
+                "dpiApplications": {"graphiant_dia_ping": {"application": get_app}},
+                "networkLists": {
+                    "graphiant_dia_prefix": {"list": {"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}}
+                },
+            }
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "graphiant_dia_ping": {
+                "application": {
+                    "ipProtocol": "icmp",
+                    "destinationNetworkList": "graphiant_dia_prefix",
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_dpi_idempotent_when_portal_omits_unknown_ip_protocol() -> None:
+    """Portal GET may drop ipProtocol after PUT with UnknownIPProtocol; must not re-push."""
+    desired = {
+        "ipProtocol": "UnknownIPProtocol",
+        "destinationNetwork": "8.8.8.8/32",
+        "sourceNetworkList": None,
+    }
+    before = {"name": "graphiant_dia_ping_via_IP", "destinationNetwork": "8.8.8.8/32"}
+    assert EdgeServicesManager._dpi_applications_equal(before, desired, "graphiant_dia_ping_via_IP") is True
+
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "trafficPolicy": {
+            "dpiApplications": [
+                {"name": "graphiant_dia_ping_via_IP", "destinationNetwork": "8.8.8.8/32"},
+            ],
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "graphiant_dia_ping_via_IP": {
+                "application": {
+                    "ipProtocol": "UnknownIPProtocol",
+                    "sourceNetwork": None,
+                    "sourceNetworkList": None,
+                    "sourcePort": None,
+                    "sourcePortList": None,
+                    "destinationNetwork": "8.8.8.8/32",
+                    "destinationNetworkList": None,
+                    "destinationPort": None,
+                    "destinationPortList": None,
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-2", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_skips_dpi_when_portal_description_not_in_yaml() -> None:
+    """Portal GET may include description; YAML without it should still be idempotent."""
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "trafficPolicy": {
+            "dpiApplications": [
+                {
+                    "name": "whitehouse.gov",
+                    "description": "TCP app using destination prefix and port list",
+                    "ipProtocol": "tcp",
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationPortList": "web_ports",
+                },
+            ],
+            "portLists": [{"id": 1, "name": "web_ports", "ports": [80, 443]}],
+        },
+    }
+    cfg = {
+        "dpiApplications": {
+            "whitehouse.gov": {
+                "application": {
+                    "ipProtocol": "tcp",
+                    "destinationNetwork": "192.0.66.180/32",
+                    "destinationPortList": "web_ports",
+                }
+            }
+        }
+    }
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_skips_dpi_when_unchanged() -> None:
+    mgr = _make_manager()
+    app = {
+        "name": "whitehouse.gov",
+        "description": None,
+        "ipProtocol": "tcp",
+        "sourceNetwork": None,
+        "sourceNetworkList": None,
+        "sourcePort": None,
+        "sourcePortList": None,
+        "destinationNetwork": "192.0.66.180/32",
+        "destinationNetworkList": None,
+        "destinationPort": None,
+        "destinationPortList": "web_ports",
+    }
+    current = {
+        "role": "cpe",
+        "edge": {
+            "trafficPolicy": {
+                "dpiApplications": {"whitehouse.gov": {"application": app}},
+                "portLists": {"web_ports": {"list": {"name": "web_ports", "ports": [80, 443]}}},
+            }
+        },
+    }
+    cfg = {"dpiApplications": {"whitehouse.gov": {"application": dict(app)}}}
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert "trafficPolicy" not in edge
+
+
+def test_build_edge_payload_dpi_remove_application() -> None:
+    mgr = _make_manager()
+    current = {
+        "role": "cpe",
+        "edge": {
+            "trafficPolicy": {
+                "dpiApplications": {
+                    "old-app": {
+                        "application": {"name": "old-app", "ipProtocol": "icmp"},
+                    }
+                }
+            }
+        },
+    }
+    cfg = {"dpiApplications": {"old-app": {"state": "absent"}}}
+    edge = mgr._build_edge_payload("edge-1", cfg, current)
+    assert edge["trafficPolicy"]["dpiApplications"]["old-app"] == {"application": None}
+
+
+def test_validate_dpi_unknown_port_list_fails() -> None:
+    mgr = _make_manager()
+    current = {"edge": {"trafficPolicy": {"portLists": {}}}}
+    desired = {
+        "app1": {
+            "application": {
+                "name": "app1",
+                "ipProtocol": "tcp",
+                "destinationPortList": "missing_ports",
+            }
+        }
+    }
+    with pytest.raises(ConfigurationError, match="missing_ports"):
+        mgr._validate_dpi_list_references("edge-1", desired, current)

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_prefix_and_port_list_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_prefix_and_port_list_manager.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for PrefixAndPortListManager (no live API)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.prefix_and_port_list import (
+    PrefixAndPortListManager,
+)
+
+
+def _mgr() -> PrefixAndPortListManager:
+    return PrefixAndPortListManager(MagicMock())
+
+
+def _network_lists_payload(network_lists):
+    return {"edge": {"trafficPolicy": {"networkLists": network_lists}}}
+
+
+def _port_lists_payload(port_lists):
+    return {"edge": {"trafficPolicy": {"portLists": port_lists}}}
+
+
+def _device_network_lists(lists):
+    return {"device": {"edge": {"trafficPolicy": {"networkLists": lists}}}}
+
+
+def _device_port_lists(lists):
+    return {"device": {"edge": {"trafficPolicy": {"portLists": lists}}}}
+
+
+def test_load_section_preserves_list_shaped_device_config() -> None:
+    m = _mgr()
+    yaml_cfg = {
+        "networkLists": [
+            {
+                "edge-1-sdktest": [
+                    {
+                        "name": "demo_prefix_list_1",
+                        "networks": ["1.1.1.1/32", "2.2.2.2/32"],
+                    }
+                ]
+            }
+        ]
+    }
+    m.render_config_file = lambda _path: yaml_cfg
+    loaded = m._load_section("sample_prefix_and_port_list.yaml", "networkLists")
+    assert loaded["edge-1-sdktest"] == yaml_cfg["networkLists"][0]["edge-1-sdktest"]
+
+
+def test_build_device_payload_from_list_shaped_yaml() -> None:
+    m = _mgr()
+    yaml_cfg = {
+        "networkLists": [
+            {
+                "edge-1-sdktest": [
+                    {
+                        "name": "demo_prefix_list_1",
+                        "networks": ["1.1.1.1/32", "2.2.2.2/32"],
+                    }
+                ]
+            }
+        ]
+    }
+    m.render_config_file = lambda _path: yaml_cfg
+    payload = m._build_device_payload("edge-1-sdktest", "sample_prefix_and_port_list.yaml", "create", "network")
+    assert payload == {
+        "edge": {
+            "trafficPolicy": {
+                "networkLists": {
+                    "demo_prefix_list_1": {
+                        "list": {
+                            "name": "demo_prefix_list_1",
+                            "networks": ["1.1.1.1/32", "2.2.2.2/32"],
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+def test_normalize_list_items_merges_split_yaml_shape() -> None:
+    m = _mgr()
+    raw = [{"name": "demo_prefix_list_1"}, {"networks": ["1.1.1.1/32", "2.2.2.2/32"]}]
+    items = m._normalize_list_items(raw, value_field="networks")
+    assert items == [{"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32", "2.2.2.2/32"]}]
+
+
+def test_network_lists_from_yaml_create_shape() -> None:
+    m = _mgr()
+    out = m._network_lists_from_yaml(
+        [{"name": "demo_prefix_list_1", "networks": ["2.2.2.2/32", "1.1.1.1/32"]}],
+        operation="create",
+    )
+    assert out == {
+        "demo_prefix_list_1": {
+            "list": {"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32", "2.2.2.2/32"]},
+        }
+    }
+
+
+def test_network_lists_from_yaml_delete_shape() -> None:
+    m = _mgr()
+    out = m._network_lists_from_yaml([{"name": "demo_prefix_list_1"}], operation="delete")
+    assert out == {"demo_prefix_list_1": {"list": None}}
+
+
+def test_network_lists_from_yaml_create_state_absent() -> None:
+    m = _mgr()
+    out = m._network_lists_from_yaml(
+        [{"name": "testing_prefix_list", "networks": ["10.1.1.0/24"], "state": "absent"}],
+        operation="create",
+    )
+    assert out == {"testing_prefix_list": {"list": None}}
+
+
+def test_port_lists_from_yaml_create_state_absent() -> None:
+    m = _mgr()
+    out = m._port_lists_from_yaml(
+        [{"name": "web_ports", "ports": [80, 443], "state": "absent"}],
+        operation="create",
+    )
+    assert out == {"web_ports": {"list": None}}
+
+
+def test_build_device_payload_mixed_present_and_absent() -> None:
+    m = _mgr()
+    yaml_cfg = {
+        "networkLists": [
+            {
+                "edge-1-sdktest": [
+                    {"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32", "8.8.8.8/32"]},
+                    {"name": "testing_prefix_list", "networks": ["10.1.1.0/24"], "state": "absent"},
+                ]
+            }
+        ],
+        "portLists": [
+            {
+                "edge-1-sdktest": [
+                    {"name": "web_ports", "ports": [80, 443]},
+                    {"name": "testing_port_list", "ports": [123], "state": "absent"},
+                ]
+            }
+        ],
+    }
+    m.render_config_file = lambda _path: yaml_cfg
+    payload = m._build_device_payload("edge-1-sdktest", "sample_prefix_and_port_list.yaml", "create", "both")
+    nl = payload["edge"]["trafficPolicy"]["networkLists"]
+    pl = payload["edge"]["trafficPolicy"]["portLists"]
+    assert nl["graphiant_dia_prefix"]["list"]["networks"] == ["1.1.1.1/32", "8.8.8.8/32"]
+    assert nl["testing_prefix_list"] == {"list": None}
+    assert pl["web_ports"]["list"]["ports"] == [80, 443]
+    assert pl["testing_port_list"] == {"list": None}
+
+
+def test_payload_differs_false_when_create_state_absent_already_gone() -> None:
+    m = _mgr()
+    desired = _network_lists_payload(
+        {
+            "testing_prefix_list": {"list": None},
+            "graphiant_dia_prefix": {"list": {"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}},
+        }
+    )
+    device_info = _device_network_lists([{"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}])
+    assert m._payload_differs(desired, device_info) is False
+
+
+def test_payload_differs_false_when_network_list_matches() -> None:
+    m = _mgr()
+    desired = _network_lists_payload(
+        {
+            "demo_prefix_list_1": {
+                "list": {"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32", "2.2.2.2/32"]},
+            }
+        }
+    )
+    device_info = _device_network_lists(
+        [{"name": "demo_prefix_list_1", "networks": ["2.2.2.2/32", "1.1.1.1/32"]}]
+    )
+    assert m._payload_differs(desired, device_info) is False
+
+
+def test_payload_differs_true_when_network_list_missing() -> None:
+    m = _mgr()
+    desired = _network_lists_payload(
+        {"demo_prefix_list_1": {"list": {"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32"]}}}
+    )
+    device_info = {"device": {"edge": {"trafficPolicy": {"networkLists": []}}}}
+    assert m._payload_differs(desired, device_info) is True
+
+
+def test_payload_differs_false_when_delete_target_already_absent() -> None:
+    m = _mgr()
+    desired = _network_lists_payload({"demo_prefix_list_1": {"list": None}})
+    device_info = {"device": {"edge": {"trafficPolicy": {"networkLists": []}}}}
+    assert m._payload_differs(desired, device_info) is False
+
+
+def test_payload_differs_true_when_port_list_differs() -> None:
+    m = _mgr()
+    desired = _port_lists_payload({"demo_port_list_1": {"list": {"name": "demo_port_list_1", "ports": [100, 200]}}})
+    device_info = _device_port_lists([{"name": "demo_port_list_1", "ports": [100]}])
+    assert m._payload_differs(desired, device_info) is True
+
+
+def test_traffic_policy_lists_diff_create_network_list() -> None:
+    m = _mgr()
+    device = {"edge": {"trafficPolicy": {"networkLists": []}}}
+    payload = _network_lists_payload(
+        {
+            "demo_prefix_list_1": {
+                "list": {"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32", "2.2.2.2/32"]},
+            }
+        }
+    )
+    before, after = m._traffic_policy_lists_diff(device, payload)
+    assert before["networkLists"]["demo_prefix_list_1"] is None
+    assert after["networkLists"]["demo_prefix_list_1"] == {
+        "name": "demo_prefix_list_1",
+        "networks": ["1.1.1.1/32", "2.2.2.2/32"],
+    }
+
+
+def test_traffic_policy_lists_diff_delete_network_list() -> None:
+    m = _mgr()
+    device = _device_network_lists([{"name": "demo_prefix_list_1", "networks": ["1.1.1.1/32"]}])["device"]
+    payload = _network_lists_payload({"demo_prefix_list_1": {"list": None}})
+    before, after = m._traffic_policy_lists_diff(device, payload)
+    assert before["networkLists"]["demo_prefix_list_1"] == {
+        "name": "demo_prefix_list_1",
+        "networks": ["1.1.1.1/32"],
+    }
+    assert after["networkLists"]["demo_prefix_list_1"] is None

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/test_graphiant_config_auth_mocked.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/test_graphiant_config_auth_mocked.py
@@ -77,3 +77,4 @@ def test_graphiant_config_init_succeeds_when_bearer_succeeds(
     assert st.get("sites") is True
     assert st.get("device_system") is True
     assert st.get("traffic_policy") is True
+    assert st.get("prefix_port_list") is True

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_edge_services.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_edge_services.py
@@ -58,6 +58,7 @@ def test_main_requires_device_or_file(mock_module_cls, mock_conn) -> None:
         "dns": None,
         "lldp": None,
         "dhcpSubnets": None,
+        "dpiApplications": None,
         "vault_devices_lws_password": {},
         "operation": "configure",
         "state": "present",

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_prefix_and_port_list.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_prefix_and_port_list.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for graphiant_prefix_port_list module (mocked Ansible + connection)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.device_config_common import (
+    ansible_diff_from_plan,
+)
+from ansible_collections.graphiant.naas.plugins.modules import graphiant_prefix_port_list
+
+
+def _base_params() -> dict:
+    return {
+        "host": "https://api.example.com",
+        "username": "u",
+        "password": "p",
+        "access_token": None,
+        "prefix_port_list_config_file": "sample_prefix_and_port_list.yaml",
+        "operation": "create_prefix_port_lists",
+        "state": "present",
+        "detailed_logs": False,
+    }
+
+
+def _manager_result(*, changed: bool = False, configured=None, skipped=None, diff_plan=None) -> dict:
+    return {
+        "changed": changed,
+        "configured_devices": configured or [],
+        "skipped_devices": skipped or [],
+        "diff_plan": diff_plan or [],
+    }
+
+
+def test_ansible_diff_from_plan_prefix_port_lists() -> None:
+    diff_plan = [
+        {
+            "device": "edge-1-sdktest",
+            "branch": "edge.trafficPolicy",
+            "before": {"networkLists": {"demo": None}},
+            "after": {"networkLists": {"demo": {"name": "demo", "networks": ["1.1.1.1/32"]}}},
+        }
+    ]
+    d = ansible_diff_from_plan(diff_plan)
+    assert "edge-1-sdktest" in d["before"]
+    assert "1.1.1.1/32" in d["after"]
+
+
+def test_execute_with_logging_no_change_adds_skipped_count_to_message() -> None:
+    module = MagicMock()
+    module.params = {"detailed_logs": False}
+    out = graphiant_prefix_port_list.execute_with_logging(
+        module,
+        lambda: _manager_result(skipped=["d1", "d2"]),
+    )
+    assert out["changed"] is False
+    assert "skipped" in out["result_msg"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_create_prefix_port_lists_diff_mode(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod._diff = True
+    mod.params = _base_params()
+    mod.params["operation"] = "create_prefix_port_lists"
+    mock_ansible_module.return_value = mod
+
+    diff_plan = [
+        {
+            "device": "edge-1-sdktest",
+            "branch": "edge.trafficPolicy",
+            "before": {"networkLists": {"graphiant_dia_prefix": None}},
+            "after": {
+                "networkLists": {
+                    "graphiant_dia_prefix": {"name": "graphiant_dia_prefix", "networks": ["1.1.1.1/32"]}
+                }
+            },
+        }
+    ]
+    ppl = MagicMock()
+    ppl.create_prefix_port_lists.return_value = _manager_result(
+        changed=True, configured=["edge-1-sdktest"], diff_plan=diff_plan
+    )
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    kwargs = mod.exit_json.call_args[1]
+    assert "diff" in kwargs
+    assert "graphiant_dia_prefix" in kwargs["diff"]["after"]
+    assert kwargs["details"]["diff_plan"] == diff_plan
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_create_prefix_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "create_prefix_port_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.create_prefix_port_lists.return_value = _manager_result(skipped=["x"])
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.create_prefix_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    mod.exit_json.assert_called_once()
+    kwargs = mod.exit_json.call_args[1]
+    assert kwargs["operation"] == "create_prefix_port_lists"
+    assert kwargs["changed"] is False
+    assert kwargs["skipped_devices"] == ["x"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_delete_prefix_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "delete_prefix_port_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.delete_prefix_port_lists.return_value = _manager_result(changed=True, configured=["edge-1"])
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.delete_prefix_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    kwargs = mod.exit_json.call_args[1]
+    assert kwargs["operation"] == "delete_prefix_port_lists"
+    assert kwargs["changed"] is True
+    assert kwargs["configured_devices"] == ["edge-1"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_create_prefix_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "create_prefix_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.create_prefix_lists.return_value = _manager_result(changed=True, configured=["edge-1"])
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.create_prefix_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "create_prefix_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_delete_prefix_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "delete_prefix_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.delete_prefix_lists.return_value = _manager_result()
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.delete_prefix_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "delete_prefix_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_create_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "create_port_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.create_port_lists.return_value = _manager_result(changed=True, configured=["edge-1"])
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.create_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "create_port_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_delete_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "delete_port_lists"
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.delete_port_lists.return_value = _manager_result()
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.delete_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "delete_port_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_state_present_defaults_to_create_prefix_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = None
+    p["state"] = "present"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.create_prefix_port_lists.return_value = _manager_result()
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.create_prefix_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "create_prefix_port_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_state_absent_defaults_to_delete_prefix_port_lists(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = None
+    p["state"] = "absent"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    ppl = MagicMock()
+    ppl.delete_prefix_port_lists.return_value = _manager_result()
+    gc = MagicMock()
+    gc.prefix_port_list = ppl
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_prefix_port_list.main()
+
+    ppl.delete_prefix_port_lists.assert_called_once_with("sample_prefix_and_port_list.yaml")
+    assert mod.exit_json.call_args[1]["operation"] == "delete_prefix_port_lists"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_prefix_port_list.AnsibleModule")
+def test_main_unsupported_operation_fails_json(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = "not-a-valid-op"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    mock_get_connection.return_value = MagicMock()
+
+    graphiant_prefix_port_list.main()
+    mod.fail_json.assert_called_once()
+    err = mod.fail_json.call_args[1]
+    assert "Unsupported" in err["msg"]
+    assert err["operation"] == "not-a-valid-op"
+    mod.exit_json.assert_not_called()


### PR DESCRIPTION
# Conflicts:
#	ansible_collections/graphiant/naas/README.md
#	ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py #	ansible_collections/graphiant/naas/tests/test.py

## Description

Adds support for Custom DPI, Prefix List, and Port List automation through the Ansible collection. This feature enables users to configure, update, and remove these policy objects programmatically, improving automation coverage and operational consistency.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [ ] **Ansible Inclusion Checklist Compliance**
  - [x] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [x] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [ ] **Code Quality**
  - [x] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [x] Code follows project style guidelines
  - [x] No new linting errors introduced

- [ ] **Testing**
  - [x] Local tests pass
  - [x] Added/updated unit tests if applicable
  - [x] E2E integration test passes (if applicable)

- [ ] **Documentation**
  - [x] Updated README.md if needed
  - [x] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [ ] **CI/CD**
  - [x] All CI/CD workflows are expected to pass
  - [x] No breaking changes to existing functionality (unless intentional)

## Testing

- Configure Custom DPI, Prefix Lists, and Port Lists.
- Update existing configurations.
- Add new entries.
- Remove existing entries.
- Deconfigure Custom DPI, Prefix Lists, and Port Lists

Test.py: 
[test.txt](https://github.com/user-attachments/files/28655230/test.txt)

Ansible playbook: 
[ansible_run.txt](https://github.com/user-attachments/files/28654923/ansible_run.txt)

## Related Issues

https://github.com/Graphiant-Inc/graphiant-playbooks/issues/92

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
