### PR TITLE
Security policy support and documentation updates

### DIFF
--- a/ansible_collections/graphiant/naas/README.md
+++ b/ansible_collections/graphiant/naas/README.md
@@ -79,6 +79,7 @@ This collection provides Ansible modules to automate:
 | `graphiant_device_config` | Push raw device configurations to Edge, Gateway, and Core devices |
 | `graphiant_ntp` | Manage NTP objects |
 | `graphiant_traffic_policy` | Manage device traffic policy rulesets and LAN segment attachments (configure workflow: rulesets + attach; deconfigure workflow: detach + delete) |
+| `graphiant_security_policy` | Manage device security policy rulesets and zone pair attachments (configure workflow: rulesets + attach_to_zone_pairs; deconfigure workflow: detach_from_zone_pairs + delete) |
 | `graphiant_prefix_port_list` | Manage Prefix & Port Lists on Edge devices | 
 
 ## Installation
@@ -356,6 +357,7 @@ The collection includes ready-to-use example playbooks in the `playbooks/` direc
 | `edge_services_management.yml` | Edge DHCP, DNS, LLDP, local web server password (Vault-supported) |
 | `test_collection.yml` | Collection validation and testing |
 | `traffic_policies_management.yml` | Traffic policies and LAN-segment attachments |
+| `security_policies_management.yml` | Security policies and zone-pair attachments |
 | `prefix_port_list_management.yml` | Prefix and port lists | 
 
 #### Data Exchange Workflows
@@ -386,6 +388,7 @@ ansible-doc graphiant.naas.graphiant_interfaces
 ansible-doc graphiant.naas.graphiant_static_routes
 ansible-doc graphiant.naas.graphiant_ntp
 ansible-doc graphiant.naas.graphiant_traffic_policy
+ansible-doc graphiant.naas.graphiant_security_policy
 ansible-doc graphiant.naas.graphiant_device_system
 ansible-doc graphiant.naas.graphiant_edge_services
 ansible-doc graphiant.naas.graphiant_vrrp
@@ -461,7 +464,7 @@ Use `ansible-playbook ... --check` or set `check_mode: true` on a task to run wi
 
 | Support | Modules | Behavior |
 |--------|---------|----------|
-| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
+| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list`, `graphiant_traffic_policy`, `graphiant_security_policy` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
 | **Partial** | `graphiant_bgp`, `graphiant_device_config`, `graphiant_backbone`                                                                                                                                                                                                                                                                    | Writes are still skipped, but `changed` is not computed from a full live diff: BGP reports `changed: true` for configure/deconfigure/detach in check mode; `graphiant_device_config` returns `changed: false` for `show_validated_payload` and `changed: true` for `configure`; `graphiant_backbone` reports `changed: true` whenever the supplied config file contains matching backbone resources (no live diff against current Core device state). See each module's `attributes.check_mode` details. |
 | **Read-only** | `graphiant_macsec_info` | Always read-only; check mode has no side effects. |
 
@@ -517,6 +520,7 @@ Modules are designed to be idempotent where possible and to report `changed` acc
 - **Structured results**: Manager methods return results with `changed`, `created`, `skipped`, and `deleted` so playbooks can react to what actually happened.
 - **Interface and circuit modules**: Deconfigure logic (e.g. `deconfigure_lan_interfaces`, `deconfigure_circuits`, `deconfigure_wan_circuits_interfaces`) correctly reports `changed: false` when there is nothing to remove; static route cleanup and circuit removal order are handled so repeated runs stay safe.
 - **Configure operations**: Many configure operations (e.g. full interface or BGP push) do not perform a full state comparison before applying. They push the desired config and may report `changed: true` even if the device is already in that state. This is documented in the relevant modules.
+- **Traffic and security policies**: `graphiant_traffic_policy` and `graphiant_security_policy` compare intended rulesets (and segment or zone-pair attachments) to live device state and skip the push when already matched.
 
 **Summary:**
 - Run deconfigure tasks repeatedly without concern; they are idempotent.
@@ -604,6 +608,7 @@ Configuration files use YAML format with optional Jinja2 templating. Sample file
 - `sample_static_route.yaml` - Static routes (per-segment) configuration
 - `sample_device_ntp.yaml` - NTP objects under `edge.ntpGlobalObject`
 - `sample_device_traffic_policies.yaml` - Traffic rulesets under `edge.trafficPolicy` and LAN segment ruleset attachments under `edge.segments` (use configure + attach_to_lan_segments, or the `traffic_policies_management.yml` playbook `--tags configure`)
+- `sample_device_security_policies.yaml` - Security rulesets under `edge.trafficPolicy.securityRulesets` and zone pair ruleset attachments under `edge.trafficPolicy.zones` (use configure + attach_to_zone_pairs, or the `security_policies_management.yml` playbook `--tags configure`). Custom application matches (`applicationCustom`) require DPI applications from `graphiant_edge_services` / `sample_edge_services.yaml`.
 - `sample_vrrp_config.yaml` - VRRP (Virtual Router Redundancy Protocol) configurations
 - `sample_lag_interface_config.yaml` - LAG interface configurations
 - `sample_macsec.yaml` - Interface MACsec (PSK/SAK) configuration; CAK via `vault_devices_macsec_psk` in `vault_secrets.yml`

--- a/ansible_collections/graphiant/naas/configs/sample_device_security_policies.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_device_security_policies.yaml
@@ -1,0 +1,100 @@
+# Device-level security policy (edge.trafficPolicy.securityRulesets).
+# Rule guidance:
+#   - seq (required), logging (true/false).
+#   - action (required): accept | reject | inspect | drop (lowercased on push).
+#       accept  — allow matching traffic.
+#       reject  — deny matching traffic.
+#       inspect — allow and inspect matching traffic (DPI / threat inspection).
+#       drop    — silently deny matching traffic.
+#   - implicitRuleAction on the ruleset: accept or reject (default for unmatched traffic).
+#
+# Match options (under rules.match; scalars are normalized to API shape on push):
+#   You cannot switch a rule's primary match type in place (application <-> network/L4).
+#   The device API merges rule updates and will keep stale match criteria. To change
+#   match type, delete the rule (state: absent) and add a new rule with the desired match.
+#   Application match and network/L4 match are mutually exclusive — use one per rule.
+#   - ipProtocol: any, icmp, igmp, tcp, udp, esp, or ah (also sets protocol.ipProtocol).
+#   - sourceNetwork / destinationNetwork: CIDR string or API dict.
+#   - sourcePort / destinationPort: 1-65535 (sent as strings).
+#   - applicationBuiltin / applicationCustom: portal built-in or custom application match.
+#     or API shape: application: { match: { builtin: "..." } } / { match: { custom: "..." } }
+#   - contentFilter: domainCategoryIds shorthand or API shape
+#     (contentFilter: { match: { domainCategoryIds: [] } })
+#   - domainList: domainWildcards shorthand or API shape
+#     (domainList: { match: { domainWildcards: [] } })
+#
+# Zone attachment (edge.trafficPolicy.zones):
+#   configure: securityRulesets then attach_to_zone_pairs (reads zones from YAML).
+#   YAML zones list: fromZone, toZone, ruleset, optional tcpProtection (directional; no reverse pair).
+#
+# Per-object state (under configure; default is present):
+#   - Delete one ruleset:  name: My-Ruleset / state: absent
+#   - Delete one rule:     seq: 500 / state: absent
+
+SecurityPolicyObject:
+  - edge-1-sdktest:
+      securityRulesets:
+        - name: Edge-1-Security-Policy-DIA-LAN-1-TEST
+          description: Security policy for edge-1 DIA
+          implicitRuleAction: reject
+          rules:
+            - seq: 150
+              logging: true
+              match:
+                applicationBuiltin: WhatsApp
+              action: accept
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+        - name: Edge-1-Security-Policy-LAN-1-TEST-DIA
+          description: Security policy for edge-1 LAN-1-TEST to DIA
+          implicitRuleAction: reject
+          rules:
+            - seq: 150
+              logging: true
+              match:
+                applicationBuiltin: Facebook
+              action: inspect
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+              downlinkPolicerRate: 5000
+              downlinkBurstRate: 10000
+            - seq: 160
+              logging: true
+              match:
+                applicationBuiltin: WhatsApp
+              action: accept
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+            - seq: 170
+              logging: true
+              match:
+                applicationCustom: graphiant_dia_ping
+              action: reject
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+        - name: Edge-1-Security-Policy-Same-LAN-1
+          description: Security policy for edge-1 Same LAN
+          implicitRuleAction: reject
+          rules:
+            - seq: 150
+              logging: true
+              match:
+                ipProtocol: tcp
+                destinationNetwork: 10.2.1.101/32
+              action: reject
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+
+      zones:
+        - fromZone: zone-DIA
+          toZone: zone-lan-1-test
+          ruleset: Edge-1-Security-Policy-DIA-LAN-1-TEST
+          tcpProtection: false
+        - fromZone: zone-lan-1-test
+          toZone: zone-DIA
+          ruleset: Edge-1-Security-Policy-LAN-1-TEST-DIA
+          tcpProtection: false
+        - fromZone: zone-lan-1-test
+          toZone: zone-lan-1-test
+          ruleset: Edge-1-Security-Policy-Same-LAN-1
+          tcpProtection: false

--- a/ansible_collections/graphiant/naas/docs/README.md
+++ b/ansible_collections/graphiant/naas/docs/README.md
@@ -45,6 +45,8 @@ ansible-doc graphiant.naas.graphiant_sites
 ansible-doc graphiant.naas.graphiant_data_exchange
 ansible-doc graphiant.naas.graphiant_static_routes
 ansible-doc graphiant.naas.graphiant_ntp
+ansible-doc graphiant.naas.graphiant_traffic_policy
+ansible-doc graphiant.naas.graphiant_security_policy
 ansible-doc graphiant.naas.graphiant_backbone
 ansible-doc graphiant.naas.graphiant_edge_services
 ```

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -1155,6 +1155,587 @@ Read-only monitoring status per interface (`MACSEC_STATUS_SECURE`, `MACSEC_STATU
   register: lag_macsec_status
 ```
 
+## Prefix and Port Lists
+
+### Module: graphiant.naas.graphiant_prefix_port_list
+
+`graphiant_prefix_port_list` manages device-level prefix and port lists via `PUT /v1/devices/{id}/config`:
+
+- **Prefix lists** — `edge.trafficPolicy.networkLists` (named CIDR collections)
+- **Port lists** — `edge.trafficPolicy.portLists` (named port number collections)
+
+Create operations compare intended lists to live device state and skip the push when already matched. Delete operations remove only the list names listed in the YAML for each device. Check mode (`--check`) and diff mode (`--diff`) are supported — use `--check --diff` to preview `details.diff_plan` and Ansible `diff`.
+
+Use `configs/sample_prefix_and_port_list.yaml`. Top-level keys are `networkLists` and `portLists` (each a list of device entries). Under each device name, list entries use `name`, `networks` or `ports`, and optional `state: absent` on create operations to delete a single list (`list: null`) without removing other entries in the same file.
+
+**Prerequisite for:** traffic policy and security policy rules that reference custom applications often depend on edge services (DPI); prefix/port lists are used directly in policy match criteria and edge services where network/port list objects are required. Configure prefix/port lists before traffic or security policy when your design references those names.
+
+### Playbook
+
+Playbook file: `playbooks/prefix_port_list_mangement.yml` (note spelling).
+
+Tags: `create_prefix_port_lists`, `delete_prefix_port_lists`, `create_prefix_lists`, `delete_prefix_lists`, `create_port_lists`, `delete_port_lists`.
+
+```bash
+# Create prefix and port lists (dry run, then apply)
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags create_prefix_port_lists --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags create_prefix_port_lists --check --diff
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags create_prefix_port_lists
+
+# Delete prefix and port lists listed in the YAML
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags delete_prefix_port_lists --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags delete_prefix_port_lists
+
+# Prefix lists or port lists only
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags create_prefix_lists
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags delete_prefix_lists
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags create_port_lists
+ansible-playbook ansible_collections/graphiant/naas/playbooks/prefix_port_list_mangement.yml --tags delete_port_lists
+```
+
+### Module task
+
+**Create prefix and port lists:**
+
+```yaml
+- name: Create prefix and port lists
+  graphiant.naas.graphiant_prefix_port_list:
+    <<: *graphiant_client_params
+    operation: create_prefix_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: present
+  register: create_result
+  tags: ['create_prefix_port_lists']
+
+- name: Display create result
+  ansible.builtin.debug:
+    msg: |
+      {{ create_result.msg | trim }}
+      configured_devices={{ create_result.configured_devices | default([]) }}
+      skipped_devices={{ create_result.skipped_devices | default([]) }}
+  when: create_result is defined and create_result.msg is defined
+  tags: ['create_prefix_port_lists']
+```
+
+**Delete prefix and port lists** (removes every list name listed under each device in the YAML):
+
+```yaml
+- name: Delete prefix and port lists
+  graphiant.naas.graphiant_prefix_port_list:
+    <<: *graphiant_client_params
+    operation: delete_prefix_port_lists
+    prefix_port_list_config_file: "sample_prefix_and_port_list.yaml"
+    detailed_logs: true
+    state: absent
+  register: delete_result
+  tags: ['delete_prefix_port_lists']
+
+- name: Display delete result
+  ansible.builtin.debug:
+    msg: |
+      {{ delete_result.msg | trim }}
+      configured_devices={{ delete_result.configured_devices | default([]) }}
+      skipped_devices={{ delete_result.skipped_devices | default([]) }}
+  when: delete_result is defined and delete_result.msg is defined
+  tags: ['delete_prefix_port_lists']
+```
+
+**Create or delete prefix lists only** (`create_prefix_lists` / `delete_prefix_lists`) or **port lists only** (`create_port_lists` / `delete_port_lists`) — same YAML file; set `operation` accordingly and omit the other list type from the payload.
+
+### Config YAML (`configs/sample_prefix_and_port_list.yaml`)
+
+```yaml
+networkLists:
+  - edge-1-sdktest:
+    - name: graphiant_dia_prefix
+      networks:
+        - 1.1.1.1/32
+        - 8.8.8.8/32
+    - name: testing_prefix_list
+      networks:
+        - 10.1.1.0/24
+        - 10.1.2.0/24
+      state: absent          # on create_*: delete this list only (list: null)
+
+portLists:
+  - edge-1-sdktest:
+    - name: web_ports
+      ports:
+        - 80
+        - 443
+    - name: testing_port_list
+      ports:
+        - 123
+```
+
+**Per-list deletion on create** (under `create_*` operations; default is present):
+
+```yaml
+- name: old_prefix_list
+  networks:
+    - 10.0.0.0/8
+  state: absent
+```
+
+**Operations:**
+
+| Operation | Description |
+|-----------|-------------|
+| `create_prefix_port_lists` | Create or update both prefix and port lists in the YAML |
+| `delete_prefix_port_lists` | Delete all prefix and port list names listed per device |
+| `create_prefix_lists` | Create or update prefix lists only (`networkLists`) |
+| `delete_prefix_lists` | Delete listed prefix lists only |
+| `create_port_lists` | Create or update port lists only (`portLists`) |
+| `delete_port_lists` | Delete listed port lists only |
+
+When `operation` is omitted, `state: present` maps to `create_prefix_port_lists` and `state: absent` maps to `delete_prefix_port_lists`.
+
+## Traffic Policies
+
+### Module: graphiant.naas.graphiant_traffic_policy
+
+`graphiant_traffic_policy` manages device-level traffic policy rulesets and LAN segment attachments via `PUT /v1/devices/{id}/config` (`edge.trafficPolicy.trafficRulesets` and `edge.segments.<segment>.trafficRuleset`).
+
+- **Traffic rulesets** — named collections of rules with sequence numbers, match criteria (application, network/L4, DSCP), SLA class, and egress action (overlay, DIA, or IPsec circuit selection)
+- **LAN segment attachments** — map each segment name to a ruleset reference under `segments` in the YAML
+- **Rule shorthand** — match fields (`applicationBuiltin`, `ipProtocol`, `destinationNetwork`, and so on) may be listed at rule top level; the manager normalizes them to API shape on push
+- **Per-rule action** — optional `remarkCodePoint`, `primaryCircuitLabel`, and `backupCircuitLabel` (required for `dia` / `ipsec` egress when circuit labels apply)
+
+Configure-only operations require LAN segments to be attached separately (or use the `configure` tag, which runs both steps). Check mode (`--check`) is supported — nothing is pushed, and would-be payloads are logged with a `[check_mode]` prefix.
+
+Use `configs/sample_device_traffic_policies.yaml`. Top-level key is `trafficPolicyObject` (list of devices). Each device entry contains `trafficRulesets` (list of rulesets) and `segments` (map of segment name to ruleset name).
+
+**Prerequisites:** Configure prefix/port lists (`graphiant_prefix_port_list`) and edge services (DPI applications) before rules that reference `applicationCustom`. WAN circuits must exist before rules with `egress: dia` or `egress: ipsec` and circuit labels. Integration tests in `tests/test.py` run `test_configure_prefix_and_port_list` and `test_configure_edge_services` before traffic policy tests.
+
+### Playbook
+
+Tags: `configure` (configure rulesets + attach to LAN segments), `deconfigure` (detach from segments + delete rulesets), `attach_to_lan_segments`, `detach_from_lan_segments`.
+
+```bash
+# Configure (dry run, then apply)
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags configure --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags configure
+
+# Deconfigure (dry run, then apply)
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags deconfigure --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags deconfigure
+
+# Attach / detach LAN segments only
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags attach_to_lan_segments
+ansible-playbook ansible_collections/graphiant/naas/playbooks/traffic_policies_management.yml --tags detach_from_lan_segments
+```
+
+### Module task
+
+**Configure rulesets** (`configure` tag — runs configure then attach_to_lan_segments):
+
+```yaml
+- name: Configure device-level traffic policy rulesets
+  graphiant.naas.graphiant_traffic_policy:
+    <<: *graphiant_client_params
+    operation: configure
+    traffic_policy_config_file: "sample_device_traffic_policies.yaml"
+    detailed_logs: true
+    state: present
+  register: configure_result
+  tags: ['configure']
+
+- name: Display configure result
+  ansible.builtin.debug:
+    msg: |
+      {{ configure_result.msg | trim }}
+      configured_devices={{ configure_result.configured_devices | default([]) }}
+      skipped_devices={{ configure_result.skipped_devices | default([]) }}
+  when: configure_result is defined and configure_result.msg is defined
+  tags: ['configure']
+```
+
+**Attach rulesets to LAN segments** (run after `configure`, or standalone to update segment assignments):
+
+```yaml
+- name: Attach traffic ruleset to LAN segments
+  graphiant.naas.graphiant_traffic_policy:
+    <<: *graphiant_client_params
+    operation: attach_to_lan_segments
+    traffic_policy_config_file: "sample_device_traffic_policies.yaml"
+    detailed_logs: true
+  register: attach_result
+  tags: ['configure', 'attach_to_lan_segments']
+
+- name: Display attach-to-segments result
+  ansible.builtin.debug:
+    msg: |
+      {{ attach_result.msg | trim }}
+      configured_devices={{ attach_result.configured_devices | default([]) }}
+      skipped_devices={{ attach_result.skipped_devices | default([]) }}
+  when: attach_result is defined and attach_result.msg is defined
+  tags: ['configure', 'attach_to_lan_segments']
+```
+
+**Detach rulesets from LAN segments** (run before `deconfigure` to clear segment references first):
+
+```yaml
+- name: Detach traffic ruleset from LAN segments
+  graphiant.naas.graphiant_traffic_policy:
+    <<: *graphiant_client_params
+    operation: detach_from_lan_segments
+    traffic_policy_config_file: "sample_device_traffic_policies.yaml"
+    detailed_logs: true
+  register: detach_result
+  tags: ['deconfigure', 'detach_from_lan_segments']
+
+- name: Display detach-from-segments result
+  ansible.builtin.debug:
+    msg: |
+      {{ detach_result.msg | trim }}
+      configured_devices={{ detach_result.configured_devices | default([]) }}
+      skipped_devices={{ detach_result.skipped_devices | default([]) }}
+  when: detach_result is defined and detach_result.msg is defined
+  tags: ['deconfigure', 'detach_from_lan_segments']
+```
+
+**Deconfigure rulesets** (run after `detach_from_lan_segments` — removes rulesets listed in the YAML):
+
+```yaml
+- name: Deconfigure device-level traffic policy rulesets
+  graphiant.naas.graphiant_traffic_policy:
+    <<: *graphiant_client_params
+    operation: deconfigure
+    traffic_policy_config_file: "sample_device_traffic_policies.yaml"
+    detailed_logs: true
+    state: absent
+  register: deconfigure_result
+  tags: ['deconfigure']
+
+- name: Display deconfigure result
+  ansible.builtin.debug:
+    msg: |
+      {{ deconfigure_result.msg | trim }}
+      configured_devices={{ deconfigure_result.configured_devices | default([]) }}
+      skipped_devices={{ deconfigure_result.skipped_devices | default([]) }}
+  when: deconfigure_result is defined and deconfigure_result.msg is defined
+  tags: ['deconfigure']
+```
+
+### Config YAML (`configs/sample_device_traffic_policies.yaml`)
+
+```yaml
+trafficPolicyObject:
+  - edge-1-sdktest:
+      trafficRulesets:
+        - name: Edge-1-Traffic-Policy
+          description: Application and network steering
+          rules:
+            - seq: 1
+              applicationBuiltin: Office 365
+              logging: true
+              slaClass: Gold                    # Default | Bronze | Silver | Gold
+              egress: overlay                   # overlay | dia | ipsec
+
+            - seq: 200
+              ipProtocol: udp                   # any | icmp | igmp | tcp | udp | esp | ah
+              destinationPort: 53
+              destinationNetwork: 0.0.0.0/0
+              logging: true
+              slaClass: Silver
+              egress: dia
+              primaryCircuitLabel: internet_dia_2   # required for dia egress
+
+            - seq: 300
+              applicationCustom: graphiant_dia_ping   # requires DPI app from edge_services
+              logging: true
+              slaClass: Gold
+              egress: ipsec
+              primaryCircuitLabel:
+                ipsecLabel: ipsec_label_1
+              backupCircuitLabel:
+                ipsecLabel: ipsec_label_2
+
+        - name: Edge-2-Traffic-Policy
+          description: Catch-all and remark example
+          rules:
+            - seq: 2000
+              sourceNetwork: 10.10.10.0/24
+              destinationNetwork: 20.20.20.0/24
+              dscpCodePoint: 1                      # match DSCP 0-63
+              logging: true
+              slaClass: Default
+              remarkCodePoint: 3                    # remark DSCP 0-63
+              egress: dia
+              primaryCircuitLabel: internet_dia_2
+
+      segments:
+        lan-1-test: Edge-2-Traffic-Policy          # segment name -> ruleset name
+```
+
+**Per-object deletion** (under `configure`; `state: absent` targets individual objects):
+
+```yaml
+# Delete one ruleset by name
+- name: My-Ruleset
+  state: absent
+
+# Delete one rule by seq (only seq required)
+- seq: 500
+  state: absent
+```
+
+**Required rule fields:**
+
+| Field | Description |
+|-------|-------------|
+| `seq` | Rule sequence number (unique within the ruleset) |
+| `logging` | `true` or `false` |
+| `slaClass` | `Default`, `Bronze`, `Silver`, or `Gold` |
+| `egress` | `overlay`, `dia`, or `ipsec` |
+
+**Optional match fields** (rule shorthand — may appear at rule top level):
+
+| Key | Description |
+|-----|-------------|
+| `applicationBuiltin` | Portal built-in application name |
+| `applicationCustom` | Custom DPI application name (configure via `graphiant_edge_services` first) |
+| `ipProtocol` | `any`, `icmp`, `igmp`, `tcp`, `udp`, `esp`, `ah` |
+| `sourceNetwork` / `destinationNetwork` | CIDR string |
+| `sourcePort` / `destinationPort` | Port number 1–65535 (meaningful for `tcp` / `udp`) |
+| `dscpCodePoint` | DSCP match value 0–63 |
+| `icmpType` | ICMP type when `ipProtocol` is `icmp` (see sample YAML comments for values) |
+
+**Optional action / egress fields:**
+
+| Key | Description |
+|-----|-------------|
+| `primaryCircuitLabel` | DIA circuit label string, or `{ipsecLabel: ...}` for IPsec |
+| `backupCircuitLabel` | Optional backup circuit (same shapes as primary) |
+| `remarkCodePoint` | DSCP remark value 0–63 |
+
+For `egress: overlay`, circuit labels are usually omitted. For `egress: dia`, set `primaryCircuitLabel` to an existing WAN circuit label. For `egress: ipsec`, use `ipsecLabel` objects under the circuit label fields.
+
+## Security Policies
+
+### Module: graphiant.naas.graphiant_security_policy
+
+`graphiant_security_policy` manages device-level security policy rulesets and zone pair attachments via `PUT /v1/devices/{id}/config` (`edge.trafficPolicy.securityRulesets` and `edge.trafficPolicy.zones`).
+
+- **Security rulesets** — named collections of rules with sequence numbers, actions (`accept`, `reject`, `inspect`, `drop`), and match criteria (application, network/L4, content filter, domain list)
+- **Zone pair attachments** — directional pairs (fromZone → toZone) that reference a named ruleset; optional `tcpProtection` flag per pair
+- **Meter rates** — per-rule uplink/downlink policing rates (`uplinkPolicerRate`, `uplinkBurstRate`, `downlinkPolicerRate`, `downlinkBurstRate`)
+- **Implicit rule action** — `implicitRuleAction` on the ruleset controls the default action for unmatched traffic (`accept` or `reject`)
+
+Configure-only operations require zone pairs to be attached separately (or use the `configure` tag which runs both steps). Check mode (`--check`) is supported — nothing is pushed, and would-be payloads are logged with a `[check_mode]` prefix.
+
+**Match type constraint:** Each rule uses one primary match type — application **or** network/L4, not both. Combining `applicationBuiltin` / `applicationCustom` with `ipProtocol`, `sourceNetwork`, `destinationNetwork`, or ports in the same rule is rejected at validation. You also cannot switch match type on an existing rule; delete it (`state: absent`) and add a new rule with the desired match type.
+
+Use `configs/sample_device_security_policies.yaml`. Top-level key is `SecurityPolicyObject` (list of devices). Each device entry contains `securityRulesets` (list of rulesets) and `zones` (list of zone pairs).
+
+**Prerequisites:** Configure prefix/port lists (`graphiant_prefix_port_list`) and edge services (DPI applications) before rules that reference `applicationCustom`. Integration tests in `tests/test.py` run `test_configure_prefix_and_port_list` and `test_configure_edge_services` before security policy tests.
+
+### Playbook
+
+Tags: `configure` (configure rulesets + attach zone pairs), `deconfigure` (detach zone pairs + delete rulesets), `attach_to_zone_pairs`, `detach_from_zone_pairs`.
+
+```bash
+# Configure (dry run, then apply)
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags configure --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags configure
+
+# Deconfigure (dry run, then apply)
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags deconfigure --check
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags deconfigure
+
+# Attach / detach zone pairs only
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags attach_to_zone_pairs
+ansible-playbook ansible_collections/graphiant/naas/playbooks/security_policies_management.yml --tags detach_from_zone_pairs
+```
+
+### Module task
+
+**Configure rulesets** (`configure` tag — runs configure then attach_to_zone_pairs):
+
+```yaml
+- name: Configure device-level security policy rulesets
+  graphiant.naas.graphiant_security_policy:
+    <<: *graphiant_client_params
+    operation: configure
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    detailed_logs: true
+    state: present
+  register: configure_result
+  tags: ['configure']
+
+- name: Display configure result
+  ansible.builtin.debug:
+    msg: |
+      {{ configure_result.msg | trim }}
+      configured_devices={{ configure_result.configured_devices | default([]) }}
+      skipped_devices={{ configure_result.skipped_devices | default([]) }}
+  when: configure_result is defined and configure_result.msg is defined
+  tags: ['configure']
+```
+
+**Attach rulesets to zone pairs** (run after `configure`, or standalone to update zone assignments):
+
+```yaml
+- name: Attach security ruleset to zone pairs
+  graphiant.naas.graphiant_security_policy:
+    <<: *graphiant_client_params
+    operation: attach_to_zone_pairs
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    detailed_logs: true
+  register: attach_result
+  tags: ['configure', 'attach_to_zone_pairs']
+
+- name: Display attach-to-zone-pairs result
+  ansible.builtin.debug:
+    msg: |
+      {{ attach_result.msg | trim }}
+      configured_devices={{ attach_result.configured_devices | default([]) }}
+      skipped_devices={{ attach_result.skipped_devices | default([]) }}
+  when: attach_result is defined and attach_result.msg is defined
+  tags: ['configure', 'attach_to_zone_pairs']
+```
+
+**Detach rulesets from zone pairs** (run before `deconfigure` to clear zone references first):
+
+```yaml
+- name: Detach security ruleset from zone pairs
+  graphiant.naas.graphiant_security_policy:
+    <<: *graphiant_client_params
+    operation: detach_from_zone_pairs
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    detailed_logs: true
+  register: detach_result
+  tags: ['deconfigure', 'detach_from_zone_pairs']
+
+- name: Display detach-from-zone-pairs result
+  ansible.builtin.debug:
+    msg: |
+      {{ detach_result.msg | trim }}
+      configured_devices={{ detach_result.configured_devices | default([]) }}
+      skipped_devices={{ detach_result.skipped_devices | default([]) }}
+  when: detach_result is defined and detach_result.msg is defined
+  tags: ['deconfigure', 'detach_from_zone_pairs']
+```
+
+**Deconfigure rulesets** (run after `detach_from_zone_pairs` — removes rulesets listed in the YAML):
+
+```yaml
+- name: Deconfigure device-level security policy rulesets
+  graphiant.naas.graphiant_security_policy:
+    <<: *graphiant_client_params
+    operation: deconfigure
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    detailed_logs: true
+    state: absent
+  register: deconfigure_result
+  tags: ['deconfigure']
+
+- name: Display deconfigure result
+  ansible.builtin.debug:
+    msg: |
+      {{ deconfigure_result.msg | trim }}
+      configured_devices={{ deconfigure_result.configured_devices | default([]) }}
+      skipped_devices={{ deconfigure_result.skipped_devices | default([]) }}
+  when: deconfigure_result is defined and deconfigure_result.msg is defined
+  tags: ['deconfigure']
+```
+
+### Config YAML (`configs/sample_device_security_policies.yaml`)
+
+```yaml
+SecurityPolicyObject:
+  - edge-1-sdktest:
+      securityRulesets:
+        - name: Edge-1-Security-Policy-DIA-LAN-1
+          description: Security policy for DIA to LAN-1 traffic
+          implicitRuleAction: reject     # accept | reject (default for unmatched traffic)
+          rules:
+            - seq: 150
+              logging: true
+              match:
+                applicationBuiltin: WhatsApp    # built-in application match
+              action: accept                    # accept | reject | inspect | drop
+              uplinkPolicerRate: 5000           # kbps; optional meter rates
+              uplinkBurstRate: 10000
+
+        - name: Edge-1-Security-Policy-LAN-1-DIA
+          description: Security policy for LAN-1 to DIA traffic
+          implicitRuleAction: reject
+          rules:
+            - seq: 150
+              logging: true
+              match:
+                applicationCustom: graphiant_dia_ping   # custom application
+              action: reject
+            - seq: 160
+              logging: true
+              match:
+                ipProtocol: tcp                          # any | icmp | igmp | tcp | udp | esp | ah
+                destinationNetwork: 10.2.1.101/32        # CIDR string
+              action: reject
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+            - seq: 170
+              logging: true
+              match:
+                applicationBuiltin: Facebook
+              action: inspect                            # DPI / threat inspection
+              uplinkPolicerRate: 5000
+              uplinkBurstRate: 10000
+              downlinkPolicerRate: 5000
+              downlinkBurstRate: 10000
+
+      zones:
+        - fromZone: zone-DIA
+          toZone: zone-lan-1
+          ruleset: Edge-1-Security-Policy-DIA-LAN-1
+          tcpProtection: false          # optional; defaults to false
+        - fromZone: zone-lan-1
+          toZone: zone-DIA
+          ruleset: Edge-1-Security-Policy-LAN-1-DIA
+          tcpProtection: false
+```
+
+**Per-object deletion** (under `configure`; `state: absent` targets individual objects):
+
+```yaml
+# Delete one ruleset by name
+- name: My-Ruleset
+  state: absent
+
+# Delete one rule by seq
+- seq: 500
+  state: absent
+```
+
+**Rule actions** (per rule; normalized to lowercase on push):
+
+| Value | Description |
+|-------|-------------|
+| `accept` | Allow matching traffic |
+| `reject` | Deny matching traffic |
+| `inspect` | Allow and inspect matching traffic (DPI / threat inspection) |
+| `drop` | Silently deny matching traffic |
+
+`implicitRuleAction` on the ruleset (catch-all for unmatched traffic) accepts only `accept` or `reject`.
+
+**Match type reference:**
+
+| Key | Description |
+|-----|-------------|
+| `applicationBuiltin` | Portal built-in application name |
+| `applicationCustom` | Custom application name |
+| `ipProtocol` | `any`, `icmp`, `igmp`, `tcp`, `udp`, `esp`, `ah` |
+| `sourceNetwork` | CIDR string (e.g. `10.0.0.0/8`) |
+| `destinationNetwork` | CIDR string |
+| `sourcePort` | Port number 1–65535 |
+| `destinationPort` | Port number 1–65535 |
+| `contentFilter` | `domainCategoryIds` shorthand or full API shape |
+| `domainList` | `domainWildcards` shorthand or full API shape |
+
+Use exactly one primary match type per rule: **application** (`applicationBuiltin` / `applicationCustom`) **or** **network/L4** (`ipProtocol`, `sourceNetwork`, `destinationNetwork`, ports). Do not combine both in the same rule. You cannot switch match type on an existing rule — delete it (`state: absent`) and create a new rule with the desired type.
+
 ## BGP Configuration
 
 ```yaml
@@ -2134,6 +2715,9 @@ Sample configuration files are in the `configs/` directory:
 | `sample_static_route.yaml` | Static routes under edge segments |
 | `sample_macsec.yaml` | Interface MACsec (802.1AE) on ethernet or LAG main interfaces |
 | `sample_edge_services.yaml` | Edge services (DHCP, DNS, LLDP, LWS password) |
+| `sample_prefix_and_port_list.yaml` | Device-level prefix lists (`networkLists`) and port lists (`portLists`) under `edge.trafficPolicy` |
+| `sample_device_traffic_policies.yaml` | Device-level traffic policy rulesets and LAN segment attachments |
+| `sample_device_security_policies.yaml` | Device-level security policy rulesets and zone pair attachments |
 
 Data Exchange configs are in `configs/de_workflows_configs/`.
 

--- a/ansible_collections/graphiant/naas/playbooks/security_policies_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/security_policies_management.yml
@@ -1,0 +1,100 @@
+---
+# Manage device-level security policy rulesets and zone pair attachments.
+#
+# Tags:
+#   configure     — configure rulesets, then attach zone pairs (full apply)
+#   deconfigure   — detach zone pairs, then delete listed rulesets (full teardown)
+#   attach_to_zone_pairs / detach_from_zone_pairs — zone pair attach/detach only
+#
+# Rule match type: application and network/L4 are mutually exclusive (one per rule).
+# You cannot switch application <-> network/L4 on an existing rule.
+# Delete the rule (state: absent in YAML) and add a new rule with the desired match.
+#
+# Example:
+#   ansible-playbook security_policies_management.yml --tags configure
+#   ansible-playbook security_policies_management.yml --tags deconfigure
+#
+- name: Manage Graphiant Device-level Security Policy Configuration
+  hosts: localhost
+  gather_facts: false
+  vars:
+    graphiant_client_params: &graphiant_client_params
+      host: "{{ graphiant_host | default(lookup('env', 'GRAPHIANT_HOST')) }}"
+      username: "{{ graphiant_username | default(lookup('env', 'GRAPHIANT_USERNAME')) }}"
+      password: "{{ graphiant_password | default(lookup('env', 'GRAPHIANT_PASSWORD')) }}"
+      access_token: "{{ graphiant_access_token | default(lookup('env', 'GRAPHIANT_ACCESS_TOKEN')) }}"
+
+  tasks:
+    - name: Configure device-level security policy rulesets (edge.trafficPolicy)
+      graphiant.naas.graphiant_security_policy:
+        <<: *graphiant_client_params
+        operation: configure
+        security_policy_config_file: "sample_device_security_policies.yaml"
+        detailed_logs: true
+        state: present
+      register: configure_result
+      tags: ['configure']
+
+    - name: Display configure result message
+      ansible.builtin.debug:
+        msg:
+          - "{{ configure_result.msg }}"
+          - "configured_devices={{ configure_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ configure_result.skipped_devices | default([]) }}"
+      when: configure_result is defined and configure_result.msg is defined
+      tags: ['configure']
+
+    - name: Attach security ruleset to zone pairs (part of configure workflow)
+      graphiant.naas.graphiant_security_policy:
+        <<: *graphiant_client_params
+        operation: attach_to_zone_pairs
+        security_policy_config_file: "sample_device_security_policies.yaml"
+        detailed_logs: true
+      register: attach_zone_pairs_result
+      tags: ['configure', 'attach_to_zone_pairs']
+
+    - name: Display attach-to-zone-pairs result
+      ansible.builtin.debug:
+        msg:
+          - "{{ attach_zone_pairs_result.msg }}"
+          - "configured_devices={{ attach_zone_pairs_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ attach_zone_pairs_result.skipped_devices | default([]) }}"
+      when: attach_zone_pairs_result is defined and attach_zone_pairs_result.msg is defined
+      tags: ['configure', 'attach_to_zone_pairs']
+
+    - name: Detach security ruleset from zone pairs (part of deconfigure workflow)
+      graphiant.naas.graphiant_security_policy:
+        <<: *graphiant_client_params
+        operation: detach_from_zone_pairs
+        security_policy_config_file: "sample_device_security_policies.yaml"
+        detailed_logs: true
+      register: detach_zone_pairs_result
+      tags: ['deconfigure', 'detach_from_zone_pairs']
+
+    - name: Display detach-from-zone-pairs result
+      ansible.builtin.debug:
+        msg:
+          - "{{ detach_zone_pairs_result.msg }}"
+          - "configured_devices={{ detach_zone_pairs_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ detach_zone_pairs_result.skipped_devices | default([]) }}"
+      when: detach_zone_pairs_result is defined and detach_zone_pairs_result.msg is defined
+      tags: ['deconfigure', 'detach_from_zone_pairs']
+
+    - name: Deconfigure device-level security policy rulesets (after zone pair detach)
+      graphiant.naas.graphiant_security_policy:
+        <<: *graphiant_client_params
+        operation: deconfigure
+        security_policy_config_file: "sample_device_security_policies.yaml"
+        detailed_logs: true
+        state: absent
+      register: deconfigure_result
+      tags: ['deconfigure']
+
+    - name: Display deconfigure result message
+      ansible.builtin.debug:
+        msg:
+          - "{{ deconfigure_result.msg }}"
+          - "configured_devices={{ deconfigure_result.configured_devices | default([]) }}"
+          - "skipped_devices={{ deconfigure_result.skipped_devices | default([]) }}"
+      when: deconfigure_result is defined and deconfigure_result.msg is defined
+      tags: ['deconfigure']

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
@@ -18,6 +18,7 @@ from .site_to_site_vpn_manager import SiteToSiteVpnManager
 from .static_routes_manager import StaticRoutesManager
 from .ntp_manager import NtpManager
 from .traffic_policy_manager import TrafficPolicyManager
+from .security_policy_manager import SecurityPolicyManager
 from .device_system_manager import DeviceSystemManager
 from .edge_services_manager import EdgeServicesManager
 from .prefix_and_port_list import PrefixAndPortListManager
@@ -89,6 +90,7 @@ class GraphiantConfig:
             self.static_routes = StaticRoutesManager(self.config_utils)
             self.ntp = NtpManager(self.config_utils)
             self.traffic_policy = TrafficPolicyManager(self.config_utils)
+            self.security_policy = SecurityPolicyManager(self.config_utils)
             self.device_system = DeviceSystemManager(self.config_utils)
             self.edge_services = EdgeServicesManager(self.config_utils)
             self.prefix_port_list = PrefixAndPortListManager(self.config_utils)
@@ -122,6 +124,7 @@ class GraphiantConfig:
             "static_routes": hasattr(self, "static_routes") and self.static_routes is not None,
             "ntp": hasattr(self, "ntp") and self.ntp is not None,
             "traffic_policy": hasattr(self, "traffic_policy") and self.traffic_policy is not None,
+            "security_policy": hasattr(self, "security_policy") and self.security_policy is not None,
             "device_system": hasattr(self, "device_system") and self.device_system is not None,
             "edge_services": hasattr(self, "edge_services") and self.edge_services is not None,
             "prefix_port_list": hasattr(self, "prefix_port_list") and self.prefix_port_list is not None,

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/security_policy_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/security_policy_manager.py
@@ -1,0 +1,1547 @@
+"""
+Security Policy Manager for Graphiant Playbooks.
+
+Manages device-level security policy objects under:
+  edge.trafficPolicy.securityRulesets
+  edge.trafficPolicy.zones
+- Build raw device-config payload in Python from a structured YAML file
+- Idempotency: compare intended rulesets to current device state; skip push when already matched
+- Deconfigure: delete only the rulesets listed in the YAML by setting ruleset=null per key
+- Per-object state in YAML: ruleset or rule ``state: absent`` sends ``ruleset: null`` or ``rule: null``
+  under ``configure``
+- Rule match type (application vs network/L4) is mutually exclusive — one primary match per rule.
+  Combining application and network/L4 keys in the same rule raises a validation error.
+  Match type cannot be changed in place on the device API; delete the rule (``state: absent``)
+  and add a new rule with the desired match criteria.
+
+Zone association (directional zone pair ruleset reference):
+  edge.trafficPolicy.zones.<fromZone>.zone.pairs.<toZone>.pair
+- attach_to_zone_pairs / detach_from_zone_pairs read ``zones`` from YAML
+- Configure workflow: ``configure`` (rulesets) then ``attach_to_zone_pairs`` (zones)
+- Deconfigure workflow: ``detach_from_zone_pairs`` (zones) then ``deconfigure`` (rulesets)
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from .base_manager import BaseManager
+from .device_config_common import (
+    as_dict,
+    fetch_device_by_name,
+    load_device_list_yaml_config,
+    new_apply_result,
+    push_device_config_raw,
+    unwrap_device,
+)
+from .logger import setup_logger
+from .exceptions import ConfigurationError
+
+LOG = setup_logger()
+
+SECURITY_POLICY_KEYS = ("trafficPolicy", "traffic_policy", "securityPolicy", "security_policy")
+EDGE_POLICY_KEY = "trafficPolicy"
+SECURITY_RULESETS_KEYS = ("securityRulesets", "security_rulesets")
+RULESET_REF_KEYS = ("ruleset", "name", "rulesetName", "ruleset_name", "id")
+WRAPPER_KEYS = ("match", "val")
+FIELD_ALIASES = {
+    "match": ("val",),
+    "codePoint": (
+        "code_point",
+        "value",
+        "dscpCodePoint",
+        "dscp_code_point",
+        "remarkCodePoint",
+        "remark_code_point",
+    ),
+    "setSlaClass": ("slaClass", "sla_class", "set_sla_class"),
+    "primaryCircuitLabel": ("primary_circuit_label",),
+    "backupCircuitLabel": ("backup_circuit_label",),
+    "dscp": ("dscpCodePoint", "dscp_code_point"),
+    "remark": ("remarkCodePoint", "remark_code_point"),
+    "destinationNetwork": ("destination_network",),
+    "sourceNetwork": ("source_network",),
+    "ipProtocol": ("ip_protocol", "protocol"),
+    "icmpType": ("icmp_type",),
+}
+OMITTED_DEFAULTS = {
+    "icmpType": 0,
+    "logging": False,
+}
+# Fields sent on config PUT but omitted from device GET responses.
+GET_COMPARE_SKIP_KEYS = frozenset(
+    {
+        "implicitRuleAction",
+        "globalId",
+        "isGlobalSync",
+        "id",
+        "index",
+        "status",
+        "errorMessage",
+    }
+)
+METER_RATE_FIELDS = (
+    "uplinkPolicerRate",
+    "uplinkBurstRate",
+    "downlinkPolicerRate",
+    "downlinkBurstRate",
+)
+_METER_RATE_FIELDS_SET = frozenset(METER_RATE_FIELDS)
+_APPLICATION_MATCH_INPUT_KEYS = frozenset(
+    {
+        "application",
+        "applicationBuiltin",
+        "application_builtin",
+        "applicationCustom",
+        "application_custom",
+    }
+)
+_NETWORK_MATCH_INPUT_KEYS = frozenset(
+    {
+        "destinationNetwork",
+        "destination_network",
+        "sourceNetwork",
+        "source_network",
+        "sourcePort",
+        "destinationPort",
+        "ipProtocol",
+        "ip_protocol",
+        "protocol",
+        "icmpType",
+    }
+)
+_STATE_CHOICES = frozenset({"present", "absent"})
+_LOG_PREFIX = "[security-policy]"
+_YAML_KEY = "SecurityPolicyObject"
+
+
+class SecurityPolicyManager(BaseManager):
+    """
+    Manage security policy rulesets and LAN-segment ruleset references via raw device-config payloads.
+    """
+
+    @classmethod
+    def _device_dict(cls, device_info_dict: Any) -> Dict[str, Any]:
+        return unwrap_device(as_dict(device_info_dict))
+
+    @staticmethod
+    def _validate_device_cfg(device_name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(cfg, dict):
+            raise ConfigurationError(f"Device '{device_name}' config must be a dict")
+        return cfg
+
+    def _load_devices(self, config_yaml_file: str) -> Dict[str, Dict[str, Any]]:
+        return load_device_list_yaml_config(
+            _YAML_KEY,
+            config_yaml_file,
+            None,
+            self.render_config_file,
+            missing_input_error="security_policy_config_file is required.",
+            build_row_from_params=lambda _mp: {},
+            validate_device_cfg=self._validate_device_cfg,
+        )
+
+    @staticmethod
+    def _first_present(mapping: Dict[str, Any], keys: Tuple[str, ...]) -> Any:
+        if not isinstance(mapping, dict):
+            return None
+        for key in keys:
+            if key in mapping:
+                return mapping.get(key)
+        return None
+
+    @staticmethod
+    def _existing_value_for_key(mapping: Dict[str, Any], key: str) -> Tuple[bool, Any]:
+        if not isinstance(mapping, dict):
+            return False, None
+        if key in mapping:
+            return True, mapping.get(key)
+        for alias in FIELD_ALIASES.get(key, ()):
+            if alias in mapping:
+                return True, mapping.get(alias)
+        return False, None
+
+    @staticmethod
+    def _matches_omitted_default(key: str, desired_value: Any, existing_value: Any = None) -> bool:
+        if key not in OMITTED_DEFAULTS:
+            return False
+        return desired_value == OMITTED_DEFAULTS[key] and existing_value is None
+
+    @classmethod
+    def _normalize(cls, obj: Any) -> Any:
+        """Stable JSON-comparable structure for diffing (dict key order normalized)."""
+        if obj is None:
+            return None
+        if hasattr(obj, "to_dict"):
+            try:
+                return cls._normalize(obj.to_dict())
+            except Exception:
+                pass
+        if isinstance(obj, dict):
+            return {str(k): cls._normalize(v) for k, v in sorted(obj.items(), key=lambda kv: str(kv[0]))}
+        if isinstance(obj, list):
+            return [cls._normalize(v) for v in obj]
+        if isinstance(obj, (str, int, float, bool)):
+            return obj
+        return str(obj)
+
+    @classmethod
+    def _is_effectively_null(cls, obj: Any) -> bool:
+        if obj is None:
+            return True
+        if isinstance(obj, dict):
+            return all(cls._is_effectively_null(v) for v in obj.values())
+        return False
+
+    @classmethod
+    def _single_leaf_value(cls, obj: Any) -> Tuple[bool, Any]:
+        if not isinstance(obj, dict):
+            return True, obj
+        if len(obj) != 1:
+            return False, None
+        value = next(iter(obj.values()))
+        return cls._single_leaf_value(value)
+
+    @classmethod
+    def _desired_matches_existing(cls, desired: Any, existing: Any) -> bool:
+        """
+        Compare desired config as a subset of existing device state.
+
+        The API may add defaults or omit null-valued fields. Idempotency should only
+        fail when a field explicitly set by the YAML differs in current state.
+        """
+        if isinstance(desired, dict):
+            if not isinstance(existing, dict):
+                if cls._is_effectively_null(desired) and existing is None:
+                    return True
+                has_single_leaf, leaf_value = cls._single_leaf_value(desired)
+                return has_single_leaf and cls._normalize(leaf_value) == cls._normalize(existing)
+            for key, desired_value in desired.items():
+                found, existing_value = cls._existing_value_for_key(existing, key)
+                if not found:
+                    if key in WRAPPER_KEYS and cls._desired_matches_existing(desired_value, existing):
+                        continue
+                    if cls._matches_omitted_default(key, desired_value):
+                        continue
+                    if cls._is_effectively_null(desired_value):
+                        continue
+                    if cls._meter_rate_omitted_on_get(key):
+                        continue
+                    return False
+                if cls._matches_omitted_default(key, desired_value, existing_value):
+                    continue
+                if key == "action" and cls._actions_equivalent_for_compare(desired_value, existing_value):
+                    continue
+                if not cls._desired_matches_existing(desired_value, existing_value):
+                    return False
+            return True
+
+        if isinstance(desired, list):
+            return cls._normalize(desired) == cls._normalize(existing)
+
+        return cls._normalize(desired) == cls._normalize(existing)
+
+    @classmethod
+    def _first_mismatch_path(cls, desired: Any, existing: Any, path: str = "") -> Optional[str]:
+        if isinstance(desired, dict):
+            if not isinstance(existing, dict):
+                if cls._is_effectively_null(desired) and existing is None:
+                    return None
+                has_single_leaf, leaf_value = cls._single_leaf_value(desired)
+                if has_single_leaf and cls._normalize(leaf_value) == cls._normalize(existing):
+                    return None
+                return path or "<root>"
+            for key, desired_value in desired.items():
+                child_path = f"{path}.{key}" if path else str(key)
+                found, existing_value = cls._existing_value_for_key(existing, key)
+                if not found:
+                    if key in WRAPPER_KEYS and cls._desired_matches_existing(desired_value, existing):
+                        continue
+                    if cls._matches_omitted_default(key, desired_value):
+                        continue
+                    if cls._is_effectively_null(desired_value):
+                        continue
+                    if cls._meter_rate_omitted_on_get(key):
+                        continue
+                    return child_path
+                if cls._matches_omitted_default(key, desired_value, existing_value):
+                    continue
+                if key == "action" and cls._actions_equivalent_for_compare(desired_value, existing_value):
+                    continue
+                mismatch = cls._first_mismatch_path(desired_value, existing_value, child_path)
+                if mismatch:
+                    return mismatch
+            return None
+
+        if isinstance(desired, list):
+            return None if cls._normalize(desired) == cls._normalize(existing) else path or "<root>"
+
+        return None if cls._normalize(desired) == cls._normalize(existing) else path or "<root>"
+
+    @staticmethod
+    def _value_at_path(obj: Any, path: Optional[str]) -> Any:
+        if not path or path == "<root>":
+            return obj
+        cur = obj
+        for part in path.split("."):
+            if not isinstance(cur, dict):
+                return None
+            cur = cur.get(part)
+        return cur
+
+    @staticmethod
+    def _parent_path(path: Optional[str]) -> Optional[str]:
+        if not path or path == "<root>" or "." not in path:
+            return None
+        return path.rsplit(".", 1)[0]
+
+    def _traffic_policy_from_device(self, device_info_dict: Any) -> Dict[str, Any]:
+        """Merge ``trafficPolicy`` from device GET (``device`` or ``device.edge``)."""
+        d = self._device_dict(device_info_dict)
+        edge = as_dict(d.get("edge"))
+        merged: Dict[str, Any] = {}
+        for container in (edge, d):
+            tp = as_dict(self._first_present(container, SECURITY_POLICY_KEYS))
+            if tp:
+                merged.update(tp)
+        return merged
+
+    def _extract_rulesets_from_device(self, device_info_dict: Any) -> Dict[str, Any]:
+        tp = self._traffic_policy_from_device(device_info_dict)
+        rs = self._first_present(tp, SECURITY_RULESETS_KEYS)
+        if rs is not None:
+            return self._coerce_rulesets_map(rs)
+        return {}
+
+    @classmethod
+    def _normalize_meter_rate_for_compare(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            rate = value.get("rate")
+            if rate is not None and set(value.keys()) <= {"rate"}:
+                return rate
+        return value
+
+    @classmethod
+    def _normalize_action_for_compare(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            inner = value.get("action")
+            if inner is not None:
+                return str(inner).strip().lower()
+            if len(value) == 1:
+                only = next(iter(value.values()))
+                if isinstance(only, str):
+                    return only.strip().lower()
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            return normalized if normalized else None
+        return value
+
+    @classmethod
+    def _actions_equivalent_for_compare(cls, desired: Any, existing: Any) -> bool:
+        desired_action = cls._normalize_action_for_compare(desired)
+        existing_action = cls._normalize_action_for_compare(existing)
+        if desired_action == existing_action:
+            return True
+        # Device GET may return reject when YAML requests drop (silent deny).
+        return desired_action == "drop" and existing_action == "reject"
+
+    @classmethod
+    def _meter_rate_omitted_on_get(cls, key: str) -> bool:
+        """
+        Meter policer/burst rates are sent on PUT but are often omitted from rule GET
+        responses (including drop/reject rules and downlink rates that mirror uplink).
+        """
+        return key in _METER_RATE_FIELDS_SET
+
+    @classmethod
+    def _normalize_match_for_compare(cls, match: Any) -> Any:
+        if not isinstance(match, dict):
+            return match
+        out = dict(match)
+        ip_proto = out.get("ipProtocol")
+        if ip_proto is None:
+            ip_proto = out.get("ip_protocol")
+        protocol = out.get("protocol")
+        if ip_proto is None and isinstance(protocol, dict):
+            nested = protocol.get("ipProtocol")
+            if nested is None:
+                nested = protocol.get("ip_protocol")
+            if nested is not None:
+                ip_proto = nested
+        if ip_proto is not None:
+            out["ipProtocol"] = str(ip_proto).strip().lower()
+        out.pop("ip_protocol", None)
+        # PUT normalization adds protocol.ipProtocol; GET often returns ipProtocol only.
+        out.pop("protocol", None)
+        return out
+
+    @classmethod
+    def _normalize_rule_for_compare(cls, rule: Any) -> Any:
+        if not isinstance(rule, dict):
+            return rule
+        out = dict(rule)
+        for field in METER_RATE_FIELDS:
+            if field in out:
+                out[field] = cls._normalize_meter_rate_for_compare(out[field])
+        if "action" in out:
+            normalized_action = cls._normalize_action_for_compare(out["action"])
+            if normalized_action is not None:
+                out["action"] = normalized_action
+        if isinstance(out.get("match"), dict):
+            out["match"] = cls._normalize_match_for_compare(out["match"])
+        return out
+
+    def _find_existing_ruleset_entry(self, existing_rs: Dict[str, Any], rs_id: str) -> Any:
+        if not isinstance(existing_rs, dict):
+            return None
+        if rs_id in existing_rs:
+            return existing_rs[rs_id]
+        for key, entry in existing_rs.items():
+            if str(key).endswith(f"-{rs_id}"):
+                return entry
+        for entry in existing_rs.values():
+            body = self._existing_ruleset_from_entry(entry)
+            name = (body or {}).get("name") if isinstance(body, dict) else None
+            if name and self._ruleset_refs_match(rs_id, name):
+                return entry
+        return None
+
+    def _ruleset_metadata_matches(self, desired_ruleset: Dict[str, Any], existing_ruleset: Any) -> bool:
+        desired_meta = {k: v for k, v in desired_ruleset.items() if k != "rules" and k not in GET_COMPARE_SKIP_KEYS}
+        existing_meta = {
+            k: v for k, v in (existing_ruleset or {}).items() if k != "rules" and k not in GET_COMPARE_SKIP_KEYS
+        }
+        desired_name = desired_ruleset.get("name")
+        if desired_name is not None:
+            existing_name = (existing_ruleset or {}).get("name")
+            if not self._ruleset_refs_match(desired_name, existing_name):
+                return False
+        desired_meta.pop("name", None)
+        existing_meta.pop("name", None)
+        return self._desired_matches_existing(desired_meta, existing_meta)
+
+    @staticmethod
+    def _ruleset_name_from_entry(entry: Any) -> Optional[str]:
+        if not isinstance(entry, dict):
+            return None
+        ruleset_body = entry.get("ruleset")
+        if isinstance(ruleset_body, dict):
+            ruleset: Dict[str, Any] = ruleset_body
+        else:
+            ruleset = entry
+        name = SecurityPolicyManager._first_present(ruleset, RULESET_REF_KEYS) or entry.get("name")
+        return str(name).strip() if name else None
+
+    @staticmethod
+    def _coerce_rulesets_map(rulesets: Any) -> Dict[str, Any]:
+        if not rulesets:
+            return {}
+
+        if isinstance(rulesets, dict):
+            mapped: Dict[str, Any] = dict(rulesets)
+            for key, entry in rulesets.items():
+                name = SecurityPolicyManager._ruleset_name_from_entry(entry)
+                if name:
+                    mapped.setdefault(name, entry)
+                elif isinstance(key, str):
+                    mapped.setdefault(key.strip(), entry)
+            return mapped
+
+        if isinstance(rulesets, list):
+            out: Dict[str, Any] = {}
+            for item in rulesets:
+                if not isinstance(item, dict):
+                    continue
+                name = SecurityPolicyManager._ruleset_name_from_entry(item)
+                if name:
+                    out[str(name).strip()] = item
+            return out
+
+        return {}
+
+    @staticmethod
+    def _existing_ruleset_from_entry(existing_entry: Any) -> Any:
+        if not isinstance(existing_entry, dict):
+            return None
+        if "ruleset" in existing_entry:
+            return existing_entry.get("ruleset")
+        if any(k in existing_entry for k in ("name", "rules", "description")):
+            return existing_entry
+        return None
+
+    @classmethod
+    def _coerce_existing_rules_map(cls, rules: Any) -> Any:
+        if isinstance(rules, dict):
+            return rules
+        if not isinstance(rules, list):
+            return rules
+
+        out: Dict[str, Any] = {}
+        for item in rules:
+            if not isinstance(item, dict):
+                continue
+            rule_obj = item.get("rule") if isinstance(item.get("rule"), dict) else item
+            seq = rule_obj.get("seq") if isinstance(rule_obj, dict) else None
+            if seq is None:
+                continue
+            out[str(seq).strip()] = item if "rule" in item else {"rule": rule_obj}
+        return out
+
+    @classmethod
+    def _coerce_existing_ruleset_body(cls, ruleset: Any, ruleset_name: str) -> Any:
+        if not isinstance(ruleset, dict):
+            return ruleset
+
+        out = dict(ruleset)
+        # Some API responses use the map key as the ruleset identity and omit
+        # the nested name field. The YAML always includes it after normalization.
+        out.setdefault("name", ruleset_name)
+        if "rules" in out:
+            out["rules"] = cls._coerce_existing_rules_map(out.get("rules"))
+        return out
+
+    @classmethod
+    def _normalized_state(cls, value: Any, *, context: str) -> str:
+        if value is None:
+            return "present"
+        state = str(value).strip().lower()
+        if state not in _STATE_CHOICES:
+            raise ConfigurationError(f"{context}: 'state' must be 'present' or 'absent'")
+        return state
+
+    @classmethod
+    def _rule_delete_entry(cls) -> Dict[str, Any]:
+        return {"rule": None}
+
+    @classmethod
+    def _rule_state_from_shapes(cls, entry: Dict[str, Any], rule_obj: Dict[str, Any], *, context: str) -> str:
+        state = entry.get("state")
+        if state is None:
+            state = rule_obj.get("state")
+        return cls._normalized_state(state, context=context)
+
+    @staticmethod
+    def _strip_rule_state(entry: Dict[str, Any], rule_obj: Dict[str, Any]) -> Dict[str, Any]:
+        cleaned_entry = dict(entry)
+        cleaned_rule = dict(rule_obj)
+        cleaned_entry.pop("state", None)
+        cleaned_rule.pop("state", None)
+        if "rule" in cleaned_entry:
+            cleaned_entry["rule"] = cleaned_rule
+            return cleaned_entry
+        return cleaned_rule
+
+    @classmethod
+    def _rules_from_yaml(cls, rules_cfg: Any) -> Dict[str, Any]:
+        """
+        Build the API rules map.
+
+        YAML may either use the raw API map shape:
+          "10": { rule: { seq: 10, ... } }
+
+        or the simpler list shape:
+          - seq: 10
+            match: ...
+            action: ...
+
+        Per-rule lifecycle (under ``configure``):
+          - seq: 500
+            state: absent
+
+        sends ``{"500": {"rule": null}}`` (delete that rule only).
+        """
+        if rules_cfg is None:
+            return {}
+
+        if isinstance(rules_cfg, dict):
+            out: Dict[str, Any] = {}
+            for raw_key, raw_val in rules_cfg.items():
+                key = str(raw_key).strip()
+                if not key:
+                    raise ConfigurationError("rules dict keys must be non-empty sequence numbers")
+                if not isinstance(raw_val, dict):
+                    raise ConfigurationError(f"rules['{key}'] must be a dict")
+                entry = dict(raw_val)
+                if entry.get("rule") is None and "rule" in entry:
+                    out[key] = cls._rule_delete_entry()
+                    continue
+                rule_obj = entry.get("rule") if "rule" in entry else entry
+                if not isinstance(rule_obj, dict):
+                    raise ConfigurationError(f"rules['{key}'] must be a dict")
+                state = cls._rule_state_from_shapes(entry, rule_obj, context=f"rule {key}")
+                if state == "absent":
+                    out[key] = cls._rule_delete_entry()
+                    continue
+                cleaned = cls._strip_rule_state(entry, rule_obj)
+                if isinstance(cleaned, dict) and "rule" in cleaned:
+                    cleaned["rule"] = cls._normalize_rule_body(cleaned.get("rule"))
+                    out[key] = cleaned
+                else:
+                    out[key] = {"rule": cls._normalize_rule_body(cleaned)}
+            return out
+
+        if isinstance(rules_cfg, list):
+            out = {}
+            for entry in rules_cfg:
+                if not isinstance(entry, dict):
+                    raise ConfigurationError("rules list items must be dicts")
+                entry_copy = dict(entry)
+                rule_obj = entry_copy.get("rule") if "rule" in entry_copy else dict(entry_copy)
+                if not isinstance(rule_obj, dict):
+                    raise ConfigurationError("rules list item 'rule' must be a dict")
+                rule_obj = dict(rule_obj)
+                seq = rule_obj.get("seq")
+                if seq is None:
+                    raise ConfigurationError("rules list item missing 'seq'")
+                key = str(seq).strip()
+                if not key:
+                    raise ConfigurationError("rules list item 'seq' must be non-empty")
+                state = cls._rule_state_from_shapes(entry_copy, rule_obj, context=f"rule seq {key}")
+                if state == "absent":
+                    out[key] = cls._rule_delete_entry()
+                    continue
+                cleaned = cls._strip_rule_state(entry_copy, rule_obj)
+                if isinstance(cleaned, dict) and "rule" in cleaned:
+                    cleaned["rule"] = cls._normalize_rule_body(cleaned.get("rule"))
+                    out[key] = cleaned
+                else:
+                    out[key] = {"rule": cls._normalize_rule_body(cleaned)}
+            return out
+
+        raise ConfigurationError("'rules' must be a dict or list")
+
+    @staticmethod
+    def _normalize_circuit_label(value: Any, field_name: str) -> Any:
+        if value is None or isinstance(value, dict):
+            return value
+        if isinstance(value, str):
+            label = value.strip()
+            if not label:
+                raise ConfigurationError(f"'{field_name}' label must be non-empty")
+            return {"label": label}
+        raise ConfigurationError(f"'{field_name}' must be a string label or dict")
+
+    @staticmethod
+    def _set_nested(target: Dict[str, Any], path: Tuple[str, ...], value: Any) -> None:
+        cur = target
+        for key in path[:-1]:
+            nxt = cur.get(key)
+            if not isinstance(nxt, dict):
+                nxt = {}
+                cur[key] = nxt
+            cur = nxt
+        cur[path[-1]] = value
+
+    @classmethod
+    def _normalize_network_match_field(cls, field: str, value: Any) -> Dict[str, Any]:
+        if isinstance(value, dict):
+            if field in value or "match" in value:
+                return value
+        return {field: str(value).strip()}
+
+    @classmethod
+    def _normalize_content_filter(cls, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ConfigurationError("contentFilter must be a dict")
+        if "match" in value:
+            match_body = dict(value.get("match") or {})
+            ids = match_body.get("domainCategoryIds")
+            if ids is None:
+                ids = match_body.get("domain_category_ids")
+            if ids is not None:
+                match_body["domainCategoryIds"] = list(ids)
+                match_body.pop("domain_category_ids", None)
+            return {"match": match_body}
+        ids = value.get("domainCategoryIds")
+        if ids is None:
+            ids = value.get("domain_category_ids")
+        if ids is not None:
+            return {"match": {"domainCategoryIds": list(ids)}}
+        return value
+
+    @classmethod
+    def _normalize_domain_list(cls, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ConfigurationError("domainList must be a dict")
+        if "match" in value:
+            match_body = dict(value.get("match") or {})
+            wildcards = match_body.get("domainWildcards")
+            if wildcards is None:
+                wildcards = match_body.get("domain_wildcards")
+            if wildcards is not None:
+                match_body["domainWildcards"] = list(wildcards)
+                match_body.pop("domain_wildcards", None)
+            return {"match": match_body}
+        wildcards = value.get("domainWildcards")
+        if wildcards is None:
+            wildcards = value.get("domain_wildcards")
+        if wildcards is not None:
+            return {"match": {"domainWildcards": list(wildcards)}}
+        return value
+
+    @classmethod
+    def _normalize_application_match(cls, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise ConfigurationError("application must be a dict")
+        if "match" in value:
+            match_body = dict(value.get("match") or {})
+            builtin = match_body.get("builtin")
+            if builtin is None:
+                builtin = match_body.get("application_builtin") or match_body.get("applicationBuiltin")
+            custom = match_body.get("custom")
+            if custom is None:
+                custom = match_body.get("application_custom") or match_body.get("applicationCustom")
+        else:
+            builtin = value.get("builtin")
+            if builtin is None:
+                builtin = value.get("application_builtin") or value.get("applicationBuiltin")
+            custom = value.get("custom")
+            if custom is None:
+                custom = value.get("application_custom") or value.get("applicationCustom")
+        if builtin is not None and custom is None:
+            return {"match": {"builtin": str(builtin).strip()}}
+        if custom is not None and builtin is None:
+            return {"match": {"custom": str(custom).strip()}}
+        normalized: Dict[str, Any] = {}
+        if builtin is not None:
+            normalized["builtin"] = str(builtin).strip()
+        if custom is not None:
+            normalized["custom"] = str(custom).strip()
+        if normalized:
+            return {"match": normalized}
+        return value
+
+    @classmethod
+    def _prune_empty_match_fields(cls, out: Dict[str, Any]) -> Dict[str, Any]:
+        for key in list(out.keys()):
+            value = out[key]
+            if value == {}:
+                out.pop(key, None)
+                continue
+            if key == "application" and isinstance(value, dict):
+                match_body = value.get("match")
+                if not match_body:
+                    out.pop(key, None)
+        return out
+
+    @classmethod
+    def _raw_match_has_application(cls, match: Dict[str, Any]) -> bool:
+        if not isinstance(match, dict):
+            return False
+        for key in _APPLICATION_MATCH_INPUT_KEYS:
+            if key == "application":
+                app = match.get("application")
+                if isinstance(app, dict) and app:
+                    return True
+                continue
+            if match.get(key) is not None:
+                return True
+        return False
+
+    @classmethod
+    def _raw_match_has_network(cls, match: Dict[str, Any]) -> bool:
+        if not isinstance(match, dict):
+            return False
+        return any(match.get(key) is not None for key in _NETWORK_MATCH_INPUT_KEYS)
+
+    @classmethod
+    def _combined_raw_match_from_rule(cls, rule: Dict[str, Any]) -> Dict[str, Any]:
+        combined = dict(rule.get("match") or {})
+        for key in _APPLICATION_MATCH_INPUT_KEYS | _NETWORK_MATCH_INPUT_KEYS:
+            if key in rule and key not in combined:
+                combined[key] = rule[key]
+        return combined
+
+    @classmethod
+    def _validate_exclusive_match_type(cls, match: Dict[str, Any], *, context: str) -> None:
+        if cls._raw_match_has_application(match) and cls._raw_match_has_network(match):
+            raise ConfigurationError(
+                f"{context}: rule match cannot combine application and network/L4 criteria; "
+                "use one match type per rule"
+            )
+
+    @classmethod
+    def _normalize_match_body(cls, match: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Normalize security rule match to the device-config API shape.
+
+        Scalar networks become ``{sourceNetwork: "..."}`` / ``{destinationNetwork: "..."}``.
+        Ports are string values. ``ipProtocol`` also sets ``protocol.ipProtocol``.
+        Application uses ``application.match.builtin`` or ``application.match.custom``.
+        """
+        cls._validate_exclusive_match_type(match, context="rule match")
+        out = dict(match)
+
+        for field in ("sourceNetwork", "destinationNetwork"):
+            if field in out and out[field] is not None:
+                out[field] = cls._normalize_network_match_field(field, out[field])
+
+        for port_field in ("sourcePort", "destinationPort"):
+            if port_field in out and out[port_field] is not None:
+                out[port_field] = str(out[port_field]).strip()
+
+        ip_proto = out.get("ipProtocol")
+        if ip_proto is None:
+            ip_proto = out.get("ip_protocol")
+        if ip_proto is not None:
+            ip_proto = str(ip_proto).strip()
+            out["ipProtocol"] = ip_proto
+            out.pop("ip_protocol", None)
+            protocol = out.get("protocol")
+            if not isinstance(protocol, dict):
+                out["protocol"] = {"ipProtocol": ip_proto}
+            else:
+                proto = dict(protocol)
+                nested_proto = proto.get("ipProtocol")
+                if nested_proto is None:
+                    nested_proto = proto.get("ip_protocol")
+                if nested_proto is None:
+                    proto["ipProtocol"] = ip_proto
+                else:
+                    proto["ipProtocol"] = str(nested_proto).strip()
+                    proto.pop("ip_protocol", None)
+                out["protocol"] = proto
+
+        if "icmpType" in out and out["icmpType"] is not None:
+            out["icmpType"] = out["icmpType"]
+
+        app_builtin = out.pop("applicationBuiltin", None)
+        if app_builtin is None:
+            app_builtin = out.pop("application_builtin", None)
+        app_custom = out.pop("applicationCustom", None)
+        if app_custom is None:
+            app_custom = out.pop("application_custom", None)
+        if app_builtin is not None or app_custom is not None:
+            app_match: Dict[str, Any] = {}
+            if app_builtin is not None:
+                app_match["builtin"] = str(app_builtin).strip()
+            if app_custom is not None:
+                app_match["custom"] = str(app_custom).strip()
+            out["application"] = {"match": app_match}
+
+        if "application" in out:
+            out["application"] = cls._normalize_application_match(out["application"])
+
+        domain_category_ids = out.pop("domainCategoryIds", None)
+        if domain_category_ids is None:
+            domain_category_ids = out.pop("domain_category_ids", None)
+        if domain_category_ids is not None and "contentFilter" not in out:
+            out["contentFilter"] = {"match": {"domainCategoryIds": list(domain_category_ids)}}
+
+        if "contentFilter" in out:
+            out["contentFilter"] = cls._normalize_content_filter(out["contentFilter"])
+
+        domain_wildcards = out.pop("domainWildcards", None)
+        if domain_wildcards is None:
+            domain_wildcards = out.pop("domain_wildcards", None)
+        if domain_wildcards is not None and "domainList" not in out:
+            out["domainList"] = {"match": {"domainWildcards": list(domain_wildcards)}}
+
+        if "domainList" in out:
+            out["domainList"] = cls._normalize_domain_list(out["domainList"])
+
+        return cls._prune_empty_match_fields(out)
+
+    @classmethod
+    def _match_from_shorthand(cls, rule: Dict[str, Any]) -> Dict[str, Any]:
+        match = dict(rule.get("match") or {})
+
+        app_builtin = rule.pop("applicationBuiltin", None)
+        if app_builtin is not None:
+            cls._set_nested(match, ("application", "match", "builtin"), app_builtin)
+            app_body = match.get("application")
+            if isinstance(app_body, dict):
+                app_match_body = app_body.get("match")
+                if isinstance(app_match_body, dict):
+                    app_match_body.pop("custom", None)
+
+        app_custom = rule.pop("applicationCustom", None)
+        if app_custom is not None:
+            cls._set_nested(match, ("application", "match", "custom"), app_custom)
+            app_body = match.get("application")
+            if isinstance(app_body, dict):
+                app_match_body = app_body.get("match")
+                if isinstance(app_match_body, dict):
+                    app_match_body.pop("builtin", None)
+
+        for field_name in ("ipProtocol", "sourcePort", "destinationPort", "icmpType"):
+            if field_name in rule:
+                match[field_name] = rule.pop(field_name)
+
+        for field_name in ("sourceNetwork", "destinationNetwork"):
+            if field_name in rule:
+                match[field_name] = rule.pop(field_name)
+
+        dscp_code_point = rule.pop("dscpCodePoint", None)
+        if dscp_code_point is not None:
+            cls._set_nested(match, ("dscp", "match", "codePoint"), dscp_code_point)
+
+        if not match:
+            return {}
+        return cls._normalize_match_body(match)
+
+    @classmethod
+    def _normalize_meter_rate(cls, value: Any) -> Any:
+        if value is None or isinstance(value, dict):
+            return value
+        if isinstance(value, (int, float, str)):
+            rate = str(value).strip()
+            if rate:
+                return {"rate": int(rate)}
+        return value
+
+    @classmethod
+    def _normalize_rule_body(cls, rule: Any) -> Any:
+        if not isinstance(rule, dict):
+            return rule
+
+        out = dict(rule)
+        cls._validate_exclusive_match_type(
+            cls._combined_raw_match_from_rule(out),
+            context=f"rule seq {out.get('seq', '?')}",
+        )
+        if isinstance(out.get("match"), dict):
+            out["match"] = cls._normalize_match_body(dict(out["match"]))
+        else:
+            match = cls._match_from_shorthand(out)
+            if match:
+                out["match"] = match
+
+        raw_action = out.pop("action", None)
+        if isinstance(raw_action, str):
+            action_val = raw_action.strip().lower()
+            if action_val:
+                out["action"] = action_val
+        elif isinstance(raw_action, dict) and raw_action:
+            out["action"] = raw_action
+
+        for field in (
+            "uplinkPolicerRate",
+            "uplinkBurstRate",
+            "downlinkPolicerRate",
+            "downlinkBurstRate",
+        ):
+            if field in out:
+                out[field] = cls._normalize_meter_rate(out[field])
+
+        return out
+
+    @classmethod
+    def _normalize_implicit_rule_action(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        action = str(value).strip()
+        if not action:
+            return None
+        return action.lower()
+
+    def _normalize_ruleset_body(self, ruleset: Any) -> Any:
+        if not isinstance(ruleset, dict):
+            return ruleset
+        out = dict(ruleset)
+        ira = out.pop("implicitRuleAction", None)
+        if ira is None:
+            ira = out.pop("implicit_rule_action", None)
+        normalized_ira = self._normalize_implicit_rule_action(ira)
+        if normalized_ira is not None:
+            out["implicitRuleAction"] = normalized_ira
+        if "rules" in out:
+            out["rules"] = self._rules_from_yaml(out.get("rules"))
+        return out
+
+    def _normalize_ruleset_entry(self, key: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+        out = dict(entry)
+        ruleset = out.get("ruleset")
+        if ruleset is not None:
+            if not isinstance(ruleset, dict):
+                raise ConfigurationError(f"securityRulesets['{key}'].ruleset must be a dict or null")
+            normalized = self._normalize_ruleset_body(ruleset)
+            if isinstance(normalized, dict) and not normalized.get("name"):
+                normalized["name"] = key
+            out["ruleset"] = normalized
+        return out
+
+    def _rulesets_from_yaml(self, tr_cfg: Any, operation: str) -> Dict[str, Any]:
+        """
+        Build the securityRulesets map for the device-config API.
+
+        Supported YAML shapes:
+        - dict keyed by ruleset id -> either ``{ruleset: {...}}`` or the inner ruleset body only
+        - list of dicts with ``name`` (configure) or list of strings / ``{name: ...}`` (deconfigure)
+        """
+        if tr_cfg is None:
+            return {}
+        if isinstance(tr_cfg, dict):
+            out: Dict[str, Any] = {}
+            for raw_key, v in tr_cfg.items():
+                key = str(raw_key).strip()
+                if not key:
+                    raise ConfigurationError("securityRulesets dict keys must be non-empty strings")
+                if operation == "deconfigure":
+                    out[key] = {"ruleset": None}
+                    continue
+                if not isinstance(v, dict):
+                    raise ConfigurationError(f"securityRulesets['{key}'] must be a dict")
+                v = dict(v)
+                rs_state = self._normalized_state(v.pop("state", None), context=f"ruleset '{key}'")
+                if rs_state == "absent":
+                    out[key] = {"ruleset": None}
+                    continue
+                if "ruleset" in v:
+                    out[key] = self._normalize_ruleset_entry(key, v)
+                else:
+                    out[key] = self._normalize_ruleset_entry(key, {"ruleset": v})
+            return out
+        if isinstance(tr_cfg, list):
+            out = {}
+            for entry in tr_cfg:
+                if operation == "deconfigure":
+                    if isinstance(entry, str):
+                        k = str(entry).strip()
+                        if not k:
+                            continue
+                        out[k] = {"ruleset": None}
+                    elif isinstance(entry, dict):
+                        n = entry.get("name")
+                        if not n:
+                            raise ConfigurationError("securityRulesets list entry missing 'name' for deconfigure")
+                        out[str(n).strip()] = {"ruleset": None}
+                    else:
+                        raise ConfigurationError("securityRulesets list entries must be str or dict for deconfigure")
+                    continue
+                if not isinstance(entry, dict):
+                    raise ConfigurationError("securityRulesets list items must be dicts with a 'name' field")
+                n = entry.get("name")
+                if not n:
+                    raise ConfigurationError("securityRulesets list entry missing 'name'")
+                name = str(n).strip()
+                rs_state = self._normalized_state(entry.get("state"), context=f"ruleset '{name}'")
+                if rs_state == "absent":
+                    out[name] = {"ruleset": None}
+                    continue
+                body = {k: val for k, val in entry.items() if k not in ("name", "state")}
+                out[name] = {"ruleset": self._normalize_ruleset_body({"name": name, **body})}
+            return out
+        raise ConfigurationError("'securityRulesets' must be a dict or list")
+
+    @classmethod
+    def _coerce_ruleset_ref(cls, value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            ref = cls._first_present(value, RULESET_REF_KEYS)
+            if ref is None:
+                return None
+            return cls._coerce_ruleset_ref(ref)
+        ref = str(value).strip()
+        return None if not ref or ref.lower() in ("none", "null") else ref
+
+    @staticmethod
+    def _ruleset_refs_match(desired_ref: Any, existing_ref: Optional[str]) -> bool:
+        desired = str(desired_ref).strip()
+        existing = (existing_ref or "").strip()
+        if desired == existing:
+            return True
+        # The API may return generated names like G-<device-id>-<ruleset-name>.
+        return bool(desired and existing.endswith(f"-{desired}"))
+
+    def _extract_zone_pairs_from_device(self, device_info_dict: Any) -> Dict[Tuple[str, str], Dict[str, Any]]:
+        """
+        Normalize zone attachments from device GET or config shape.
+
+        GET returns ``trafficPolicy.zonePairs`` as a flat list; config PUT uses
+        ``trafficPolicy.zones`` nested maps.
+        """
+        tp = self._traffic_policy_from_device(device_info_dict)
+        pairs: Dict[Tuple[str, str], Dict[str, Any]] = {}
+
+        zone_pairs = tp.get("zonePairs") or tp.get("zone_pairs")
+        if isinstance(zone_pairs, list):
+            for item in zone_pairs:
+                if not isinstance(item, dict):
+                    continue
+                inside = str(item.get("inside") or "").strip()
+                outside = str(item.get("outside") or "").strip()
+                if inside and outside:
+                    pairs[(inside, outside)] = item
+
+        zones = tp.get("zones")
+        if isinstance(zones, dict):
+            for inside, outside, ruleset, tcp_prot in self._iter_zone_pairs_from_zones_map(zones):
+                pairs.setdefault(
+                    (inside, outside),
+                    {
+                        "inside": inside,
+                        "outside": outside,
+                        "ruleset": ruleset,
+                        "tcpProtection": tcp_prot,
+                    },
+                )
+        return pairs
+
+    def _extract_zones_from_device(self, device_info_dict: Any) -> Dict[str, Any]:
+        zones = self._traffic_policy_from_device(device_info_dict).get("zones")
+        return as_dict(zones) if isinstance(zones, dict) else {}
+
+    @classmethod
+    def _lookup_zone_pair(
+        cls, pairs_map: Dict[Tuple[str, str], Dict[str, Any]], inside: str, outside: str
+    ) -> Optional[Dict[str, Any]]:
+        key = (inside, outside)
+        if key in pairs_map:
+            return pairs_map[key]
+        inside_l = inside.lower()
+        outside_l = outside.lower()
+        for (zone_inside, zone_outside), pair in pairs_map.items():
+            if zone_inside.lower() == inside_l and zone_outside.lower() == outside_l:
+                return pair
+        return None
+
+    @classmethod
+    def _pair_from_zones_map(cls, zones_map: Dict[str, Any], inside: str, outside: str) -> Optional[Dict[str, Any]]:
+        zone_entry = zones_map.get(inside)
+        if not isinstance(zone_entry, dict):
+            return None
+        zone = zone_entry.get("zone")
+        if not isinstance(zone, dict):
+            return None
+        pairs = zone.get("pairs")
+        if not isinstance(pairs, dict):
+            return None
+        pair_wrap = pairs.get(outside)
+        if not isinstance(pair_wrap, dict):
+            return None
+        pair = pair_wrap.get("pair")
+        return pair if isinstance(pair, dict) else None
+
+    @classmethod
+    def _set_zone_pair(
+        cls,
+        zones_out: Dict[str, Any],
+        inside: str,
+        outside: str,
+        ruleset: Any,
+        tcp_protection: bool,
+    ) -> None:
+        if inside not in zones_out:
+            zones_out[inside] = {"zone": {"inside": inside, "pairs": {}}}
+        zone_body = zones_out[inside]["zone"]
+        if not isinstance(zone_body.get("pairs"), dict):
+            zone_body["pairs"] = {}
+        if ruleset is None:
+            # Nullable wrapper delete/clear (same pattern as securityRulesets deconfigure).
+            zone_body["pairs"][outside] = {}
+            return
+        zone_body["pairs"][outside] = {
+            "pair": {
+                "outside": outside,
+                "ruleset": ruleset,
+                "tcpProtection": tcp_protection,
+            }
+        }
+
+    @classmethod
+    def _zone_names_from_yaml_entry(cls, entry: Dict[str, Any]) -> Tuple[str, str]:
+        from_zone = entry.get("fromZone") or entry.get("from_zone") or entry.get("inside")
+        to_zone = entry.get("toZone") or entry.get("to_zone") or entry.get("outside")
+        inside = str(from_zone or "").strip()
+        outside = str(to_zone or "").strip()
+        return inside, outside
+
+    def _parse_zone_pair_list_entry(self, entry: Dict[str, Any], detach: bool) -> Tuple[str, str, Any, bool]:
+        inside, outside = self._zone_names_from_yaml_entry(entry)
+        if not inside or not outside:
+            raise ConfigurationError("zones list entry requires non-empty 'fromZone' and 'toZone'")
+
+        state = entry.get("state")
+        if detach or state == "absent":
+            ruleset: Any = None
+        else:
+            raw_ruleset = entry.get("ruleset")
+            if raw_ruleset is None:
+                raise ConfigurationError(f"zones pair {inside}->{outside} requires 'ruleset' when attaching")
+            ruleset = str(raw_ruleset).strip()
+            if not ruleset:
+                raise ConfigurationError(f"zones pair {inside}->{outside}: ruleset name must be non-empty")
+
+        tcp = entry.get("tcpProtection")
+        if tcp is None:
+            tcp = entry.get("tcp_protection", False)
+        return inside, outside, ruleset, bool(tcp)
+
+    @classmethod
+    def _is_api_zones_dict(cls, zones_cfg: Dict[str, Any]) -> bool:
+        for value in zones_cfg.values():
+            if isinstance(value, dict) and "zone" in value:
+                return True
+        return False
+
+    def _zones_payload_from_yaml(self, zones_cfg: Any, operation: str) -> Dict[str, Any]:
+        """
+        Build edge.trafficPolicy.zones map with directional zone pairs (fromZone -> toZone only).
+
+        YAML list shape (recommended):
+          - fromZone: zone-DIA
+            toZone: zone-lan-segment-3
+            ruleset: new-ruleset-0
+            tcpProtection: false
+
+        Or pass the API zones dict directly (keys are inside zone names).
+        """
+        if zones_cfg is None:
+            return {}
+        detach = operation == "detach_from_zone_pairs"
+
+        if isinstance(zones_cfg, dict):
+            if self._is_api_zones_dict(zones_cfg):
+                if detach:
+                    out: Dict[str, Any] = {}
+                    for inside_key, zone_entry in zones_cfg.items():
+                        if not isinstance(zone_entry, dict):
+                            continue
+                        zone = zone_entry.get("zone")
+                        if not isinstance(zone, dict):
+                            continue
+                        inside = str(zone.get("inside") or inside_key).strip()
+                        pairs = zone.get("pairs")
+                        if not isinstance(pairs, dict):
+                            continue
+                        for outside_key, pair_wrap in pairs.items():
+                            pair = (pair_wrap or {}).get("pair") if isinstance(pair_wrap, dict) else {}
+                            outside = str((pair or {}).get("outside") or outside_key).strip()
+                            tcp = bool((pair or {}).get("tcpProtection", False))
+                            if inside and outside:
+                                self._set_zone_pair(out, inside, outside, None, tcp)
+                    return out
+                return dict(zones_cfg)
+            raise ConfigurationError("'zones' dict must use API shape with 'zone' entries")
+
+        if isinstance(zones_cfg, list):
+            zones_out: Dict[str, Any] = {}
+            for raw_entry in zones_cfg:
+                if not isinstance(raw_entry, dict):
+                    raise ConfigurationError("zones list entries must be dicts")
+                inside, outside, ruleset, tcp_prot = self._parse_zone_pair_list_entry(raw_entry, detach)
+                self._set_zone_pair(zones_out, inside, outside, ruleset, tcp_prot)
+            return zones_out
+
+        raise ConfigurationError("'zones' must be a list of zone pairs or an API zones dict")
+
+    @classmethod
+    def _iter_zone_pairs_from_zones_map(cls, zones_map: Dict[str, Any]) -> Iterator[Tuple[str, str, Any, bool]]:
+        for inside_key, zone_entry in zones_map.items():
+            if not isinstance(zone_entry, dict):
+                continue
+            zone = zone_entry.get("zone")
+            if not isinstance(zone, dict):
+                continue
+            inside = str(zone.get("inside") or inside_key).strip()
+            pairs = zone.get("pairs")
+            if not isinstance(pairs, dict):
+                continue
+            for outside_key, pair_wrap in pairs.items():
+                if not isinstance(pair_wrap, dict):
+                    continue
+                pair = pair_wrap.get("pair")
+                if pair is None:
+                    if pair_wrap:
+                        continue
+                    outside = str(outside_key).strip()
+                    if inside and outside:
+                        yield inside, outside, None, False
+                    continue
+                if not isinstance(pair, dict):
+                    continue
+                outside = str(pair.get("outside") or outside_key).strip()
+                if not inside or not outside:
+                    continue
+                yield inside, outside, pair.get("ruleset"), bool(pair.get("tcpProtection", False))
+
+    def _pair_ruleset_cleared(self, pair: Optional[Dict[str, Any]]) -> bool:
+        if pair is None:
+            return True
+        return self._coerce_ruleset_ref(pair.get("ruleset")) is None
+
+    def _zone_pair_matches(
+        self,
+        pairs_map: Dict[Tuple[str, str], Dict[str, Any]],
+        inside: str,
+        outside: str,
+        desired_ruleset: Any,
+        desired_tcp: bool,
+    ) -> bool:
+        if desired_ruleset is None:
+            pair = self._lookup_zone_pair(pairs_map, inside, outside)
+            return self._pair_ruleset_cleared(pair)
+
+        pair = self._lookup_zone_pair(pairs_map, inside, outside)
+        if pair is None:
+            return False
+
+        ref = self._coerce_ruleset_ref(pair.get("ruleset"))
+        if not self._ruleset_refs_match(desired_ruleset, ref):
+            return False
+        if bool(pair.get("tcpProtection")) != desired_tcp:
+            return False
+        return True
+
+    def _zone_attachments_need_update(self, desired_zones: Dict[str, Any], device_info_dict: Any) -> bool:
+        existing_pairs = self._extract_zone_pairs_from_device(device_info_dict)
+        for inside, outside, ruleset, tcp_prot in self._iter_zone_pairs_from_zones_map(desired_zones):
+            if not self._zone_pair_matches(existing_pairs, inside, outside, ruleset, tcp_prot):
+                LOG.info(
+                    "[security-policy] Zone pair %s->%s differs (desired ruleset=%r tcpProtection=%r)",
+                    inside,
+                    outside,
+                    ruleset,
+                    tcp_prot,
+                )
+                return True
+        return False
+
+    def _payload_differs(self, desired_payload: Dict[str, Any], device_info_dict: Any) -> bool:
+        desired_edge = (desired_payload or {}).get("edge") or {}
+        desired_tp = desired_edge.get(EDGE_POLICY_KEY) or {}
+        desired_zones = desired_tp.get("zones") or {}
+        if isinstance(desired_zones, dict) and desired_zones:
+            return self._zone_attachments_need_update(desired_zones, device_info_dict)
+
+        desired_rs = desired_tp.get("securityRulesets") or {}
+        if isinstance(desired_rs, dict) and desired_rs:
+            return self._security_rulesets_need_update(desired_rs, device_info_dict)
+
+        return False
+
+    def _zone_payload_differs_with_retry(self, payload: Dict[str, Any], device_id: int) -> bool:
+        for attempt in range(2):
+            time.sleep(2)
+            refreshed_info = self.gsdk.get_device_info(device_id)
+            try:
+                refreshed_dict = refreshed_info.to_dict()
+            except Exception:
+                refreshed_dict = refreshed_info
+            if not self._payload_differs(payload, refreshed_dict):
+                return False
+            LOG.info(
+                "[security-policy] Zone state still differs after refresh attempt %d for device_id=%s",
+                attempt + 1,
+                device_id,
+            )
+        return True
+
+    def _ruleset_payload_differs_with_retry(self, payload: Dict[str, Any], device_id: int) -> bool:
+        for attempt in range(2):
+            time.sleep(2)
+            refreshed_info = self.gsdk.get_device_info(device_id)
+            try:
+                refreshed_dict = refreshed_info.to_dict()
+            except Exception:
+                refreshed_dict = refreshed_info
+            if not self._payload_differs(payload, refreshed_dict):
+                return False
+            LOG.info(
+                "[security-policy] Ruleset state still differs after refresh attempt %d for device_id=%s",
+                attempt + 1,
+                device_id,
+            )
+        return True
+
+    @staticmethod
+    def _existing_rule_from_entry(existing_entry: Any) -> Any:
+        if not isinstance(existing_entry, dict):
+            return None
+        if "rule" in existing_entry:
+            return existing_entry.get("rule")
+        if any(k in existing_entry for k in ("seq", "match", "action")):
+            return existing_entry
+        return None
+
+    def _desired_rules_need_update(self, desired_rules: Dict[str, Any], existing_rules: Any) -> bool:
+        if not isinstance(desired_rules, dict):
+            return True
+
+        existing_map = existing_rules if isinstance(existing_rules, dict) else {}
+        for rule_key, desired_entry in desired_rules.items():
+            if not isinstance(desired_entry, dict):
+                LOG.info("[security-policy] Desired rule entry %s is not a dict", rule_key)
+                return True
+
+            desired_rule = desired_entry.get("rule")
+            existing_entry = existing_map.get(rule_key) if isinstance(existing_map, dict) else None
+            existing_rule = self._existing_rule_from_entry(existing_entry)
+
+            if desired_rule is None:
+                if existing_rule is not None:
+                    LOG.info("[security-policy] Rule %s exists and will be deleted", rule_key)
+                    return True
+                continue
+
+            if not self._desired_matches_existing(
+                self._normalize_rule_for_compare(desired_rule),
+                self._normalize_rule_for_compare(existing_rule),
+            ):
+                mismatch = self._first_mismatch_path(desired_rule, existing_rule)
+                LOG.info(
+                    "[security-policy] Rule %s differs at %s (desired=%r existing=%r)",
+                    rule_key,
+                    mismatch,
+                    self._value_at_path(desired_rule, mismatch),
+                    self._value_at_path(existing_rule, mismatch),
+                )
+                return True
+
+        return False
+
+    def _security_rulesets_need_update(self, desired_rs: Dict[str, Any], device_info_dict: Any) -> bool:
+        existing_rs = self._extract_rulesets_from_device(device_info_dict)
+        LOG.info("[security-policy] existing securityRulesets keys: %s", list(existing_rs.keys()))
+        LOG.info("[security-policy] desired securityRulesets keys: %s", list(desired_rs.keys()))
+
+        for rs_id, desired_entry in desired_rs.items():
+            if not isinstance(desired_entry, dict):
+                LOG.info("[security-policy] Desired ruleset entry %s is not a dict", rs_id)
+                return True
+            desired_ruleset = desired_entry.get("ruleset")
+            existing_entry = self._find_existing_ruleset_entry(existing_rs, str(rs_id))
+            existing_ruleset = self._existing_ruleset_from_entry(existing_entry)
+            existing_ruleset = self._coerce_existing_ruleset_body(existing_ruleset, str(rs_id))
+
+            if desired_ruleset is None:
+                if existing_ruleset is not None:
+                    LOG.info("[security-policy] Ruleset %s exists and will be deleted", rs_id)
+                    return True
+                continue
+
+            desired_rules = desired_ruleset.get("rules") if isinstance(desired_ruleset, dict) else None
+            if isinstance(desired_rules, dict) and desired_rules:
+                existing_rules = (existing_ruleset or {}).get("rules") or {}
+                if self._desired_rules_need_update(desired_rules, existing_rules):
+                    return True
+                if not self._ruleset_metadata_matches(desired_ruleset, existing_ruleset):
+                    mismatch = self._first_mismatch_path(
+                        {k: v for k, v in desired_ruleset.items() if k != "rules" and k not in GET_COMPARE_SKIP_KEYS},
+                        {
+                            k: v
+                            for k, v in (existing_ruleset or {}).items()
+                            if k != "rules" and k not in GET_COMPARE_SKIP_KEYS
+                        },
+                    )
+                    LOG.info("[security-policy] Ruleset %s metadata differs at %s", rs_id, mismatch)
+                    return True
+                continue
+
+            if not self._ruleset_metadata_matches(
+                desired_ruleset if isinstance(desired_ruleset, dict) else {},
+                existing_ruleset,
+            ):
+                mismatch = self._first_mismatch_path(desired_ruleset, existing_ruleset)
+                LOG.info(
+                    "[security-policy] Ruleset %s differs at %s "
+                    "(desired=%r existing=%r; desired_parent=%r existing_parent=%r)",
+                    rs_id,
+                    mismatch,
+                    self._value_at_path(desired_ruleset, mismatch),
+                    self._value_at_path(existing_ruleset, mismatch),
+                    self._value_at_path(desired_ruleset, self._parent_path(mismatch)),
+                    self._value_at_path(existing_ruleset, self._parent_path(mismatch)),
+                )
+                return True
+
+        return False
+
+    def _iter_device_payloads(
+        self, config_yaml_file: str, operation: str
+    ) -> Iterator[Tuple[int, str, Dict[str, Any], Dict[str, Any]]]:
+        if operation not in (
+            "configure",
+            "deconfigure",
+            "attach_to_zone_pairs",
+            "detach_from_zone_pairs",
+        ):
+            raise ConfigurationError(f"Unsupported operation '{operation}'")
+
+        enterprise = self.gsdk.enterprise_info["company_name"]
+        by_name = self._load_devices(config_yaml_file)
+        if not by_name:
+            LOG.info("%s No '%s' entries to process in %s", _LOG_PREFIX, _YAML_KEY, config_yaml_file)
+            return
+
+        for device_name, device_cfg in by_name.items():
+            device_id, device_dict = fetch_device_by_name(self.gsdk, device_name, enterprise)
+
+            payload: Dict[str, Any]
+            if operation in ("attach_to_zone_pairs", "detach_from_zone_pairs"):
+                zones_cfg = device_cfg.get("zones")
+                zones_map = self._zones_payload_from_yaml(zones_cfg, operation=operation)
+                if not zones_map:
+                    LOG.info("%s No 'zones' for %s, skipping", _LOG_PREFIX, device_name)
+                    continue
+                payload = {"edge": {EDGE_POLICY_KEY: {"zones": zones_map}}}
+            else:
+                tr_cfg = device_cfg.get("securityRulesets")
+                rulesets_map = self._rulesets_from_yaml(tr_cfg, operation=operation)
+                if not rulesets_map:
+                    LOG.info("%s No securityRulesets for %s, skipping", _LOG_PREFIX, device_name)
+                    continue
+                payload = {"edge": {EDGE_POLICY_KEY: {"securityRulesets": rulesets_map}}}
+
+            if "description" in device_cfg:
+                payload["description"] = device_cfg.get("description", "")
+            if "configurationMetadata" in device_cfg:
+                meta = device_cfg.get("configurationMetadata")
+                payload["configurationMetadata"] = meta if isinstance(meta, dict) else {"name": ""}
+
+            yield device_id, device_name, payload, device_dict
+
+    def apply_security_policy(self, config_yaml_file: str, operation: str) -> dict:
+        result = new_apply_result()
+        to_push: Dict[int, Dict[str, Any]] = {}
+        configured_devices: List[str] = []
+        for device_id, device_name, payload, device_dict in self._iter_device_payloads(
+            config_yaml_file, operation=operation
+        ):
+            differs = self._payload_differs(payload, {"device": device_dict})
+            desired_tp = (payload.get("edge") or {}).get(EDGE_POLICY_KEY) or {}
+            desired_zones = desired_tp.get("zones")
+            desired_rs = desired_tp.get("securityRulesets")
+            if differs and isinstance(desired_zones, dict) and desired_zones:
+                differs = self._zone_payload_differs_with_retry(payload, device_id)
+            elif differs and isinstance(desired_rs, dict) and desired_rs:
+                differs = self._ruleset_payload_differs_with_retry(payload, device_id)
+
+            if not differs:
+                LOG.info("%s ✓ No changes needed for %s (ID: %s), skipping", _LOG_PREFIX, device_name, device_id)
+                result["skipped_devices"].append(device_name)
+                continue
+
+            to_push[device_id] = {"device_id": device_id, "payload": payload}
+            configured_devices.append(device_name)
+
+        if not to_push:
+            return result
+
+        push_device_config_raw(
+            self.execute_concurrent_tasks,
+            self.gsdk.put_device_config_raw,
+            to_push,
+            log_prefix=_LOG_PREFIX,
+        )
+
+        result["changed"] = True
+        result["configured_devices"] = configured_devices
+        return result
+
+    def configure(self, config_yaml_file: str) -> dict:
+        return self.apply_security_policy(config_yaml_file, operation="configure")
+
+    def deconfigure(self, config_yaml_file: str) -> dict:
+        return self.apply_security_policy(config_yaml_file, operation="deconfigure")
+
+    def attach_to_zone_pairs(self, config_yaml_file: str) -> dict:
+        return self.apply_security_policy(config_yaml_file, operation="attach_to_zone_pairs")
+
+    def detach_from_zone_pairs(self, config_yaml_file: str) -> dict:
+        return self.apply_security_policy(config_yaml_file, operation="detach_from_zone_pairs")

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_security_policy.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_security_policy.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Graphiant Team <support@graphiant.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Ansible module for managing Graphiant device-level security policy objects under:
+  edge.trafficPolicy.securityRulesets
+  edge.trafficPolicy.zones (zone pair association)
+"""
+
+DOCUMENTATION = r"""
+---
+module: graphiant_security_policy
+short_description: Manage device security policy rulesets and zone pair attachments
+description:
+  - Configure or delete device-level security policy rulesets under C(edge.trafficPolicy.securityRulesets).
+  - Attach or detach a named ruleset on zone pairs under C(edge.trafficPolicy.zones).
+  - Reads a structured YAML config file and builds the raw device-config payload in Python.
+  - >-
+    The configure workflow applies rulesets (C(operation=configure)) and attaches them to zone pairs
+    (C(operation=attach_to_zone_pairs)). The deconfigure workflow clears zone pair references
+    (C(operation=detach_from_zone_pairs)) and deletes listed rulesets (C(operation=deconfigure)).
+  - "Configure is idempotent: compares intended rulesets to existing device state and skips push when already matched."
+  - "Deconfigure deletes only the rulesets listed in the YAML by setting C(ruleset: null) per ruleset key."
+  - >-
+    Under C(configure), set C(state: absent) on a ruleset or individual rule in YAML to delete only
+    that object (sends C(ruleset: null) or C(rule: null) in the payload). Omitted C(state) means
+    C(present).
+  - >-
+    Rule C(action) (per rule): C(accept), C(reject), C(inspect), or C(drop). Ruleset
+    C(implicitRuleAction) (catch-all for unmatched traffic): C(accept) or C(reject) only.
+    Values are normalized to lowercase strings in the device-config payload.
+  - >-
+    Each rule supports one primary match type: application (C(applicationBuiltin) /
+    C(applicationCustom)) or network/L4 (C(ipProtocol), C(sourceNetwork),
+    C(destinationNetwork), ports). Combining both in the same rule is rejected.
+  - >-
+    You cannot change a rule's primary match type in place (for example, from C(applicationBuiltin)
+    to C(ipProtocol) / C(destinationNetwork), or the reverse). The device API merges rule updates
+    and leaves stale match criteria. Delete the rule (C(state: absent)) and add a new rule with
+    the desired match instead.
+  - "Attach/detach operations compare each listed segment's ruleset reference to the device and skip when unchanged."
+notes:
+  - >-
+    One YAML file may define both C(securityRulesets) and C(zones). C(configure)/C(deconfigure) read
+    C(securityRulesets) only; C(attach_to_zone_pairs)/C(detach_from_zone_pairs) read C(zones) only.
+    Run both steps for a full security policy lifecycle, or use the sample playbook tags C(configure) and
+    C(deconfigure).
+  - "Configuration files support Jinja2 templating syntax for dynamic configuration generation."
+version_added: "26.5.0"
+extends_documentation_fragment:
+  - graphiant.naas.graphiant_portal_auth
+options:
+  security_policy_config_file:
+    description:
+      - Path to the security policy YAML file.
+      - Can be an absolute path or relative to the configured config_path.
+      - Expected top-level key is C(SecurityPolicyObject) (list of devices).
+      - Each device may define C(securityRulesets) and/or C(zones) in the same file.
+    type: str
+    required: true
+  operation:
+    description:
+      - Specific operation to perform.
+      - C(configure) creates/updates rulesets listed under C(securityRulesets).
+      - C(deconfigure) deletes listed rulesets by setting C(ruleset=null).
+      - >-
+        C(attach_to_zone_pairs) sets C(edge.trafficPolicy.zones) from the YAML C(zones) list
+        (each entry uses C(fromZone), C(toZone), and C(ruleset)).
+      - C(detach_from_zone_pairs) clears ruleset references on each zone pair listed under C(zones).
+    type: str
+    required: false
+    choices: [ configure, deconfigure, attach_to_zone_pairs, detach_from_zone_pairs ]
+  state:
+    description:
+      - Desired state for security policy rulesets.
+      - C(present) maps to C(configure) when C(operation) is omitted.
+      - C(absent) maps to C(deconfigure) when C(operation) is omitted.
+    type: str
+    required: false
+    default: present
+    choices: [ present, absent ]
+  detailed_logs:
+    description:
+      - Enable detailed logging.
+    type: bool
+    default: false
+attributes:
+  check_mode:
+    description: Supports check mode.
+    support: full
+requirements:
+  - python >= 3.7
+  - graphiant-sdk >= 25.12.1
+author:
+  - Graphiant Team (@graphiant)
+"""
+
+EXAMPLES = r"""
+- name: Configure device-level security policy rulesets
+  graphiant.naas.graphiant_security_policy:
+    operation: configure
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+
+- name: Attach security ruleset to zone pairs
+  graphiant.naas.graphiant_security_policy:
+    operation: attach_to_zone_pairs
+    security_policy_config_file: "sample_device_security_policies.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+"""
+
+RETURN = r"""
+msg:
+  description: Result message (includes detailed logs when enabled).
+  type: str
+  returned: always
+changed:
+  description: Whether the operation would push config to at least one device.
+  type: bool
+  returned: always
+operation:
+  description: The operation performed.
+  type: str
+  returned: always
+security_policy_config_file:
+  description: The security policy config file used for the operation.
+  type: str
+  returned: always
+configured_devices:
+  description: Device names where configuration was pushed (when changed=true).
+  type: list
+  elements: str
+  returned: when supported
+skipped_devices:
+  description: Device names that were skipped because desired state already matched.
+  type: list
+  elements: str
+  returned: when supported
+"""
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+
+from ansible_collections.graphiant.naas.plugins.module_utils.graphiant_utils import (  # noqa: E402
+    ansible_module_log,
+    graphiant_portal_auth_argument_spec,
+    get_graphiant_connection,
+    handle_graphiant_exception,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.logging_decorator import (  # noqa: E402
+    capture_library_logs,
+)
+
+
+@capture_library_logs
+def execute_with_logging(module, func, *args, **kwargs):
+    success_msg = kwargs.pop("success_msg", "Operation completed successfully")
+    no_change_msg = kwargs.pop("no_change_msg", "No changes needed")
+    try:
+        result = func(*args, **kwargs)
+    except Exception as e:
+        if module.params.get("detailed_logs"):
+            name = getattr(func, "__name__", str(func))
+            ansible_module_log(
+                module,
+                f"graphiant_security_policy: manager {name!s} failed: {type(e).__name__}: {e!s}",
+            )
+        raise
+    if isinstance(result, dict) and "changed" in result:
+        changed = bool(result.get("changed"))
+        configured = result.get("configured_devices") or []
+        skipped = result.get("skipped_devices") or []
+        msg = success_msg if changed else no_change_msg
+        if not changed and skipped:
+            msg += f" (skipped {len(skipped)} device(s))"
+        return {
+            "changed": changed,
+            "result_msg": msg,
+            "details": result,
+            "configured_devices": configured,
+            "skipped_devices": skipped,
+        }
+    return {"changed": True, "result_msg": success_msg, "details": result}
+
+
+def main():
+    argument_spec = dict(
+        **graphiant_portal_auth_argument_spec(),
+        security_policy_config_file=dict(type="str", required=True),
+        operation=dict(
+            type="str",
+            required=False,
+            choices=["configure", "deconfigure", "attach_to_zone_pairs", "detach_from_zone_pairs"],
+        ),
+        state=dict(type="str", required=False, default="present", choices=["present", "absent"]),
+        detailed_logs=dict(type="bool", required=False, default=False),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    params = module.params
+    operation = params.get("operation")
+    state = params.get("state", "present")
+    cfg_file = params["security_policy_config_file"]
+
+    if not operation:
+        operation = "configure" if state == "present" else "deconfigure"
+
+    try:
+        if params.get("detailed_logs"):
+            ansible_module_log(
+                module,
+                (
+                    f"graphiant_security_policy: start operation={operation!r} "
+                    f"security_policy_config_file={cfg_file!r} check_mode={module.check_mode!r}"
+                ),
+            )
+        connection = get_graphiant_connection(params, check_mode=module.check_mode)
+        graphiant_config = connection.graphiant_config
+        manager = graphiant_config.security_policy
+
+        if operation == "configure":
+            result = execute_with_logging(
+                module,
+                manager.configure,
+                cfg_file,
+                success_msg="Successfully configured device-level security policy rulesets",
+                no_change_msg="Device-level security policy already matches desired state; no changes needed",
+            )
+        elif operation == "deconfigure":
+            result = execute_with_logging(
+                module,
+                manager.deconfigure,
+                cfg_file,
+                success_msg="Successfully deconfigured device-level security policy rulesets",
+                no_change_msg="Device-level security policy rulesets already absent; no changes needed",
+            )
+        elif operation == "attach_to_zone_pairs":
+            result = execute_with_logging(
+                module,
+                manager.attach_to_zone_pairs,
+                cfg_file,
+                success_msg="Successfully attached security ruleset(s) to zone pair(s)",
+                no_change_msg="Zone pair security ruleset references already match desired state",
+            )
+        elif operation == "detach_from_zone_pairs":
+            result = execute_with_logging(
+                module,
+                manager.detach_from_zone_pairs,
+                cfg_file,
+                success_msg="Successfully detached security ruleset(s) from zone pair(s)",
+                no_change_msg="Zone pair security ruleset references already cleared",
+            )
+        else:
+            module.fail_json(
+                msg=(
+                    f"Unsupported operation '{operation}'. Supported operations: configure, deconfigure, "
+                    f"attach_to_zone_pairs, detach_from_zone_pairs."
+                ),
+                operation=operation,
+            )
+            return
+
+        module.exit_json(
+            changed=result["changed"],
+            msg=result["result_msg"],
+            operation=operation,
+            security_policy_config_file=cfg_file,
+            configured_devices=result.get("configured_devices", []),
+            skipped_devices=result.get("skipped_devices", []),
+            details=result.get("details", {}),
+        )
+
+    except Exception as e:
+        ansible_module_log(
+            module,
+            f"graphiant_security_policy: failed {type(e).__name__}: {e!s}",
+        )
+        error_msg = handle_graphiant_exception(e, operation)
+        module.fail_json(msg=error_msg, operation=operation)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -1177,6 +1177,63 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         LOG.info("Detach traffic policy from LAN segments (idempotency check): %s", result2)
         assert result2['changed'] is False, "Detach LAN segment traffic policy idempotency failed"
 
+    def test_configure_device_security_policy(self):
+        """
+        Configure device-level security policy rulesets (edge.trafficPolicy.securityRulesets).
+
+        Second run should be idempotent (changed=False) if desired state already matches.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.security_policy.configure("sample_device_security_policies.yaml")
+        LOG.info("Configure device-level security policy result: %s", result)
+        result2 = graphiant_config.security_policy.configure("sample_device_security_policies.yaml")
+        LOG.info("Configure device-level security policy result (idempotency check): %s", result2)
+        assert result2['changed'] is False, "Configure device-level security policy idempotency failed"
+
+    def test_deconfigure_device_security_policy(self):
+        """
+        Deconfigure (delete) device-level security policy rulesets listed in the YAML file.
+
+        Second run should be idempotent (changed=False) when rulesets are already absent.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.security_policy.deconfigure("sample_device_security_policies.yaml")
+        LOG.info("Deconfigure device-level security policy result: %s", result)
+        result2 = graphiant_config.security_policy.deconfigure("sample_device_security_policies.yaml")
+        LOG.info("Deconfigure device-level security policy result (idempotency check): %s", result2)
+        assert result2['changed'] is False, "Deconfigure device-level security policy idempotency failed"
+
+    def test_attach_device_security_policy_zone_pairs(self):
+        """
+        Attach security ruleset on zone pairs (edge.trafficPolicy.zones).
+
+        Uses ``sample_device_security_policies.yaml``. Second run is idempotent when
+        the portal already shows the same ruleset on the zone pair.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.security_policy.attach_to_zone_pairs("sample_device_security_policies.yaml")
+        LOG.info("Attach security policy to zone pairs result: %s", result)
+        result2 = graphiant_config.security_policy.attach_to_zone_pairs("sample_device_security_policies.yaml")
+        LOG.info("Attach security policy to zone pairs (idempotency check): %s", result2)
+        assert result2['changed'] is False, "Attach zone pair security policy idempotency failed"
+
+    def test_detach_device_security_policy_zone_pairs(self):
+        """
+        Clear security ruleset reference on zone pairs listed in the YAML file.
+
+        Second run should be idempotent (changed=False) when references are already cleared.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.security_policy.detach_from_zone_pairs("sample_device_security_policies.yaml")
+        LOG.info("Detach security policy from zone pairs result: %s", result)
+        result2 = graphiant_config.security_policy.detach_from_zone_pairs("sample_device_security_policies.yaml")
+        LOG.info("Detach security policy from zone pairs (idempotency check): %s", result2)
+        assert result2['changed'] is False, "Detach zone pair security policy idempotency failed"
+
     def test_configure_device_system(self):
         """
         Configure device system settings (edge/core name, regionName, site) from YAML.
@@ -1938,6 +1995,16 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_prefix_and_port_list'))
     suite.addTest(TestGraphiantPlaybooks('test_delete_site_to_site_vpn'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vpn_profiles'))
+
+    # Device Security Policy Management Tests
+    suite.addTest(TestGraphiantPlaybooks('test_configure_prefix_and_port_list'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_edge_services'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_device_security_policy'))
+    suite.addTest(TestGraphiantPlaybooks('test_attach_device_security_policy_zone_pairs'))
+    suite.addTest(TestGraphiantPlaybooks('test_detach_device_security_policy_zone_pairs'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_device_security_policy'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_edge_services'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_prefix_and_port_list'))
 
     # To deconfigure all interfaces
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_interfaces'))

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_security_policy_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_security_policy_manager.py
@@ -1,0 +1,560 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for SecurityPolicyManager (no live API)."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.exceptions import ConfigurationError
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.security_policy_manager import (
+    SecurityPolicyManager,
+    _YAML_KEY,
+    SECURITY_POLICY_KEYS,
+    SECURITY_RULESETS_KEYS,
+)
+
+
+def _mgr() -> SecurityPolicyManager:
+    return SecurityPolicyManager(MagicMock())
+
+
+def test_normalize_ruleset_implicit_rule_action() -> None:
+    m = _mgr()
+    ruleset = {
+        "name": "rs1",
+        "implicitRuleAction": "reject",
+        "rules": [
+            {
+                "seq": 1,
+                "logging": True,
+                "match": {"ipProtocol": "tcp", "destinationNetwork": "0.0.0.0/0"},
+                "action": "accept",
+            }
+        ],
+    }
+    normalized = m._normalize_ruleset_body(ruleset)
+    assert normalized["implicitRuleAction"] == "reject"
+    rule_body = normalized["rules"]["1"]["rule"]
+    assert rule_body["action"] == "accept"
+    assert rule_body["logging"] is True
+
+
+def test_security_policy_constants() -> None:
+    assert SECURITY_POLICY_KEYS[0] == "trafficPolicy"
+    assert SECURITY_RULESETS_KEYS[0] == "securityRulesets"
+    assert _YAML_KEY == "SecurityPolicyObject"
+
+
+def test_normalize_match_api_shape() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 1,
+            "match": {
+                "ipProtocol": "tcp",
+                "sourceNetwork": "0.0.0.0/0",
+                "destinationNetwork": "0.0.0.0/0",
+                "sourcePort": 53,
+                "destinationPort": 53,
+            },
+            "action": "accept",
+        }
+    )
+    match = normalized["match"]
+    assert match["sourceNetwork"] == {"sourceNetwork": "0.0.0.0/0"}
+    assert match["destinationNetwork"] == {"destinationNetwork": "0.0.0.0/0"}
+    assert match["sourcePort"] == "53"
+    assert match["destinationPort"] == "53"
+    assert match["ipProtocol"] == "tcp"
+    assert match["protocol"] == {"ipProtocol": "tcp"}
+
+
+def test_normalize_match_application_builtin_and_custom() -> None:
+    m = _mgr()
+    builtin_rule = m._normalize_rule_body(
+        {
+            "seq": 1,
+            "match": {"applicationBuiltin": "Office 365"},
+            "action": "accept",
+        }
+    )
+    assert builtin_rule["match"]["application"] == {"match": {"builtin": "Office 365"}}
+
+    custom_rule = m._normalize_rule_body(
+        {
+            "seq": 2,
+            "match": {"applicationCustom": "whitehouse.gov"},
+            "action": "reject",
+        }
+    )
+    assert custom_rule["match"]["application"] == {"match": {"custom": "whitehouse.gov"}}
+
+    api_shape = m._normalize_rule_body(
+        {
+            "seq": 3,
+            "match": {"application": {"match": {"custom": "whitehouse.gov"}}},
+            "action": "reject",
+        }
+    )
+    assert api_shape["match"]["application"] == {"match": {"custom": "whitehouse.gov"}}
+
+
+def test_normalize_match_application_switch_builtin_to_custom() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 1,
+            "match": {
+                "application": {"match": {"builtin": "WhatsApp"}},
+                "applicationCustom": "graphiant_dia_ping",
+            },
+            "action": "accept",
+        }
+    )
+    assert normalized["match"]["application"] == {"match": {"custom": "graphiant_dia_ping"}}
+
+
+def test_normalize_match_application_switch_custom_to_builtin() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 1,
+            "match": {
+                "application": {"match": {"custom": "graphiant_dia_ping"}},
+                "applicationBuiltin": "Facebook",
+            },
+            "action": "accept",
+        }
+    )
+    assert normalized["match"]["application"] == {"match": {"builtin": "Facebook"}}
+
+
+def test_normalize_match_network_only() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 150,
+            "match": {
+                "ipProtocol": "udp",
+                "destinationNetwork": "10.1.1.1/32",
+            },
+            "action": "accept",
+        }
+    )
+    match = normalized["match"]
+    assert match["destinationNetwork"] == {"destinationNetwork": "10.1.1.1/32"}
+    assert match["ipProtocol"] == "udp"
+    assert "application" not in match
+
+
+def test_normalize_match_application_only() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 160,
+            "match": {
+                "applicationBuiltin": "WhatsApp",
+            },
+            "action": "accept",
+        }
+    )
+    match = normalized["match"]
+    assert match["application"] == {"match": {"builtin": "WhatsApp"}}
+    assert "destinationNetwork" not in match
+    assert "sourceNetwork" not in match
+    assert "ipProtocol" not in match
+
+
+def test_normalize_match_rejects_application_and_network_together() -> None:
+    m = _mgr()
+    with pytest.raises(ConfigurationError, match="cannot combine application and network/L4"):
+        m._normalize_rule_body(
+            {
+                "seq": 1,
+                "match": {
+                    "applicationBuiltin": "WhatsApp",
+                    "destinationNetwork": "10.1.1.1/32",
+                    "ipProtocol": "tcp",
+                },
+                "action": "accept",
+            }
+        )
+
+
+def test_normalize_match_content_filter_and_domain_list() -> None:
+    m = _mgr()
+    normalized = m._normalize_rule_body(
+        {
+            "seq": 10,
+            "match": {
+                "ipProtocol": "tcp",
+                "domainCategoryIds": ["cat-1"],
+                "domainWildcards": ["*.example.com"],
+            },
+            "action": "reject",
+        }
+    )
+    match = normalized["match"]
+    assert match["contentFilter"] == {"match": {"domainCategoryIds": ["cat-1"]}}
+    assert match["domainList"] == {"match": {"domainWildcards": ["*.example.com"]}}
+
+
+def test_zones_payload_directional() -> None:
+    m = _mgr()
+    out = m._zones_payload_from_yaml(
+        [{"fromZone": "zone-DIA", "toZone": "zone-lan-1", "ruleset": "My-Ruleset"}],
+        operation="attach_to_zone_pairs",
+    )
+    assert out["zone-DIA"]["zone"]["pairs"]["zone-lan-1"]["pair"]["ruleset"] == "My-Ruleset"
+    assert "zone-lan-1" not in out
+
+
+def test_zones_detach_payload_clears_pair() -> None:
+    m = _mgr()
+    out = m._zones_payload_from_yaml(
+        [{"fromZone": "zone-DIA", "toZone": "zone-lan-1-test"}],
+        operation="detach_from_zone_pairs",
+    )
+    assert out["zone-DIA"]["zone"]["pairs"]["zone-lan-1-test"] == {}
+
+
+def test_zone_pairs_detach_idempotent_when_cleared() -> None:
+    m = _mgr()
+    desired_zones = m._zones_payload_from_yaml(
+        [{"fromZone": "zone-DIA", "toZone": "zone-lan-1-test"}],
+        operation="detach_from_zone_pairs",
+    )
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "zonePairs": [
+                    {
+                        "inside": "zone-DIA",
+                        "outside": "zone-lan-1-test",
+                        "tcpProtection": False,
+                    }
+                ]
+            }
+        }
+    }
+    assert m._zone_attachments_need_update(desired_zones, device) is False
+
+
+def test_zone_pairs_from_device_get_shape() -> None:
+    m = _mgr()
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "zonePairs": [
+                    {
+                        "inside": "zone-DIA",
+                        "outside": "zone-lan-1-test",
+                        "ruleset": "G-30000056600-Edge-1-Security-Policy-DIA-LAN-1-TEST",
+                        "tcpProtection": False,
+                    }
+                ]
+            }
+        }
+    }
+    pairs = m._extract_zone_pairs_from_device(device)
+    assert m._zone_pair_matches(
+        pairs,
+        "zone-DIA",
+        "zone-lan-1-test",
+        "Edge-1-Security-Policy-DIA-LAN-1-TEST",
+        False,
+    )
+
+
+def test_ruleset_idempotency_network_rule_protocol_get_shape() -> None:
+    m = _mgr()
+    desired_rs = {
+        "Edge-1-Security-Policy-Same-LAN-1": {
+            "ruleset": {
+                "name": "Edge-1-Security-Policy-Same-LAN-1",
+                "description": "Security policy for edge-1 Same LAN",
+                "implicitRuleAction": "reject",
+                "rules": {
+                    "150": {
+                        "rule": {
+                            "seq": 150,
+                            "logging": True,
+                            "match": {
+                                "ipProtocol": "tcp",
+                                "protocol": {"ipProtocol": "tcp"},
+                                "destinationNetwork": {"destinationNetwork": "10.2.1.101/32"},
+                            },
+                            "uplinkPolicerRate": {"rate": 5000},
+                            "uplinkBurstRate": {"rate": 10000},
+                            "action": "reject",
+                        }
+                    }
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "G-30000056600-Edge-1-Security-Policy-Same-LAN-1",
+                        "description": "Security policy for edge-1 Same LAN",
+                        "rules": [
+                            {
+                                "seq": 150,
+                                "logging": True,
+                                "match": {
+                                    "ipProtocol": "tcp",
+                                    "destinationNetwork": {"destinationNetwork": "10.2.1.101/32"},
+                                },
+                                "uplinkPolicerRate": 5000,
+                                "uplinkBurstRate": 10000,
+                                "action": "reject",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False
+
+
+def test_ruleset_idempotency_missing_downlink_when_equal_to_uplink() -> None:
+    m = _mgr()
+    desired_rs = {
+        "Edge-1-Security-Policy-LAN-1-TEST-DIA": {
+            "ruleset": {
+                "name": "Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                "description": "Security policy for edge-1 LAN-1-TEST to DIA",
+                "implicitRuleAction": "reject",
+                "rules": {
+                    "150": {
+                        "rule": {
+                            "seq": 150,
+                            "logging": True,
+                            "match": {"application": {"match": {"builtin": "Facebook"}}},
+                            "action": "inspect",
+                            "uplinkPolicerRate": {"rate": 5000},
+                            "uplinkBurstRate": {"rate": 10000},
+                            "downlinkPolicerRate": {"rate": 5000},
+                            "downlinkBurstRate": {"rate": 10000},
+                        }
+                    }
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "G-30000056600-Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                        "description": "Security policy for edge-1 LAN-1-TEST to DIA",
+                        "rules": [
+                            {
+                                "seq": 150,
+                                "logging": True,
+                                "match": {"application": {"match": {"builtin": "Facebook"}}},
+                                "action": "inspect",
+                                "uplinkPolicerRate": 5000,
+                                "uplinkBurstRate": 10000,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False
+
+
+def test_ruleset_idempotency_reject_rule_omits_meter_rates_on_get() -> None:
+    m = _mgr()
+    desired_rs = {
+        "Edge-1-Security-Policy-LAN-1-TEST-DIA": {
+            "ruleset": {
+                "name": "Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                "rules": {
+                    "170": {
+                        "rule": {
+                            "seq": 170,
+                            "logging": True,
+                            "match": {"application": {"match": {"custom": "graphiant_dia_ping"}}},
+                            "action": "reject",
+                            "uplinkPolicerRate": {"rate": 5000},
+                            "uplinkBurstRate": {"rate": 10000},
+                        }
+                    }
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                        "rules": [
+                            {
+                                "seq": 170,
+                                "logging": True,
+                                "match": {"application": {"match": {"custom": "graphiant_dia_ping"}}},
+                                "action": "reject",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False
+
+
+def test_ruleset_idempotency_action_dict_on_get() -> None:
+    m = _mgr()
+    desired_rs = {
+        "Edge-1-Security-Policy-LAN-1-TEST-DIA": {
+            "ruleset": {
+                "name": "Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                "rules": {
+                    "150": {
+                        "rule": {
+                            "seq": 150,
+                            "logging": True,
+                            "match": {"application": {"match": {"builtin": "Facebook"}}},
+                            "action": "inspect",
+                        }
+                    },
+                    "170": {
+                        "rule": {
+                            "seq": 170,
+                            "logging": True,
+                            "match": {"application": {"match": {"custom": "graphiant_dia_ping"}}},
+                            "action": "reject",
+                        }
+                    },
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "G-30000056600-Edge-1-Security-Policy-LAN-1-TEST-DIA",
+                        "rules": [
+                            {
+                                "seq": 150,
+                                "logging": True,
+                                "match": {"application": {"match": {"builtin": "Facebook"}}},
+                                "action": {"action": "inspect"},
+                            },
+                            {
+                                "seq": 170,
+                                "logging": True,
+                                "match": {"application": {"match": {"custom": "graphiant_dia_ping"}}},
+                                "action": "reject",
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False
+
+
+def test_ruleset_idempotency_drop_equivalent_to_reject_on_get() -> None:
+    m = _mgr()
+    desired_rs = {
+        "rs1": {
+            "ruleset": {
+                "name": "rs1",
+                "rules": {
+                    "10": {
+                        "rule": {
+                            "seq": 10,
+                            "logging": True,
+                            "match": {"application": {"match": {"custom": "my-app"}}},
+                            "action": "drop",
+                        }
+                    }
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "rs1",
+                        "rules": [
+                            {
+                                "seq": 10,
+                                "logging": True,
+                                "match": {"application": {"match": {"custom": "my-app"}}},
+                                "action": "reject",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False
+
+
+def test_ruleset_idempotency_generated_name_and_meter_rates() -> None:
+    m = _mgr()
+    desired_rs = {
+        "rs1": {
+            "ruleset": {
+                "name": "rs1",
+                "description": "test",
+                "implicitRuleAction": "reject",
+                "rules": {
+                    "150": {
+                        "rule": {
+                            "seq": 150,
+                            "logging": True,
+                            "match": {"application": {"match": {"builtin": "WhatsApp"}}},
+                            "uplinkPolicerRate": {"rate": 5000},
+                            "uplinkBurstRate": {"rate": 10000},
+                            "action": "accept",
+                        }
+                    }
+                },
+            }
+        }
+    }
+    device = {
+        "device": {
+            "trafficPolicy": {
+                "securityRulesets": [
+                    {
+                        "name": "G-30000056600-rs1",
+                        "description": "test",
+                        "rules": [
+                            {
+                                "seq": 150,
+                                "logging": True,
+                                "match": {"application": {"match": {"builtin": "WhatsApp"}}},
+                                "uplinkPolicerRate": 5000,
+                                "uplinkBurstRate": 10000,
+                                "action": "accept",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    assert m._security_rulesets_need_update(desired_rs, device) is False

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_security_policy.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_security_policy.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for graphiant_security_policy module (mocked Ansible + connection)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.graphiant.naas.plugins.modules import graphiant_security_policy
+
+
+def _base_params() -> dict:
+    return {
+        "host": "https://api.example.com",
+        "username": "u",
+        "password": "p",
+        "access_token": None,
+        "security_policy_config_file": "sample_device_security_policies.yaml",
+        "operation": "configure",
+        "state": "present",
+        "detailed_logs": False,
+    }
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_security_policy.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_security_policy.AnsibleModule")
+def test_main_configure_calls_security_policy_manager(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mod.params["operation"] = "configure"
+    mock_ansible_module.return_value = mod
+
+    spm = MagicMock()
+    spm.configure.return_value = {
+        "changed": True,
+        "configured_devices": ["edge-1-sdktest"],
+        "skipped_devices": [],
+    }
+    gc = MagicMock()
+    gc.security_policy = spm
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_security_policy.main()
+
+    spm.configure.assert_called_once_with("sample_device_security_policies.yaml")
+    mod.exit_json.assert_called_once()
+    kwargs = mod.exit_json.call_args[1]
+    assert kwargs["operation"] == "configure"
+    assert kwargs["changed"] is True
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_security_policy.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_security_policy.AnsibleModule")
+def test_main_state_absent_defaults_to_deconfigure(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = None
+    p["state"] = "absent"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    spm = MagicMock()
+    spm.deconfigure.return_value = {
+        "changed": False,
+        "configured_devices": [],
+        "skipped_devices": ["edge-1-sdktest"],
+    }
+    gc = MagicMock()
+    gc.security_policy = spm
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_security_policy.main()
+
+    spm.deconfigure.assert_called_once_with("sample_device_security_policies.yaml")
+    mod.exit_json.assert_called_once()
+    assert mod.exit_json.call_args[1]["operation"] == "deconfigure"


### PR DESCRIPTION
## Description
Adds support for Security Policy automation through the Ansible collection. This feature enables users to configure, update, and remove Security Policies programmatically, improving automation coverage and operational consistency.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [x] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [x] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

Validated the following scenarios using the Ansible collection:

- Configure Security Policies
- Update existing Security Policies
- Add new policy rules
- Modify policy rules
- Remove policy rules
- Deconfigure Security Policies
- Attach/Detach to the zone pairs

[Ansible_playbook_security_policy.txt](https://github.com/user-attachments/files/29109342/Ansible_playbook_security_policy.txt)
[test.txt](https://github.com/user-attachments/files/29109343/test.txt)


## Related Issues

https://github.com/Graphiant-Inc/graphiant-playbooks/issues/93

Fixes #
Related to #

## Additional Notes

Updated README, module utilities, and test coverage to support Security Policy automation functionality.

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
