### PR TITLE
Support for DHCP Relay

### DIFF
--- a/ansible_collections/graphiant/naas/README.md
+++ b/ansible_collections/graphiant/naas/README.md
@@ -21,6 +21,7 @@ This collection provides Ansible modules to automate:
 - Core (backbone) device configuration — interfaces, ISP circuits, direct-peer circuits, site info, and per-VRF syslog targets
 - Static routes management (per-segment configure/deconfigure)
 - VRRP (Virtual Router Redundancy Protocol) configuration
+- DHCP relay on main interfaces and VLAN subinterfaces
 - LAG (Link Aggregation Group) interface configuration
 - Interface MACsec (802.1AE) configuration and monitoring on Edge/Gateway devices
 - BGP peering management (including BFD — Bidirectional Forwarding Detection)
@@ -67,6 +68,7 @@ This collection provides Ansible modules to automate:
 | `graphiant_backbone` | Manage Graphiant Core (backbone) device interfaces, ISP circuits, direct-peer circuits, site info, and per-VRF syslog targets |
 | `graphiant_static_routes` | Manage static routes (per-segment configure/deconfigure/validate) |
 | `graphiant_vrrp` | Manage VRRP (Virtual Router Redundancy Protocol) configuration |
+| `graphiant_dhcp_relay` | Manage DHCP relay (IPv4/IPv6) on main interfaces and subinterfaces |
 | `graphiant_lag_interfaces` | Manage LAG interfaces configuration |
 | `graphiant_macsec` | Configure interface MACsec (802.1AE) on Edge/Gateway devices |
 | `graphiant_macsec_info` | Query MACsec monitoring status (secure/unsecure) per interface |
@@ -391,6 +393,7 @@ The collection includes ready-to-use example playbooks in the `playbooks/` direc
 | `backbone_management.yml` | Core (backbone) device management operations |
 | `static_routes_management.yml` | Static routes configure/deconfigure/validate |
 | `vrrp_interface_management.yml` | VRRP configuration on interfaces and subinterfaces |
+| `dhcp_relay_interface_management.yml` | DHCP relay on main interfaces and subinterfaces |
 | `lag_interface_management.yml` | LAG interface configuration |
 | `macsec_management.yml` | Interface MACsec configuration and monitoring status |
 | `circuit_management.yml` | Circuit configuration and static routes |
@@ -442,6 +445,7 @@ ansible-doc graphiant.naas.graphiant_security_policy
 ansible-doc graphiant.naas.graphiant_device_system
 ansible-doc graphiant.naas.graphiant_edge_services
 ansible-doc graphiant.naas.graphiant_vrrp
+ansible-doc graphiant.naas.graphiant_dhcp_relay
 ansible-doc graphiant.naas.graphiant_lag_interfaces
 ansible-doc graphiant.naas.graphiant_macsec
 ansible-doc graphiant.naas.graphiant_macsec_info
@@ -514,13 +518,13 @@ Use `ansible-playbook ... --check` or set `check_mode: true` on a task to run wi
 
 | Support | Modules | Behavior |
 |--------|---------|----------|
-| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list`, `graphiant_traffic_policy`, `graphiant_security_policy` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
+| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_dhcp_relay`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list`, `graphiant_traffic_policy`, `graphiant_security_policy` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
 | **Partial** | `graphiant_bgp`, `graphiant_device_config`, `graphiant_backbone`                                                                                                                                                                                                                                                                    | Writes are still skipped, but `changed` is not computed from a full live diff: BGP reports `changed: true` for configure/deconfigure/detach in check mode; `graphiant_device_config` returns `changed: false` for `show_validated_payload` and `changed: true` for `configure`; `graphiant_backbone` reports `changed: true` whenever the supplied config file contains matching backbone resources (no live diff against current Core device state). See each module's `attributes.check_mode` details. |
 | **Read-only** | `graphiant_macsec_info` | Always read-only; check mode has no side effects. |
 
-**Full-mode nuances:** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_traffic_policy`, and `graphiant_security_policy` read device state in check mode and set `changed` from whether an apply would be needed. For LWS, omit `localWebServerPasswordForce` after a successful set—force re-pushes every run because the portal stores a hash. `graphiant_data_exchange_info` and `graphiant_macsec_info` are always read-only. `graphiant_data_exchange` skips mutating writes in check mode; see that module's `attributes.check_mode` for details.
+**Full-mode nuances:** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, and `graphiant_security_policy` read device state in check mode and set `changed` from whether an apply would be needed. For LWS, omit `localWebServerPasswordForce` after a successful set—force re-pushes every run because the portal stores a hash. `graphiant_data_exchange_info` and `graphiant_macsec_info` are always read-only. `graphiant_data_exchange` skips mutating writes in check mode; see that module's `attributes.check_mode` for details.
 
-**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_prefix_port_list`, `graphiant_macsec`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_data_exchange`, `graphiant_ntp`, `graphiant_static_routes`, and `graphiant_site_to_site_vpn` support `--diff`. Use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan`. For `graphiant_data_exchange`, diff is available for `create_services`, `update_services`, `create_customers`, and `update_customers`; in `--check --diff` mode, `create_customers` also surfaces `adminEmail` drift on existing customers with a hint to use `update_customers`. For `graphiant_site_to_site_vpn`, secrets (`presharedKey`, `md5Password`) are redacted in diff output.
+**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_prefix_port_list`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_data_exchange`, `graphiant_ntp`, `graphiant_static_routes`, and `graphiant_site_to_site_vpn` support `--diff`. Use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan`. For `graphiant_data_exchange`, diff is available for `create_services`, `update_services`, `create_customers`, and `update_customers`; in `--check --diff` mode, `create_customers` also surfaces `adminEmail` drift on existing customers with a hint to use `update_customers`. For `graphiant_site_to_site_vpn`, secrets (`presharedKey`, `md5Password`) are redacted in diff output. For `graphiant_dhcp_relay`, diff shows per-interface relay server lists under `edge.interfaces`.
 
 **Example: run playbooks in check mode (dry run)**
 
@@ -535,6 +539,7 @@ ansible-playbook playbooks/macsec_management.yml --tags configure -e config_file
 
 ansible-playbook playbooks/ntp_management.yml --tags configure --check --diff
 ansible-playbook playbooks/static_routes_management.yml --tags configure --check --diff
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tags configure --check --diff
 ansible-playbook playbooks/site_to_site_vpn.yml --tag create --check --diff --vault-password-file configs/vault-password-file.sh
 # Data Exchange: check + diff to preview creates and detect adminEmail drift on existing customers
 ansible-playbook playbooks/de_workflows/02_dataex_create_customers.yml --check --diff
@@ -670,6 +675,7 @@ Configuration files use YAML format with optional Jinja2 templating. Sample file
 - `sample_device_traffic_policies.yaml` - Traffic rulesets under `edge.trafficPolicy` and LAN segment ruleset attachments under `edge.segments` (use configure + attach_to_lan_segments, or the `traffic_policies_management.yml` playbook `--tags configure`)
 - `sample_device_security_policies.yaml` - Security rulesets under `edge.trafficPolicy.securityRulesets` and zone pair ruleset attachments under `edge.trafficPolicy.zones` (use configure + attach_to_zone_pairs, or the `security_policies_management.yml` playbook `--tags configure`). Custom application matches (`applicationCustom`) require DPI applications from `graphiant_edge_services` / `sample_edge_services.yaml`.
 - `sample_vrrp_config.yaml` - VRRP (Virtual Router Redundancy Protocol) configurations
+- `sample_dhcp_relay_config.yaml` - DHCP relay on main interfaces and VLAN subinterfaces (`edge.interfaces.*.ipv4/ipv6.dhcp.dhcpRelay`)
 - `sample_lag_interface_config.yaml` - LAG interface configurations
 - `sample_macsec.yaml` - Interface MACsec (PSK/SAK) configuration; CAK via `vault_devices_macsec_psk` in `vault_secrets.yml`
 - `sample_bgp_peering.yaml` - BGP peering configurations

--- a/ansible_collections/graphiant/naas/changelogs/changelog.yaml
+++ b/ansible_collections/graphiant/naas/changelogs/changelog.yaml
@@ -5,6 +5,11 @@
 
 ancestor: null
 releases:
+  "26.7.0":
+    release_date: "2026-07-31"
+    changes:
+      minor_changes:
+        - "New ``graphiant_dhcp_relay`` module and ``dhcp_relay_interface_management.yml`` playbook for DHCP relay (IPv4/IPv6) on main interfaces and VLAN subinterfaces; sample ``sample_dhcp_relay_config.yaml``; operations ``configure`` / ``deconfigure``; idempotent comparison to live device relay server lists; interface/subinterface existence validation before push; deep merge when multiple VLAN subinterfaces on the same parent are configured in one run; full check mode and diff mode (``--check --diff`` returns accurate ``changed``, ``details.diff_plan``, and Ansible ``diff`` with per-interface relay server ``before``/``after`` under ``edge.interfaces``); integration tests in ``tests/test.py``"
   "26.6.0":
     release_date: "2026-07-10"
     changes:

--- a/ansible_collections/graphiant/naas/configs/sample_dhcp_relay_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_dhcp_relay_config.yaml
@@ -1,0 +1,44 @@
+# DHCP Relay Configuration Parameters:
+# ====================================
+# name: Parent interface name (e.g., GigabitEthernet5/0/0)
+# vlan: (optional) VLAN ID for subinterface DHCP relay. Omit for main interface.
+# dhcpRelayIpv4: List of IPv4 relay server addresses (or {relayServers: [...]} if preferred)
+# dhcpRelayIpv6: List of IPv6 relay server addresses (or {relayServers: [...]} if preferred)
+
+dhcp_relay_config:
+  # Main interface and Subinterface DHCP relay.
+  - edge-1-sdktest:
+    - name: GigabitEthernet7/0/0
+      dhcpRelayIpv4:
+        - 10.2.1.2
+      dhcpRelayIpv6:
+        - 2001:10:2:1::2
+        - 2001:10:4:1::2
+    - name: GigabitEthernet7/0/0
+      vlan: 18
+      dhcpRelayIpv4:
+        - 10.2.1.3
+        - 10.6.1.4
+      dhcpRelayIpv6:
+        - 2001:10:2:1::3
+        - 2001:10:6:1::4
+
+  # Main interface and multiple subinterfaces on the same parent (merged into one device PUT)
+  - edge-2-sdktest:
+    - name: GigabitEthernet8/0/0
+      dhcpRelayIpv4:
+        - 10.2.12.2
+        - 10.3.12.2
+    - name: GigabitEthernet8/0/0
+      vlan: 28
+      dhcpRelayIpv4:
+        - 10.4.178.2
+        - 10.5.178.2
+    - name: GigabitEthernet8/0/0
+      vlan: 29
+      dhcpRelayIpv4:
+        - 10.5.19.2
+    - name: GigabitEthernet8/0/0
+      vlan: 30
+      dhcpRelayIpv4:
+        - 10.5.19.2

--- a/ansible_collections/graphiant/naas/configs/sample_dhcp_relay_config.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_dhcp_relay_config.yaml
@@ -1,44 +1,73 @@
 # DHCP Relay Configuration Parameters:
 # ====================================
-# name: Parent interface name (e.g., GigabitEthernet5/0/0)
-# vlan: (optional) VLAN ID for subinterface DHCP relay. Omit for main interface.
-# dhcpRelayIpv4: List of IPv4 relay server addresses (or {relayServers: [...]} if preferred)
-# dhcpRelayIpv6: List of IPv6 relay server addresses (or {relayServers: [...]} if preferred)
+# interfaces:    List of interface entries for this device
+# name:          Parent interface name (e.g., GigabitEthernet5/0/0)
+# vlan:          (optional) VLAN ID for subinterface DHCP relay. Omit for main interface.
+# dhcpRelayIpv4: List of IPv4 relay server addresses, or {relayServers: [...]} dict,
+#                or {state: absent} to remove IPv4 relay only (per-AF state).
+# dhcpRelayIpv6: List of IPv6 relay server addresses (same format options as dhcpRelayIpv4).
+# state:         (optional, per-interface) Set to 'absent' to remove all relay from this
+#                interface entry while leaving others in the list unchanged.
+#
+# Per-interface state: absent -- remove all relay on one subinterface, configure others normally:
+#
+#   - edge-3-sdktest:
+#       interfaces:
+#         - name: GigabitEthernet7/0/0
+#           dhcpRelayIpv4:
+#             - 10.2.1.2
+#         - name: GigabitEthernet8/0/0
+#           vlan: 30
+#           state: absent          # removes all IPv4+IPv6 relay from this subinterface
+#
+# Per-AF state: absent -- remove only IPv4 relay, keep IPv6 (or vice versa):
+#
+#   - edge-3-sdktest:
+#       interfaces:
+#         - name: GigabitEthernet8/0/0
+#           vlan: 30
+#           dhcpRelayIpv4:
+#             state: absent        # removes IPv4 relay servers
+#           dhcpRelayIpv6:
+#             relayServers:
+#               - 2001:10:2:1::2  # keeps / updates IPv6
 
 dhcp_relay_config:
-  # Main interface and Subinterface DHCP relay.
+  # Main interface and subinterface DHCP relay.
   - edge-1-sdktest:
-    - name: GigabitEthernet7/0/0
-      dhcpRelayIpv4:
-        - 10.2.1.2
-      dhcpRelayIpv6:
-        - 2001:10:2:1::2
-        - 2001:10:4:1::2
-    - name: GigabitEthernet7/0/0
-      vlan: 18
-      dhcpRelayIpv4:
-        - 10.2.1.3
-        - 10.6.1.4
-      dhcpRelayIpv6:
-        - 2001:10:2:1::3
-        - 2001:10:6:1::4
+      interfaces:
+        - name: GigabitEthernet7/0/0
+          dhcpRelayIpv4:
+            - 10.2.1.2
+          dhcpRelayIpv6:
+            - 2001:10:2:1::2
+            - 2001:10:4:1::2
+        - name: GigabitEthernet7/0/0
+          vlan: 18
+          dhcpRelayIpv4:
+            - 10.2.1.3
+            - 10.6.1.4
+          dhcpRelayIpv6:
+            - 2001:10:2:1::3
+            - 2001:10:6:1::4
 
   # Main interface and multiple subinterfaces on the same parent (merged into one device PUT)
   - edge-2-sdktest:
-    - name: GigabitEthernet8/0/0
-      dhcpRelayIpv4:
-        - 10.2.12.2
-        - 10.3.12.2
-    - name: GigabitEthernet8/0/0
-      vlan: 28
-      dhcpRelayIpv4:
-        - 10.4.178.2
-        - 10.5.178.2
-    - name: GigabitEthernet8/0/0
-      vlan: 29
-      dhcpRelayIpv4:
-        - 10.5.19.2
-    - name: GigabitEthernet8/0/0
-      vlan: 30
-      dhcpRelayIpv4:
-        - 10.5.19.2
+      interfaces:
+        - name: GigabitEthernet8/0/0
+          dhcpRelayIpv4:
+            - 10.2.12.2
+            - 10.3.12.2
+        - name: GigabitEthernet8/0/0
+          vlan: 28
+          dhcpRelayIpv4:
+            - 10.4.178.2
+            - 10.5.178.2
+        - name: GigabitEthernet8/0/0
+          vlan: 29
+          dhcpRelayIpv4:
+            - 10.5.19.2
+        - name: GigabitEthernet8/0/0
+          vlan: 30
+          dhcpRelayIpv4:
+            - 10.5.19.2

--- a/ansible_collections/graphiant/naas/docs/README.md
+++ b/ansible_collections/graphiant/naas/docs/README.md
@@ -44,6 +44,7 @@ ansible-doc graphiant.naas.graphiant_global_config
 ansible-doc graphiant.naas.graphiant_sites
 ansible-doc graphiant.naas.graphiant_data_exchange
 ansible-doc graphiant.naas.graphiant_static_routes
+ansible-doc graphiant.naas.graphiant_dhcp_relay
 ansible-doc graphiant.naas.graphiant_ntp
 ansible-doc graphiant.naas.graphiant_traffic_policy
 ansible-doc graphiant.naas.graphiant_security_policy

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -268,6 +268,8 @@ For a **single device**, use module parameters (camelCase API names; snake_case 
 
 Each entry targets one pool on a LAN segment. `segment` must match the device LAN segment name; `interface` and `ipPrefix` must match an existing LAN interface/subinterface and its prefix (from `interface_management.yml --tags lan`). The API key is `{interface}-{ipPrefix}`. Use `state: absent` to remove a pool.
 
+**Mutual exclusion:** An interface supports either a DHCP subnet (server) or DHCP relay, not both. Configure fails if the target interface already has DHCP relay configured. Deconfigure the relay first (`graphiant_dhcp_relay` with `operation: deconfigure`) before adding a DHCP subnet.
+
 **YAML** (`configs/sample_edge_services.yaml`):
 
 ```yaml
@@ -827,6 +829,103 @@ ansible-playbook playbooks/vrrp_interface_management.yml --tag enable --check
     msg: "{{ enable_result.msg }}"
   when: enable_result is defined and enable_result.msg is defined
   tags: ['vrrp_interfaces', 'enable']
+```
+
+### Module: graphiant.naas.graphiant_dhcp_relay
+
+Configure DHCP relay (IPv4 and/or IPv6) on main interfaces and subinterfaces under `edge.interfaces.{name}.interface.ipv4.dhcp.dhcpRelay` (and the IPv6 equivalent). Payloads are built in Python (no Jinja2 template). See `configs/sample_dhcp_relay_config.yaml`.
+
+**Prerequisite:** Configure LAN/WAN interfaces first (`interface_management.yml --tag lan` or `--tag configure`).
+
+**YAML keys:**
+
+| Key | Description |
+|-----|-------------|
+| `dhcp_relay_config` | List of `{device_name: [interface entries]}` blocks |
+| `name` | Parent interface name (e.g. `GigabitEthernet4/0/0`) |
+| `vlan` | Optional VLAN ID for subinterface relay; omit for main interface |
+| `dhcpRelayIpv4` | List of IPv4 relay server addresses (or `{relayServers: [...]}`) |
+| `dhcpRelayIpv6` | List of IPv6 relay server addresses (same format) |
+
+**Idempotency:** Configure compares desired relay servers to live device state per interface and address family; deconfigure skips when relay is already removed for the families listed in YAML.
+
+**Validation:** Each entry is checked against interfaces on the device (main interface or subinterface). The task fails with a clear error if `name`/`vlan` does not exist — configure LAN/WAN interfaces first.
+
+**Mutual exclusion:** An interface supports either DHCP relay or a DHCP subnet (server), not both. Configure fails immediately if the target interface already has a DHCP subnet configured. Remove the DHCP subnet first (`graphiant_edge_services` with `state: absent`) before enabling DHCP relay on that interface.
+
+With `--check`, nothing is pushed; would-be payloads are logged with a `[check_mode]` prefix and `changed` reflects whether an apply would be needed. With `--diff`, pending changes appear in Ansible `diff` (`before` / `after`) and `details.diff_plan` (per-device relay server lists under `edge.interfaces`).
+
+#### Configure DHCP relay
+
+```bash
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag configure --check
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag configure --check --diff
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag configure
+```
+
+```yaml
+- name: Configure DHCP relay on interfaces
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    detailed_logs: true
+    state: present
+  register: configure_result
+  tags: ['dhcp_relay_interfaces', 'configure']
+
+- name: Display DHCP relay configuration results
+  ansible.builtin.debug:
+    msg: "{{ configure_result.msg }}"
+  when: configure_result is defined and configure_result.msg is defined
+  tags: ['dhcp_relay_interfaces', 'configure']
+```
+
+#### Deconfigure DHCP relay
+
+Deconfigure sets `relayServers: []` for each address family listed in the YAML entry (IPv4 and/or IPv6).
+
+```bash
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag deconfigure --check
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag deconfigure --check --diff
+ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag deconfigure
+```
+
+```yaml
+- name: Deconfigure DHCP relay from interfaces
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: deconfigure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    detailed_logs: true
+    state: absent
+  register: deconfigure_result
+  tags: ['dhcp_relay_interfaces', 'deconfigure']
+
+- name: Display DHCP relay deconfiguration results
+  ansible.builtin.debug:
+    msg: "{{ deconfigure_result.msg }}"
+  when: deconfigure_result is defined and deconfigure_result.msg is defined
+  tags: ['dhcp_relay_interfaces', 'deconfigure']
+```
+
+#### Sample YAML excerpt
+
+```yaml
+dhcp_relay_config:
+  - edge-1-sdktest:
+    - name: GigabitEthernet4/0/0
+      vlan: 1
+      dhcpRelayIpv4:
+        - 10.1.1.1
+        - 10.2.1.1
+      dhcpRelayIpv6:
+        - 2001:10:1:1::1
+  - edge-2-sdktest:
+    - name: GigabitEthernet8/0/0
+      dhcpRelayIpv4: 
+        - 10.1.11.1
+        - 10.2.11.1
 ```
 
 ### Module: graphiant.naas.graphiant_lag_interfaces
@@ -3066,27 +3165,28 @@ tasks:
 
 Sample configuration files are in the `configs/` directory:
 
-| File | Description |
-|------|-------------|
-| `sample_device_system.yaml` | Device system configuration (hostname, region and site name) |
-| `sample_interface_config.yaml` | Interface configurations |
-| `sample_circuit_config.yaml` | Circuit configurations |
-| `sample_bgp_peering.yaml` | BGP peering settings |
-| `sample_global_prefix_lists.yaml` | Prefix set definitions |
-| `sample_global_bgp_filters.yaml` | BGP filter definitions |
-| `sample_global_graphiant_filters.yaml` | Graphiant filter definitions (GraphiantIn / GraphiantOut) |
-| `sample_global_lan_segments.yaml` | LAN segment definitions |
-| `sample_global_ntp.yaml` | NTP object definitions |
-| `sample_global_vpn_profiles.yaml` | VPN profile definitions |
-| `sample_sites.yaml` | Site definitions |
-| `sample_site_attachments.yaml` | Site attachment configurations |
-| `sample_device_ntp.yaml` | Device NTP configuration  |
-| `sample_static_route.yaml` | Static routes under edge segments |
-| `sample_macsec.yaml` | Interface MACsec (802.1AE) on ethernet or LAG main interfaces |
-| `sample_edge_services.yaml` | Edge services (DHCP, DNS, LLDP, LWS password) |
+| File | Description                                                                                        |
+|------|----------------------------------------------------------------------------------------------------|
+| `sample_device_system.yaml` | Device system configuration (hostname, region and site name)                                       |
+| `sample_interface_config.yaml` | Interface configurations                                                                           |
+| `sample_circuit_config.yaml` | Circuit configurations                                                                             |
+| `sample_bgp_peering.yaml` | BGP peering settings                                                                               |
+| `sample_global_prefix_lists.yaml` | Prefix set definitions                                                                             |
+| `sample_global_bgp_filters.yaml` | BGP filter definitions                                                                             |
+| `sample_global_graphiant_filters.yaml` | Graphiant filter definitions (GraphiantIn / GraphiantOut)                                          |
+| `sample_global_lan_segments.yaml` | LAN segment definitions                                                                            |
+| `sample_global_ntp.yaml` | NTP object definitions                                                                             |
+| `sample_global_vpn_profiles.yaml` | VPN profile definitions                                                                            |
+| `sample_sites.yaml` | Site definitions                                                                                   |
+| `sample_site_attachments.yaml` | Site attachment configurations                                                                     |
+| `sample_device_ntp.yaml` | Device NTP configuration                                                                           |
+| `sample_static_route.yaml` | Static routes under edge segments                                                                  |
+| `sample_dhcp_relay_config.yaml` | DHCP relay on main interfaces and subinterfaces                                                    |
+| `sample_macsec.yaml` | Interface MACsec (802.1AE) on ethernet or LAG main interfaces                                      |
+| `sample_edge_services.yaml` | Edge services (DHCP, DNS, LLDP, LWS password)                                                      |
 | `sample_prefix_and_port_list.yaml` | Device-level prefix lists (`networkLists`) and port lists (`portLists`) under `edge.trafficPolicy` |
-| `sample_device_traffic_policies.yaml` | Device-level traffic policy rulesets and LAN segment attachments |
-| `sample_device_security_policies.yaml` | Device-level security policy rulesets and zone pair attachments |
+| `sample_device_traffic_policies.yaml` | Device-level traffic policy rulesets and LAN segment attachments                                   |
+| `sample_device_security_policies.yaml` | Device-level security policy rulesets and zone pair attachments                                    |
 
 Data Exchange configs are in `configs/de_workflows_configs/`.
 
@@ -3100,6 +3200,7 @@ For Python library usage, see `tests/test.py` which demonstrates:
 - Site operations
 - Device system settings
 - Edge services and MACsec configuration
+- DHCP relay on interfaces
 - Data Exchange workflows
 
 ```python
@@ -3116,6 +3217,9 @@ config.interfaces.configure_lan_interfaces("interface_config.yaml")
 
 # Configure BGP
 config.bgp.configure("bgp_config.yaml")
+
+# Configure DHCP relay on interfaces
+config.dhcp_relay_interfaces.configure("sample_dhcp_relay_config.yaml")
 
 # Configure global objects
 config.global_config.configure("global_prefix_lists.yaml")

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -839,13 +839,15 @@ Configure DHCP relay (IPv4 and/or IPv6) on main interfaces and subinterfaces und
 
 **YAML keys:**
 
-| Key | Description |
-|-----|-------------|
-| `dhcp_relay_config` | List of `{device_name: [interface entries]}` blocks |
-| `name` | Parent interface name (e.g. `GigabitEthernet4/0/0`) |
-| `vlan` | Optional VLAN ID for subinterface relay; omit for main interface |
-| `dhcpRelayIpv4` | List of IPv4 relay server addresses (or `{relayServers: [...]}`) |
-| `dhcpRelayIpv6` | List of IPv6 relay server addresses (same format) |
+| Key | Description                                                                                  |
+|-----|----------------------------------------------------------------------------------------------|
+| `dhcp_relay_config` | List of `{device_name: {interfaces: [...]}}` blocks                                          |
+| `interfaces` | List of interface entries for the device                                                     |
+| `name` | Parent interface name (e.g. `GigabitEthernet4/0/0`)                                          |
+| `vlan` | Optional VLAN ID for subinterface relay; omit for main interface                             |
+| `dhcpRelayIpv4` | List of IPv4 relay server addresses ` dict, or `{state: absent}` to remove                   |
+| `dhcpRelayIpv6` | List of IPv6 relay server addresses (same format)                                            |
+| `state` | Per-interface: `absent` removes all relay on that entry regardless of module-level operation |
 
 **Idempotency:** Configure compares desired relay servers to live device state per interface and address family; deconfigure skips when relay is already removed for the families listed in YAML.
 
@@ -909,23 +911,200 @@ ansible-playbook playbooks/dhcp_relay_interface_management.yml --tag deconfigure
   tags: ['dhcp_relay_interfaces', 'deconfigure']
 ```
 
-#### Sample YAML excerpt
+### Module task
+
+From YAML (configure tag — YAML drives all devices):
 
 ```yaml
-dhcp_relay_config:
-  - edge-1-sdktest:
-    - name: GigabitEthernet4/0/0
+- name: Configure DHCP relay on interfaces (from YAML)
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    dhcp_relay_config_file: "{{ config_file }}"
+    detailed_logs: true
+    state: present
+  register: configure_result
+  tags: ['configure']
+
+- name: Display DHCP relay configuration results
+  ansible.builtin.debug:
+    msg: |
+      {{ configure_result.msg | trim }}
+      configured_devices={{ configure_result.configured_devices | default([]) }}
+      skipped_devices={{ configure_result.skipped_devices | default([]) }}
+  when: configure_result is defined and configure_result.msg is defined
+  tags: ['configure']
+```
+
+For a **single device, single interface**, use module parameters directly:
+
+```yaml
+- name: Configure DHCP relay on a single interface (module params)
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    device: "edge-1-sdktest"
+    name: "GigabitEthernet4/0/0"
+    vlan: 1
+    dhcpRelayIpv4:
+      - 10.1.1.1
+      - 10.2.1.1
+    dhcpRelayIpv6:
+      - 2001:10:1:1::1
+    detailed_logs: true
+    state: present
+```
+
+For a **single device, multiple interfaces**, use the `interfaces` list:
+
+```yaml
+- name: Configure DHCP relay on multiple interfaces (module params)
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    device: "edge-1-sdktest"
+    interfaces:
+      - name: GigabitEthernet4/0/0
+        vlan: 1
+        dhcpRelayIpv4:
+          - 10.1.1.1
+          - 10.2.1.1
+        dhcpRelayIpv6:
+          - 2001:10:1:1::1
+      - name: GigabitEthernet8/0/0
+        dhcpRelayIpv4:
+          - 10.1.11.1
+          - 10.2.11.1
+    detailed_logs: true
+    state: present
+```
+
+For **multiple devices without a config file**, loop over a list (one interface per iteration):
+
+```yaml
+- name: Configure DHCP relay on multiple devices (loop)
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    device: "{{ item.device }}"
+    name: "{{ item.name }}"
+    vlan: "{{ item.vlan | default(omit) }}"
+    dhcpRelayIpv4: "{{ item.dhcpRelayIpv4 | default(omit) }}"
+    dhcpRelayIpv6: "{{ item.dhcpRelayIpv6 | default(omit) }}"
+  loop:
+    - device: edge-1-sdktest
+      name: GigabitEthernet4/0/0
       vlan: 1
       dhcpRelayIpv4:
         - 10.1.1.1
         - 10.2.1.1
       dhcpRelayIpv6:
         - 2001:10:1:1::1
-  - edge-2-sdktest:
-    - name: GigabitEthernet8/0/0
+    - device: edge-2-sdktest
+      name: GigabitEthernet8/0/0
       dhcpRelayIpv4: 
         - 10.1.11.1
-        - 10.2.11.1
+```
+
+To **override one device** from a YAML file (module params take precedence for that device):
+
+```yaml
+- name: Override DHCP relay for one device from file
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    device: "edge-1-sdktest"
+    name: "GigabitEthernet4/0/0"
+    dhcpRelayIpv4:
+      - 192.168.1.1
+```
+
+To **remove relay from a specific interface** while configuring others in the same run, use `state: absent` on that interface entry. The module-level `operation: configure` still applies to all other entries.
+
+```yaml
+- name: Configure relay on most interfaces, remove from one
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    device: "edge-3-sdktest"
+    interfaces:
+      - name: GigabitEthernet7/0/0         # configure as normal
+        dhcpRelayIpv4:
+          - 10.2.1.2
+      - name: GigabitEthernet8/0/0
+        vlan: 30
+        state: absent                       # remove all relay on this subinterface
+```
+
+YAML equivalent (inside `sample_dhcp_relay_config.yaml`):
+
+```yaml
+dhcp_relay_config:
+  - edge-3-sdktest:
+      interfaces:
+        - name: GigabitEthernet7/0/0
+          dhcpRelayIpv4:
+            - 10.2.1.2
+        - name: GigabitEthernet8/0/0
+          vlan: 30
+          state: absent                     # remove all relay on this subinterface
+```
+
+To **remove only one address family** while keeping the other, use `state: absent` on the individual `dhcpRelayIpv4` or `dhcpRelayIpv6` field:
+
+```yaml
+- name: Remove IPv4 relay only, keep IPv6
+  graphiant.naas.graphiant_dhcp_relay:
+    <<: *graphiant_client_params
+    operation: configure
+    device: "edge-3-sdktest"
+    interfaces:
+      - name: GigabitEthernet8/0/0
+        vlan: 30
+        dhcpRelayIpv4:
+          state: absent                     # removes IPv4 relay servers
+        dhcpRelayIpv6:
+          relayServers:
+            - 2001:10:2:1::2               # keeps / updates IPv6
+```
+
+YAML equivalent:
+
+```yaml
+dhcp_relay_config:
+  - edge-3-sdktest:
+      interfaces:
+        - name: GigabitEthernet8/0/0
+          vlan: 30
+          dhcpRelayIpv4:
+            state: absent
+          dhcpRelayIpv6:
+            relayServers:
+              - 2001:10:2:1::2
+```
+
+#### Sample YAML excerpt
+
+Each device entry uses an `interfaces:` list. The `vlan` key is optional (omit for main interface).
+
+```yaml
+dhcp_relay_config:
+  - edge-1-sdktest:
+      interfaces:
+        - name: GigabitEthernet4/0/0
+          vlan: 1
+          dhcpRelayIpv4:
+            - 10.1.1.1
+            - 10.2.1.1
+          dhcpRelayIpv6:
+            - 2001:10:1:1::1
+  - edge-2-sdktest:
+      interfaces:
+        - name: GigabitEthernet8/0/0
+          dhcpRelayIpv4:
+            - 10.1.11.1
+            - 10.2.11.1
 ```
 
 ### Module: graphiant.naas.graphiant_lag_interfaces

--- a/ansible_collections/graphiant/naas/playbooks/dhcp_relay_interface_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/dhcp_relay_interface_management.yml
@@ -1,0 +1,43 @@
+---
+- name: Manage Graphiant DHCP relay on interfaces
+  hosts: localhost
+  gather_facts: false
+  vars:
+    graphiant_client_params: &graphiant_client_params
+      host: "{{ graphiant_host | default(lookup('env', 'GRAPHIANT_HOST')) }}"
+      username: "{{ graphiant_username | default(lookup('env', 'GRAPHIANT_USERNAME')) }}"
+      password: "{{ graphiant_password | default(lookup('env', 'GRAPHIANT_PASSWORD')) }}"
+      access_token: "{{ graphiant_access_token | default(lookup('env', 'GRAPHIANT_ACCESS_TOKEN')) }}"
+
+  tasks:
+    - name: Configure DHCP relay on interfaces
+      graphiant.naas.graphiant_dhcp_relay:
+        <<: *graphiant_client_params
+        operation: configure
+        dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+        detailed_logs: true
+        state: present
+      register: configure_result
+      tags: ['dhcp_relay_interfaces', 'configure']
+
+    - name: Display DHCP relay configuration results
+      ansible.builtin.debug:
+        msg: "{{ configure_result.msg }}"
+      when: configure_result is defined and configure_result.msg is defined
+      tags: ['dhcp_relay_interfaces', 'configure']
+
+    - name: Deconfigure DHCP relay from interfaces
+      graphiant.naas.graphiant_dhcp_relay:
+        <<: *graphiant_client_params
+        operation: deconfigure
+        dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+        detailed_logs: true
+        state: absent
+      register: deconfigure_result
+      tags: ['dhcp_relay_interfaces', 'deconfigure']
+
+    - name: Display DHCP relay deconfiguration results
+      ansible.builtin.debug:
+        msg: "{{ deconfigure_result.msg }}"
+      when: deconfigure_result is defined and deconfigure_result.msg is defined
+      tags: ['dhcp_relay_interfaces', 'deconfigure']

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/dhcp_relay_interface_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/dhcp_relay_interface_manager.py
@@ -1,0 +1,442 @@
+"""
+DHCP Relay on Interfaces Manager for Graphiant Playbooks.
+
+Configures DHCP relay (ipv4/ipv6) on main interfaces and VLAN subinterfaces.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from .base_manager import BaseManager
+from .device_config_common import new_apply_result
+from .logger import setup_logger
+from .exceptions import ConfigurationError, DeviceNotFoundError
+
+LOG = setup_logger()
+
+
+class DhcpRelayInterfaceManager(BaseManager):
+    """Manage DHCP relay on main interfaces and subinterfaces."""
+
+    @staticmethod
+    def _relay_servers_from_config(relay_cfg: Any) -> List[str]:
+        if relay_cfg is None:
+            return []
+        if isinstance(relay_cfg, dict):
+            servers = relay_cfg.get("relayServers") or []
+            return [str(s) for s in servers] if isinstance(servers, list) else []
+        if isinstance(relay_cfg, (list, tuple)):
+            return [str(s) for s in relay_cfg]
+        return []
+
+    @classmethod
+    def _relay_servers_from_interface(cls, ip_obj: Any, af: str = "ipv4") -> List[str]:
+        if not ip_obj:
+            return []
+        relay = getattr(ip_obj, "dhcp_relay", None)
+        if not relay:
+            return []
+        attr = "dhcpv4_relays" if af == "ipv4" else "dhcpv6_relays"
+        servers = getattr(relay, attr, None) or []
+        if not isinstance(servers, list):
+            return []
+        return [str(s) for s in servers]
+
+    @staticmethod
+    def _interface_label(name: str, vlan: Optional[Any] = None) -> str:
+        if vlan is not None and vlan != "":
+            return f"{name}.{vlan}"
+        return name
+
+    @classmethod
+    def _get_interface_object(cls, gcs_device_info, interface_name: str, vlan: Optional[Any] = None):
+        if not hasattr(gcs_device_info, "device"):
+            return None
+
+        device = gcs_device_info.device
+        if not hasattr(device, "interfaces") or not device.interfaces:
+            return None
+
+        target_interface = None
+        for interface in device.interfaces:
+            if getattr(interface, "name", None) == interface_name:
+                target_interface = interface
+                break
+
+        if not target_interface:
+            return None
+
+        if vlan is not None and vlan != "":
+            vlan_int = int(vlan)
+            if hasattr(target_interface, "subinterfaces") and target_interface.subinterfaces:
+                for subintf in target_interface.subinterfaces:
+                    if getattr(subintf, "vlan", None) == vlan_int:
+                        return subintf
+            return None
+
+        return target_interface
+
+    @classmethod
+    def _list_known_interfaces(cls, gcs_device_info) -> List[str]:
+        names: set[str] = set()
+        if not hasattr(gcs_device_info, "device"):
+            return []
+
+        device = gcs_device_info.device
+        if not hasattr(device, "interfaces") or not device.interfaces:
+            return []
+
+        for interface in device.interfaces:
+            parent = getattr(interface, "name", None)
+            if parent:
+                names.add(str(parent))
+            subs = getattr(interface, "subinterfaces", None)
+            if subs:
+                for subintf in subs:
+                    vlan = getattr(subintf, "vlan", None)
+                    if parent is not None and vlan is not None:
+                        names.add(f"{parent}.{vlan}")
+
+        return sorted(names)
+
+    @classmethod
+    def _has_dhcp_subnet_on_interface(cls, gcs_device_info, interface_name: str, vlan=None) -> bool:
+        """Return True if any segment on the device has a DHCP subnet pool on this interface."""
+        label = cls._interface_label(str(interface_name), vlan)
+        device = getattr(gcs_device_info, "device", None)
+        if not device:
+            return False
+        for segment in getattr(device, "segments", None) or []:
+            for pool in getattr(segment, "dhcp_subnets", None) or []:
+                if getattr(pool, "interface", None) == label:
+                    return True
+        return False
+
+    @classmethod
+    def _validate_interface_entry(
+        cls,
+        device_name: str,
+        gcs_device_info,
+        interface_name: Any,
+        vlan: Optional[Any] = None,
+        operation: str = "configure",
+    ) -> None:
+        if not interface_name:
+            raise ConfigurationError(
+                f"Device '{device_name}': each dhcp relay entry " f"requires 'name' (interface name)."
+            )
+
+        intf_obj = cls._get_interface_object(gcs_device_info, interface_name, vlan)
+        if intf_obj is None:
+            label = cls._interface_label(str(interface_name), vlan)
+            known = cls._list_known_interfaces(gcs_device_info)
+            known_msg = (
+                ", ".join(known)
+                if known
+                else "(none — configure interfaces first, e.g. interface_management.yml --tags lan)"
+            )
+            raise ConfigurationError(
+                f"Device '{device_name}': dhcp relay references interface {label!r} which does not exist "
+                f"on this device. Known interfaces: {known_msg}."
+            )
+
+        if operation == "configure":
+            label = cls._interface_label(str(interface_name), vlan)
+            if cls._has_dhcp_subnet_on_interface(gcs_device_info, interface_name, vlan):
+                raise ConfigurationError(
+                    f"Device '{device_name}': cannot configure DHCP relay on interface {label!r} — "
+                    f"DHCP subnet (server) is already configured on this interface. "
+                    f"An interface supports either DHCP relay or DHCP subnet, not both."
+                )
+
+    @classmethod
+    def _get_existing_dhcp_relay_state(
+        cls, gcs_device_info, interface_name: str, vlan: Optional[Any] = None
+    ) -> Dict[str, List[str]]:
+        state: Dict[str, List[str]] = {"ipv4": [], "ipv6": []}
+        intf_obj = cls._get_interface_object(gcs_device_info, interface_name, vlan)
+        if not intf_obj:
+            return state
+
+        state["ipv4"] = cls._relay_servers_from_interface(getattr(intf_obj, "ipv4", None), af="ipv4")
+        state["ipv6"] = cls._relay_servers_from_interface(getattr(intf_obj, "ipv6", None), af="ipv6")
+        return state
+
+    @classmethod
+    def _has_relay_config(cls, config: Dict[str, Any]) -> bool:
+        ipv4_cfg = config.get("dhcpRelayIpv4")
+        ipv6_cfg = config.get("dhcpRelayIpv6")
+        return bool(cls._relay_servers_from_config(ipv4_cfg) or cls._relay_servers_from_config(ipv6_cfg))
+
+    @classmethod
+    def _desired_relay_state(cls, config: Dict[str, Any], action: str) -> Dict[str, List[str]]:
+        ipv4_cfg = config.get("dhcpRelayIpv4")
+        ipv6_cfg = config.get("dhcpRelayIpv6")
+        if action == "delete":
+            desired: Dict[str, List[str]] = {"ipv4": [], "ipv6": []}
+            if ipv4_cfg is not None:
+                desired["ipv4"] = []
+            if ipv6_cfg is not None:
+                desired["ipv6"] = []
+            return desired
+        return {
+            "ipv4": cls._relay_servers_from_config(ipv4_cfg) if ipv4_cfg is not None else [],
+            "ipv6": cls._relay_servers_from_config(ipv6_cfg) if ipv6_cfg is not None else [],
+        }
+
+    @classmethod
+    def _relay_afs_in_scope(cls, config: Dict[str, Any]) -> List[str]:
+        afs: List[str] = []
+        if config.get("dhcpRelayIpv4") is not None:
+            afs.append("ipv4")
+        if config.get("dhcpRelayIpv6") is not None:
+            afs.append("ipv6")
+        return afs
+
+    @classmethod
+    def _relay_state_matches(
+        cls, existing: Dict[str, List[str]], desired: Dict[str, List[str]], afs: List[str], action: str
+    ) -> bool:
+        for af in afs:
+            existing_servers = sorted(existing.get(af) or [])
+            desired_servers = sorted(desired.get(af) or [])
+            if action == "delete":
+                if existing_servers:
+                    return False
+            elif existing_servers != desired_servers:
+                return False
+        return True
+
+    @classmethod
+    def _dhcp_relay_block(cls, relay_cfg: Any, action: str) -> Optional[Dict[str, Any]]:
+        if action == "delete":
+            if relay_cfg is None:
+                return None
+            return {"dhcp": {"dhcpRelay": {"relayServers": []}}}
+
+        servers = cls._relay_servers_from_config(relay_cfg)
+        if not servers:
+            return None
+        return {"dhcp": {"dhcpRelay": {"relayServers": servers}}}
+
+    @classmethod
+    def build_dhcp_relay_interfaces_payload(cls, action: str, **config: Any) -> Dict[str, Any]:
+        """Build edge.interfaces payload for DHCP relay configure or deconfigure."""
+        name = config["name"]
+        vlan = config.get("vlan")
+        ipv4_cfg = config.get("dhcpRelayIpv4")
+        ipv6_cfg = config.get("dhcpRelayIpv6")
+
+        ip_blocks: Dict[str, Any] = {}
+        ipv4_block = cls._dhcp_relay_block(ipv4_cfg, action)
+        if ipv4_block:
+            ip_blocks["ipv4"] = ipv4_block
+        ipv6_block = cls._dhcp_relay_block(ipv6_cfg, action)
+        if ipv6_block:
+            ip_blocks["ipv6"] = ipv6_block
+
+        if not ip_blocks:
+            return {}
+
+        if vlan is not None and vlan != "":
+            interface_body = {"vlan": int(vlan), **ip_blocks}
+            return {
+                "interfaces": {
+                    name: {
+                        "interface": {
+                            "subinterfaces": {
+                                str(vlan): {
+                                    "interface": interface_body,
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+        return {"interfaces": {name: {"interface": ip_blocks}}}
+
+    @classmethod
+    def _deep_merge_subinterface_entry(cls, base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+        _bi: Any = base.get("interface")
+        base_intf: Dict[str, Any] = _bi if isinstance(_bi, dict) else {}
+        _ui: Any = update.get("interface")
+        upd_intf: Dict[str, Any] = _ui if isinstance(_ui, dict) else {}
+        if base_intf or upd_intf:
+            merged = dict(base_intf)
+            merged.update(upd_intf)
+            return {"interface": merged}
+        return update if update else base
+
+    @classmethod
+    def _deep_merge_interface_entry(cls, base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge two interface stubs for the same parent interface name."""
+        base_intf = dict(base.get("interface") or {})
+        upd_intf = dict(update.get("interface") or {})
+        merged_intf = dict(base_intf)
+
+        for key, val in upd_intf.items():
+            if key == "subinterfaces":
+                merged_subs = dict(base_intf.get("subinterfaces") or {})
+                for vlan_key, sub_entry in (val or {}).items():
+                    if vlan_key in merged_subs:
+                        merged_subs[vlan_key] = cls._deep_merge_subinterface_entry(merged_subs[vlan_key], sub_entry)
+                    else:
+                        merged_subs[vlan_key] = sub_entry
+                merged_intf["subinterfaces"] = merged_subs
+            else:
+                merged_intf[key] = val
+
+        return {"interface": merged_intf}
+
+    @classmethod
+    def merge_dhcp_relay_payload(cls, config_payload: Dict[str, Any], relay_payload: Dict[str, Any]) -> None:
+        if not relay_payload.get("interfaces"):
+            return
+        if "interfaces" not in config_payload:
+            config_payload["interfaces"] = {}
+
+        for iface_name, iface_data in relay_payload["interfaces"].items():
+            existing = config_payload["interfaces"].get(iface_name)
+            if existing is None:
+                config_payload["interfaces"][iface_name] = iface_data
+            else:
+                config_payload["interfaces"][iface_name] = cls._deep_merge_interface_entry(existing, iface_data)
+
+    def _load_device_configs(self, dhcp_relay_config_file: str) -> Dict[str, List[Dict[str, Any]]]:
+        dhcp_relay_config_data = self.render_config_file(dhcp_relay_config_file)
+        device_configs: Dict[str, List[Dict[str, Any]]] = {}
+        for device_info in dhcp_relay_config_data.get("dhcp_relay_config") or []:
+            for device_name, config_list in device_info.items():
+                device_configs[device_name] = config_list
+        return device_configs
+
+    def apply_dhcp_relay_interfaces(self, dhcp_relay_config_file: str, operation: str) -> Dict[str, Any]:
+        action = "add" if operation == "configure" else "delete"
+        result = new_apply_result(
+            deconfigured_interfaces=[],
+            skipped_interfaces=[],
+        )
+        output_config: Dict[int, Dict[str, Any]] = {}
+
+        try:
+            for device_name, interfaces in self._load_device_configs(dhcp_relay_config_file).items():
+                device_id = self.gsdk.get_device_id(device_name)
+                if device_id is None:
+                    raise ConfigurationError(
+                        f"Device '{device_name}' is not found in the current enterprise: "
+                        f"{self.gsdk.enterprise_info['company_name']}. "
+                        f"Please check device name and enterprise credentials."
+                    )
+
+                gcs_device_info = self.gsdk.get_device_info(device_id)
+                device_before: Dict[str, Any] = {}
+                device_after: Dict[str, Any] = {}
+                device_changed = False
+
+                for config in interfaces:
+                    interface_name = config.get("name")
+                    vlan = config.get("vlan")
+                    label = self._interface_label(str(interface_name or ""), vlan)
+
+                    self._validate_interface_entry(
+                        device_name, gcs_device_info, interface_name, vlan, operation=operation
+                    )
+
+                    if operation == "configure" and not self._has_relay_config(config):
+                        LOG.info(
+                            "Skipping interface '%s' on %s - no DHCP relay servers configured",
+                            interface_name,
+                            device_name,
+                        )
+                        continue
+
+                    afs = self._relay_afs_in_scope(config)
+                    if not afs:
+                        continue
+
+                    existing = self._get_existing_dhcp_relay_state(gcs_device_info, str(interface_name), vlan)
+                    desired = self._desired_relay_state(config, action)
+
+                    if self._relay_state_matches(existing, desired, afs, action):
+                        result["skipped_interfaces"].append(
+                            {
+                                "device": device_name,
+                                "interface": interface_name,
+                                "vlan": vlan,
+                                "reason": "DHCP relay already matches desired state",
+                            }
+                        )
+                        continue
+
+                    payload = self.build_dhcp_relay_interfaces_payload(action=action, **config)
+                    if not payload:
+                        result["skipped_interfaces"].append(
+                            {
+                                "device": device_name,
+                                "interface": interface_name,
+                                "vlan": vlan,
+                                "reason": "No DHCP relay payload generated",
+                            }
+                        )
+                        continue
+
+                    if device_id not in output_config:
+                        output_config[device_id] = {"device_id": device_id, "edge": {"interfaces": {}}}
+
+                    self.merge_dhcp_relay_payload(output_config[device_id]["edge"], payload)
+                    device_changed = True
+
+                    before_entry = {
+                        af: {"dhcp": {"dhcpRelay": {"relayServers": list(existing.get(af) or []) or None}}}
+                        for af in afs
+                    }
+                    after_entry = {
+                        af: {"dhcp": {"dhcpRelay": {"relayServers": list(desired.get(af) or []) or None}}} for af in afs
+                    }
+                    device_before[label] = before_entry
+                    device_after[label] = after_entry
+
+                    if operation == "configure":
+                        LOG.info("Will configure DHCP relay on %s for device %s", label, device_name)
+                    else:
+                        result["deconfigured_interfaces"].append(
+                            {"device": device_name, "interface": interface_name, "vlan": vlan}
+                        )
+                        LOG.info("Will deconfigure DHCP relay on %s for device %s", label, device_name)
+
+                if device_changed:
+                    result["configured_devices"].append(device_name)
+                    result["diff_plan"].append(
+                        {
+                            "device": device_name,
+                            "branch": "edge.interfaces",
+                            "before": device_before,
+                            "after": device_after,
+                        }
+                    )
+                else:
+                    result["skipped_devices"].append(device_name)
+
+            if output_config:
+                self.execute_concurrent_tasks(self.gsdk.put_device_config, output_config)
+                result["changed"] = True
+
+            return result
+        except DeviceNotFoundError:
+            raise
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise ConfigurationError(f"DHCP relay interface {operation} failed: {str(e)}")
+
+    def configure(self, config_yaml_file: str) -> Dict[str, Any]:
+        return self.configure_dhcp_relay_interfaces(config_yaml_file)
+
+    def deconfigure(self, config_yaml_file: str) -> Dict[str, Any]:
+        return self.deconfigure_dhcp_relay_interfaces(config_yaml_file)
+
+    def configure_dhcp_relay_interfaces(self, dhcp_relay_config_file: str) -> Dict[str, Any]:
+        return self.apply_dhcp_relay_interfaces(dhcp_relay_config_file, operation="configure")
+
+    def deconfigure_dhcp_relay_interfaces(self, dhcp_relay_config_file: str) -> Dict[str, Any]:
+        return self.apply_dhcp_relay_interfaces(dhcp_relay_config_file, operation="deconfigure")

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/dhcp_relay_interface_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/dhcp_relay_interface_manager.py
@@ -7,7 +7,7 @@ Configures DHCP relay (ipv4/ipv6) on main interfaces and VLAN subinterfaces.
 from typing import Any, Dict, List, Optional
 
 from .base_manager import BaseManager
-from .device_config_common import new_apply_result
+from .device_config_common import load_device_list_yaml_config, new_apply_result
 from .logger import setup_logger
 from .exceptions import ConfigurationError, DeviceNotFoundError
 
@@ -161,27 +161,39 @@ class DhcpRelayInterfaceManager(BaseManager):
         state["ipv6"] = cls._relay_servers_from_interface(getattr(intf_obj, "ipv6", None), af="ipv6")
         return state
 
+    @staticmethod
+    def _af_action(iface_action: str, af_cfg: Any) -> str:
+        """Return the effective action for one address family, respecting per-AF state."""
+        if isinstance(af_cfg, dict):
+            af_state = af_cfg.get("state")
+            if af_state == "absent":
+                return "delete"
+            if af_state == "present":
+                return "add"
+        return iface_action
+
     @classmethod
     def _has_relay_config(cls, config: Dict[str, Any]) -> bool:
-        ipv4_cfg = config.get("dhcpRelayIpv4")
-        ipv6_cfg = config.get("dhcpRelayIpv6")
-        return bool(cls._relay_servers_from_config(ipv4_cfg) or cls._relay_servers_from_config(ipv6_cfg))
+        for key in ("dhcpRelayIpv4", "dhcpRelayIpv6"):
+            af_cfg = config.get(key)
+            if af_cfg is None:
+                continue
+            if isinstance(af_cfg, dict) and "state" in af_cfg:
+                return True  # explicit per-AF state is always actionable
+            if cls._relay_servers_from_config(af_cfg):
+                return True
+        return False
 
     @classmethod
     def _desired_relay_state(cls, config: Dict[str, Any], action: str) -> Dict[str, List[str]]:
-        ipv4_cfg = config.get("dhcpRelayIpv4")
-        ipv6_cfg = config.get("dhcpRelayIpv6")
-        if action == "delete":
-            desired: Dict[str, List[str]] = {"ipv4": [], "ipv6": []}
-            if ipv4_cfg is not None:
-                desired["ipv4"] = []
-            if ipv6_cfg is not None:
-                desired["ipv6"] = []
-            return desired
-        return {
-            "ipv4": cls._relay_servers_from_config(ipv4_cfg) if ipv4_cfg is not None else [],
-            "ipv6": cls._relay_servers_from_config(ipv6_cfg) if ipv6_cfg is not None else [],
-        }
+        desired: Dict[str, List[str]] = {"ipv4": [], "ipv6": []}
+        for af, key in (("ipv4", "dhcpRelayIpv4"), ("ipv6", "dhcpRelayIpv6")):
+            af_cfg = config.get(key)
+            if af_cfg is None:
+                continue
+            af_action = cls._af_action(action, af_cfg)
+            desired[af] = [] if af_action == "delete" else cls._relay_servers_from_config(af_cfg)
+        return desired
 
     @classmethod
     def _relay_afs_in_scope(cls, config: Dict[str, Any]) -> List[str]:
@@ -194,21 +206,17 @@ class DhcpRelayInterfaceManager(BaseManager):
 
     @classmethod
     def _relay_state_matches(
-        cls, existing: Dict[str, List[str]], desired: Dict[str, List[str]], afs: List[str], action: str
+        cls, existing: Dict[str, List[str]], desired: Dict[str, List[str]], afs: List[str]
     ) -> bool:
         for af in afs:
-            existing_servers = sorted(existing.get(af) or [])
-            desired_servers = sorted(desired.get(af) or [])
-            if action == "delete":
-                if existing_servers:
-                    return False
-            elif existing_servers != desired_servers:
+            if sorted(existing.get(af) or []) != sorted(desired.get(af) or []):
                 return False
         return True
 
     @classmethod
     def _dhcp_relay_block(cls, relay_cfg: Any, action: str) -> Optional[Dict[str, Any]]:
-        if action == "delete":
+        af_action = cls._af_action(action, relay_cfg)
+        if af_action == "delete":
             if relay_cfg is None:
                 return None
             return {"dhcp": {"dhcpRelay": {"relayServers": []}}}
@@ -302,15 +310,46 @@ class DhcpRelayInterfaceManager(BaseManager):
             else:
                 config_payload["interfaces"][iface_name] = cls._deep_merge_interface_entry(existing, iface_data)
 
-    def _load_device_configs(self, dhcp_relay_config_file: str) -> Dict[str, List[Dict[str, Any]]]:
-        dhcp_relay_config_data = self.render_config_file(dhcp_relay_config_file)
-        device_configs: Dict[str, List[Dict[str, Any]]] = {}
-        for device_info in dhcp_relay_config_data.get("dhcp_relay_config") or []:
-            for device_name, config_list in device_info.items():
-                device_configs[device_name] = config_list
-        return device_configs
+    @staticmethod
+    def _row_from_params(mp: Dict[str, Any]) -> Dict[str, Any]:
+        """Build a per-device row dict from module params for load_device_list_yaml_config."""
+        if mp.get("interfaces"):
+            return {"interfaces": list(mp["interfaces"])}
+        entry: Dict[str, Any] = {}
+        for key in ("name", "vlan", "dhcpRelayIpv4", "dhcpRelayIpv6"):
+            if mp.get(key) is not None:
+                entry[key] = mp[key]
+        return {"interfaces": [entry]} if entry.get("name") else {}
 
-    def apply_dhcp_relay_interfaces(self, dhcp_relay_config_file: str, operation: str) -> Dict[str, Any]:
+    @staticmethod
+    def _validate_cfg(device_name: str, cfg: Dict[str, Any]) -> Dict[str, Any]:
+        ifaces = cfg.get("interfaces")
+        if not isinstance(ifaces, list):
+            raise ConfigurationError(f"Device '{device_name}': expected 'interfaces' list in dhcp_relay_config entry.")
+        return cfg
+
+    def _load_device_configs(
+        self,
+        dhcp_relay_config_file: Optional[str],
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, List[Dict[str, Any]]]:
+        by_name = load_device_list_yaml_config(
+            "dhcp_relay_config",
+            dhcp_relay_config_file,
+            module_params,
+            self.render_config_file,
+            missing_input_error="Provide dhcp_relay_config_file and/or device (portal device name).",
+            build_row_from_params=self._row_from_params,
+            validate_device_cfg=self._validate_cfg,
+        )
+        return {name: cfg.get("interfaces") or [] for name, cfg in by_name.items()}
+
+    def apply_dhcp_relay_interfaces(
+        self,
+        dhcp_relay_config_file: Optional[str],
+        operation: str,
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         action = "add" if operation == "configure" else "delete"
         result = new_apply_result(
             deconfigured_interfaces=[],
@@ -319,7 +358,7 @@ class DhcpRelayInterfaceManager(BaseManager):
         output_config: Dict[int, Dict[str, Any]] = {}
 
         try:
-            for device_name, interfaces in self._load_device_configs(dhcp_relay_config_file).items():
+            for device_name, interfaces in self._load_device_configs(dhcp_relay_config_file, module_params).items():
                 device_id = self.gsdk.get_device_id(device_name)
                 if device_id is None:
                     raise ConfigurationError(
@@ -336,13 +375,24 @@ class DhcpRelayInterfaceManager(BaseManager):
                 for config in interfaces:
                     interface_name = config.get("name")
                     vlan = config.get("vlan")
+                    iface_state = config.get("state")
+
+                    # Per-interface state overrides the module-level operation.
+                    if iface_state == "absent":
+                        iface_action = "delete"
+                    elif iface_state == "present":
+                        iface_action = "add"
+                    else:
+                        iface_action = action
+
+                    iface_operation = "deconfigure" if iface_action == "delete" else "configure"
                     label = self._interface_label(str(interface_name or ""), vlan)
 
                     self._validate_interface_entry(
-                        device_name, gcs_device_info, interface_name, vlan, operation=operation
+                        device_name, gcs_device_info, interface_name, vlan, operation=iface_operation
                     )
 
-                    if operation == "configure" and not self._has_relay_config(config):
+                    if iface_action == "add" and not self._has_relay_config(config):
                         LOG.info(
                             "Skipping interface '%s' on %s - no DHCP relay servers configured",
                             interface_name,
@@ -351,13 +401,35 @@ class DhcpRelayInterfaceManager(BaseManager):
                         continue
 
                     afs = self._relay_afs_in_scope(config)
+                    effective_config = config
+
+                    # When deleting with no explicit address families, clear whatever is live.
+                    if iface_action == "delete" and not afs:
+                        existing_for_afs = self._get_existing_dhcp_relay_state(
+                            gcs_device_info, str(interface_name), vlan
+                        )
+                        afs = [af for af in ("ipv4", "ipv6") if existing_for_afs.get(af)]
+                        if not afs:
+                            result["skipped_interfaces"].append(
+                                {
+                                    "device": device_name,
+                                    "interface": interface_name,
+                                    "vlan": vlan,
+                                    "reason": "DHCP relay already matches desired state",
+                                }
+                            )
+                            continue
+                        effective_config = dict(config)
+                        for af in afs:
+                            effective_config["dhcpRelayIpv4" if af == "ipv4" else "dhcpRelayIpv6"] = {}
+
                     if not afs:
                         continue
 
                     existing = self._get_existing_dhcp_relay_state(gcs_device_info, str(interface_name), vlan)
-                    desired = self._desired_relay_state(config, action)
+                    desired = self._desired_relay_state(effective_config, iface_action)
 
-                    if self._relay_state_matches(existing, desired, afs, action):
+                    if self._relay_state_matches(existing, desired, afs):
                         result["skipped_interfaces"].append(
                             {
                                 "device": device_name,
@@ -368,7 +440,7 @@ class DhcpRelayInterfaceManager(BaseManager):
                         )
                         continue
 
-                    payload = self.build_dhcp_relay_interfaces_payload(action=action, **config)
+                    payload = self.build_dhcp_relay_interfaces_payload(action=iface_action, **effective_config)
                     if not payload:
                         result["skipped_interfaces"].append(
                             {
@@ -396,7 +468,7 @@ class DhcpRelayInterfaceManager(BaseManager):
                     device_before[label] = before_entry
                     device_after[label] = after_entry
 
-                    if operation == "configure":
+                    if iface_action == "add":
                         LOG.info("Will configure DHCP relay on %s for device %s", label, device_name)
                     else:
                         result["deconfigured_interfaces"].append(
@@ -429,14 +501,34 @@ class DhcpRelayInterfaceManager(BaseManager):
         except Exception as e:
             raise ConfigurationError(f"DHCP relay interface {operation} failed: {str(e)}")
 
-    def configure(self, config_yaml_file: str) -> Dict[str, Any]:
-        return self.configure_dhcp_relay_interfaces(config_yaml_file)
+    def configure(
+        self,
+        config_yaml_file: Optional[str] = None,
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return self.configure_dhcp_relay_interfaces(config_yaml_file, module_params=module_params)
 
-    def deconfigure(self, config_yaml_file: str) -> Dict[str, Any]:
-        return self.deconfigure_dhcp_relay_interfaces(config_yaml_file)
+    def deconfigure(
+        self,
+        config_yaml_file: Optional[str] = None,
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return self.deconfigure_dhcp_relay_interfaces(config_yaml_file, module_params=module_params)
 
-    def configure_dhcp_relay_interfaces(self, dhcp_relay_config_file: str) -> Dict[str, Any]:
-        return self.apply_dhcp_relay_interfaces(dhcp_relay_config_file, operation="configure")
+    def configure_dhcp_relay_interfaces(
+        self,
+        dhcp_relay_config_file: Optional[str],
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return self.apply_dhcp_relay_interfaces(
+            dhcp_relay_config_file, operation="configure", module_params=module_params
+        )
 
-    def deconfigure_dhcp_relay_interfaces(self, dhcp_relay_config_file: str) -> Dict[str, Any]:
-        return self.apply_dhcp_relay_interfaces(dhcp_relay_config_file, operation="deconfigure")
+    def deconfigure_dhcp_relay_interfaces(
+        self,
+        dhcp_relay_config_file: Optional[str],
+        module_params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return self.apply_dhcp_relay_interfaces(
+            dhcp_relay_config_file, operation="deconfigure", module_params=module_params
+        )

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/edge_services_manager.py
@@ -794,6 +794,44 @@ class EdgeServicesManager(BaseManager):
                 names.add(iface)
         return frozenset(names)
 
+    @classmethod
+    def _interface_dict_has_relay(cls, iface_dict: Dict[str, Any]) -> bool:
+        """Return True if any address family on the interface dict has DHCP relay servers."""
+        for af_key in ("ipv4", "ipv6"):
+            af = iface_dict.get(af_key)
+            if not isinstance(af, dict):
+                continue
+            relay = af.get("dhcpRelay")
+            if not isinstance(relay, dict):
+                continue
+            if relay.get("dhcpv4Relays") or relay.get("dhcpv6Relays"):
+                return True
+        return False
+
+    @classmethod
+    def _has_dhcp_relay_on_interface(cls, d: Dict[str, Any], interface_name: str) -> bool:
+        """Check whether interface_name has DHCP relay configured in the device dict."""
+        parts = interface_name.rsplit(".", 1)
+        parent_name = parts[0]
+        vlan_str = parts[1] if len(parts) == 2 else None
+
+        for iface in d.get("interfaces") or []:
+            if not isinstance(iface, dict):
+                continue
+            if cls._str(iface.get("name")) != parent_name:
+                continue
+            if vlan_str is None:
+                return cls._interface_dict_has_relay(iface)
+            subs = iface.get("subinterfaces")
+            if isinstance(subs, dict):
+                sub = subs.get(vlan_str) or {}
+                return cls._interface_dict_has_relay(sub.get("interface") or sub)
+            if isinstance(subs, list):
+                for sub in subs:
+                    if isinstance(sub, dict) and str(sub.get("vlan", "")) == vlan_str:
+                        return cls._interface_dict_has_relay(sub)
+        return False
+
     def _validate_dhcp_entries(
         self, device_name: str, dhcp_entries: List[Dict[str, Any]], current_device: Dict[str, Any]
     ) -> None:
@@ -827,6 +865,12 @@ class EdgeServicesManager(BaseManager):
                 raise ConfigurationError(
                     f"Device '{device_name}': dhcpSubnets references interface {iface!r} which does not exist "
                     f"on this device. Known interfaces: {known}."
+                )
+            if iface and self._has_dhcp_relay_on_interface(current_device, iface):
+                raise ConfigurationError(
+                    f"Device '{device_name}': cannot configure DHCP subnet on interface {iface!r} — "
+                    f"DHCP relay is already active on this interface. "
+                    f"An interface supports either DHCP relay or DHCP subnet, not both."
                 )
 
     def _build_edge_payload(

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
@@ -13,6 +13,7 @@ from .site_manager import SiteManager
 from .data_exchange_manager import DataExchangeManager
 from .device_config_manager import DeviceConfigManager
 from .vrrp_interface_manager import VRRPInterfaceManager
+from .dhcp_relay_interface_manager import DhcpRelayInterfaceManager
 from .lag_interface_manager import LagInterfaceManager
 from .site_to_site_vpn_manager import SiteToSiteVpnManager
 from .static_routes_manager import StaticRoutesManager
@@ -85,6 +86,7 @@ class GraphiantConfig:
             self.data_exchange = DataExchangeManager(self.config_utils)
             self.device_config = DeviceConfigManager(self.config_utils)
             self.vrrp_interfaces = VRRPInterfaceManager(self.config_utils)
+            self.dhcp_relay_interfaces = DhcpRelayInterfaceManager(self.config_utils)
             self.lag_interfaces = LagInterfaceManager(self.config_utils)
             self.site_to_site_vpn = SiteToSiteVpnManager(self.config_utils)
             self.static_routes = StaticRoutesManager(self.config_utils)
@@ -118,6 +120,7 @@ class GraphiantConfig:
             "data_exchange": hasattr(self, "data_exchange") and self.data_exchange is not None,
             "device_config": hasattr(self, "device_config") and self.device_config is not None,
             "vrrp_interfaces": hasattr(self, "vrrp_interfaces") and self.vrrp_interfaces is not None,
+            "dhcp_relay_interfaces": hasattr(self, "dhcp_relay_interfaces") and self.dhcp_relay_interfaces is not None,
             "config_utils": hasattr(self, "config_utils") and self.config_utils is not None,
             "lag_interfaces": hasattr(self, "lag_interfaces") and self.lag_interfaces is not None,
             "site_to_site_vpn": hasattr(self, "site_to_site_vpn") and self.site_to_site_vpn is not None,

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_dhcp_relay.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_dhcp_relay.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Graphiant Team <support@graphiant.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Ansible module for managing Graphiant DHCP relay on interfaces.
+"""
+
+DOCUMENTATION = r"""
+---
+module: graphiant_dhcp_relay
+short_description: Manage Graphiant DHCP relay on interfaces and subinterfaces
+description:
+  - >-
+    Configures DHCP relay (IPv4 and/or IPv6) on main interfaces and VLAN subinterfaces
+    via C(PUT /v1/devices/{device_id}/config) under
+    C(edge.interfaces.{name}.interface.ipv4.dhcp.dhcpRelay) and the IPv6 equivalent.
+  - >-
+    Supports configure and deconfigure operations. Deconfigure sets C(relayServers: [])
+    for the address families listed in the config file (idempotent when relay is already removed).
+  - Configuration files support Jinja2 templating for dynamic generation.
+  - >-
+    Configure idempotency: compares intended relay servers to existing device state per
+    interface and address family; skips push when already matched (V(changed)=V(false)).
+  - >-
+    Validates that each referenced main interface or VLAN subinterface exists on the device
+    before pushing; fails with a list of known interfaces when not found.
+  - >-
+    Mutual exclusion: an interface supports either DHCP relay or a DHCP subnet (server), not both.
+    Configure fails with a clear error if the target interface already has a DHCP subnet configured.
+    Remove the DHCP subnet first using M(graphiant.naas.graphiant_edge_services) with C(state: absent)
+    before enabling DHCP relay on that interface.
+version_added: "26.5.0"
+notes:
+  - >-
+    Check mode (C(--check)): No config is pushed; payloads that would be pushed are logged
+    with C([check_mode]). V(changed) reflects whether an apply would update at least one device.
+  - >-
+    Interfaces must be configured first using M(graphiant.naas.graphiant_interfaces) before
+    applying DHCP relay.
+  - >-
+    Multiple relay entries for the same parent interface (different VLAN subinterfaces) are
+    merged into a single device PUT payload.
+extends_documentation_fragment:
+  - graphiant.naas.graphiant_portal_auth
+options:
+  dhcp_relay_config_file:
+    description:
+      - Path to the DHCP relay configuration YAML file.
+      - Required for all operations.
+      - Can be an absolute path or relative path. Relative paths are resolved using the configured config_path.
+      - File must contain interface definitions with device names, interface names, and relay server lists.
+    type: str
+    required: true
+    aliases:
+      - dhcp_relay_file
+  operation:
+    description:
+      - "The specific DHCP relay operation to perform."
+      - "V(configure): Configure DHCP relay on interfaces and subinterfaces."
+      - "V(deconfigure): Remove DHCP relay from interfaces and subinterfaces."
+    type: str
+    choices:
+      - configure
+      - deconfigure
+  state:
+    description:
+      - "The desired state of the DHCP relay configuration."
+      - "V(present): Maps to V(configure) when O(operation) is not specified."
+      - "V(absent): Maps to V(deconfigure) when O(operation) is not specified."
+    type: str
+    choices: [ present, absent ]
+    default: present
+  detailed_logs:
+    description:
+      - Enable detailed logging output for troubleshooting and monitoring.
+    type: bool
+    default: false
+attributes:
+  check_mode:
+    description: Supports check mode.
+    support: full
+    details: >
+      In check mode, no configuration is pushed to devices, but the module still reads current
+      device state to determine whether changes would be made. Payloads that would be pushed are
+      logged with a C([check_mode]) prefix.
+  diff_mode:
+    description: Supports diff mode.
+    support: full
+    details: >
+      With C(--diff), the module shows per-device before/after relay server lists for interfaces
+      that would change (under C(edge.interfaces)).
+requirements:
+  - python >= 3.7
+  - graphiant-sdk >= 26.5.0
+seealso:
+  - module: graphiant.naas.graphiant_interfaces
+    description: Configure interfaces before setting up DHCP relay
+author:
+  - Graphiant Team (@graphiant)
+"""
+
+EXAMPLES = r"""
+- name: Configure DHCP relay on interfaces
+  graphiant.naas.graphiant_dhcp_relay:
+    operation: configure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+
+- name: Deconfigure DHCP relay from interfaces
+  graphiant.naas.graphiant_dhcp_relay:
+    operation: deconfigure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+
+- name: Preview DHCP relay changes
+  graphiant.naas.graphiant_dhcp_relay:
+    operation: configure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+  check_mode: true
+  diff: true
+"""
+
+RETURN = r"""
+msg:
+  description: Result message from the operation.
+  type: str
+  returned: always
+changed:
+  description:
+    - Whether the operation made changes.
+    - V(true) when config would be pushed to at least one device; V(false) when intended state already matched.
+    - In check mode (C(--check)), no configuration is pushed, but V(changed) reflects whether changes would be made.
+  type: bool
+  returned: always
+operation:
+  description: The operation that was performed.
+  type: str
+  returned: always
+dhcp_relay_config_file:
+  description: The DHCP relay configuration file used for the operation.
+  type: str
+  returned: always
+configured_devices:
+  description: Device names where configuration would be or was pushed.
+  type: list
+  elements: str
+  returned: when supported
+skipped_devices:
+  description: Device names where no DHCP relay changes were needed.
+  type: list
+  elements: str
+  returned: when supported
+details:
+  description: Raw manager result (includes C(diff_plan), configured/skipped device and interface lists).
+  type: dict
+  returned: when supported
+diff:
+  description: Ansible C(--diff) payload showing per-device before/after DHCP relay state.
+  type: dict
+  returned: when playbook uses C(--diff) and at least one device would be updated
+"""
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+from ansible_collections.graphiant.naas.plugins.module_utils.graphiant_utils import (  # noqa: E402
+    graphiant_portal_auth_argument_spec,
+    get_graphiant_connection,
+    handle_graphiant_exception,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.device_config_common import (  # noqa: E402
+    apply_module_diff,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.logging_decorator import capture_library_logs  # noqa: E402
+
+
+@capture_library_logs
+def execute_with_logging(module, func, *args, **kwargs):
+    success_msg = kwargs.pop("success_msg", "Operation completed successfully")
+    no_change_msg = kwargs.pop("no_change_msg", "No changes needed")
+    result = func(*args, **kwargs)
+    if isinstance(result, dict) and "changed" in result:
+        msg = no_change_msg if not result["changed"] else success_msg
+        return {"changed": result["changed"], "result_msg": msg, "details": result}
+    return {"changed": True, "result_msg": success_msg}
+
+
+def main():
+    argument_spec = dict(
+        **graphiant_portal_auth_argument_spec(),
+        dhcp_relay_config_file=dict(type="str", required=True, aliases=["dhcp_relay_file"]),
+        operation=dict(type="str", required=False, choices=["configure", "deconfigure"]),
+        state=dict(type="str", required=False, default="present", choices=["present", "absent"]),
+        detailed_logs=dict(type="bool", required=False, default=False),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    params = module.params
+    operation = params.get("operation")
+    state = params.get("state", "present")
+    dhcp_relay_config_file = params["dhcp_relay_config_file"]
+
+    if not operation:
+        operation = "configure" if state == "present" else "deconfigure"
+
+    try:
+        connection = get_graphiant_connection(params, check_mode=module.check_mode)
+        graphiant_config = connection.graphiant_config
+
+        if operation == "configure":
+            result = execute_with_logging(
+                module,
+                graphiant_config.dhcp_relay_interfaces.configure_dhcp_relay_interfaces,
+                dhcp_relay_config_file,
+                success_msg="Successfully configured DHCP relay on interfaces",
+                no_change_msg="DHCP relay already matches desired state; no changes needed",
+            )
+        else:
+            result = execute_with_logging(
+                module,
+                graphiant_config.dhcp_relay_interfaces.deconfigure_dhcp_relay_interfaces,
+                dhcp_relay_config_file,
+                success_msg="Successfully deconfigured DHCP relay from interfaces",
+                no_change_msg="DHCP relay already removed or not configured; no changes needed",
+            )
+
+        details = result.get("details") or {}
+        exit_payload = dict(
+            changed=result["changed"],
+            msg=result["result_msg"],
+            operation=operation,
+            dhcp_relay_config_file=dhcp_relay_config_file,
+            configured_devices=details.get("configured_devices", []),
+            skipped_devices=details.get("skipped_devices", []),
+            details=details,
+        )
+        apply_module_diff(module, exit_payload, details)
+        module.exit_json(**exit_payload)
+
+    except Exception as e:
+        error_msg = handle_graphiant_exception(e, operation)
+        module.fail_json(msg=error_msg, operation=operation)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_dhcp_relay.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_dhcp_relay.py
@@ -49,13 +49,57 @@ options:
   dhcp_relay_config_file:
     description:
       - Path to the DHCP relay configuration YAML file.
-      - Required for all operations.
+      - Optional when O(device) is set with at least O(name) or O(interfaces).
       - Can be an absolute path or relative path. Relative paths are resolved using the configured config_path.
-      - File must contain interface definitions with device names, interface names, and relay server lists.
+      - >-
+        File must contain a C(dhcp_relay_config) list; each entry maps a device name to a dict with
+        an C(interfaces) key (list of interface entries with C(name), C(vlan), C(dhcpRelayIpv4),
+        C(dhcpRelayIpv6)).
     type: str
-    required: true
+    required: false
     aliases:
       - dhcp_relay_file
+  device:
+    description:
+      - Portal device hostname for single-device or loop execution.
+      - When combined with O(dhcp_relay_config_file), overrides that device's interface list in the file.
+      - Required when O(dhcp_relay_config_file) is omitted.
+    type: str
+  name:
+    description:
+      - Interface name for single-interface module-param mode (e.g. C(GigabitEthernet4/0/0)).
+      - Required when O(dhcp_relay_config_file) is omitted and O(interfaces) is not set.
+    type: str
+    aliases:
+      - interface_name
+  vlan:
+    description:
+      - VLAN ID for subinterface relay. Omit for main interface.
+      - Used together with O(name) in single-interface mode.
+    type: raw
+  dhcpRelayIpv4:
+    description:
+      - List of IPv4 DHCP relay server addresses for the interface named by O(name).
+      - Ignored when O(interfaces) is set.
+    type: list
+    elements: str
+    aliases:
+      - dhcp_relay_ipv4
+  dhcpRelayIpv6:
+    description:
+      - List of IPv6 DHCP relay server addresses for the interface named by O(name).
+      - Ignored when O(interfaces) is set.
+    type: list
+    elements: str
+    aliases:
+      - dhcp_relay_ipv6
+  interfaces:
+    description:
+      - List of interface entries for multi-interface module-param mode.
+      - Each entry may contain C(name), C(vlan), C(dhcpRelayIpv4), and C(dhcpRelayIpv6).
+      - When set, takes precedence over O(name) / O(vlan) / O(dhcpRelayIpv4) / O(dhcpRelayIpv6).
+    type: list
+    elements: dict
   operation:
     description:
       - "The specific DHCP relay operation to perform."
@@ -103,7 +147,9 @@ author:
 """
 
 EXAMPLES = r"""
-- name: Configure DHCP relay on interfaces
+# --- From YAML config file ---
+
+- name: Configure DHCP relay on interfaces (from YAML)
   graphiant.naas.graphiant_dhcp_relay:
     operation: configure
     dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
@@ -112,7 +158,7 @@ EXAMPLES = r"""
     password: "{{ graphiant_password }}"
     detailed_logs: true
 
-- name: Deconfigure DHCP relay from interfaces
+- name: Deconfigure DHCP relay from interfaces (from YAML)
   graphiant.naas.graphiant_dhcp_relay:
     operation: deconfigure
     dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
@@ -120,7 +166,132 @@ EXAMPLES = r"""
     username: "{{ graphiant_username }}"
     password: "{{ graphiant_password }}"
 
-- name: Preview DHCP relay changes
+# --- Single device, single interface from module parameters ---
+
+- name: Configure DHCP relay on a single interface (module params)
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    device: "edge-1-sdktest"
+    name: "GigabitEthernet4/0/0"
+    vlan: 1
+    dhcpRelayIpv4:
+      - 10.1.1.1
+      - 10.2.1.1
+    dhcpRelayIpv6:
+      - 2001:10:1:1::1
+
+- name: Deconfigure DHCP relay on a single interface (module params)
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: deconfigure
+    device: "edge-1-sdktest"
+    name: "GigabitEthernet4/0/0"
+    vlan: 1
+    dhcpRelayIpv4:
+      - 10.1.1.1
+
+# --- Single device, multiple interfaces from module parameters ---
+
+- name: Configure DHCP relay on multiple interfaces (module params)
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    device: "edge-1-sdktest"
+    interfaces:
+      - name: GigabitEthernet4/0/0
+        vlan: 1
+        dhcpRelayIpv4:
+          - 10.1.1.1
+          - 10.2.1.1
+        dhcpRelayIpv6:
+          - 2001:10:1:1::1
+      - name: GigabitEthernet8/0/0
+        dhcpRelayIpv4:
+          - 10.1.11.1
+          - 10.2.11.1
+
+# --- Loop over multiple devices (one interface per iteration) ---
+
+- name: Configure DHCP relay on multiple devices (loop)
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    device: "{{ item.device }}"
+    name: "{{ item.name }}"
+    vlan: "{{ item.vlan | default(omit) }}"
+    dhcpRelayIpv4: "{{ item.dhcpRelayIpv4 | default(omit) }}"
+    dhcpRelayIpv6: "{{ item.dhcpRelayIpv6 | default(omit) }}"
+  loop:
+    - device: edge-1-sdktest
+      name: GigabitEthernet4/0/0
+      vlan: 1
+      dhcpRelayIpv4: ["10.1.1.1", "10.2.1.1"]
+      dhcpRelayIpv6: ["2001:10:1:1::1"]
+    - device: edge-2-sdktest
+      name: GigabitEthernet8/0/0
+      dhcpRelayIpv4: ["10.1.11.1"]
+
+# --- Override one device from a YAML file ---
+
+- name: Override DHCP relay for one device from file
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
+    device: "edge-1-sdktest"
+    name: "GigabitEthernet4/0/0"
+    dhcpRelayIpv4:
+      - 192.168.1.1
+
+# --- Per-interface state: absent (remove all relay on one interface, configure others) ---
+
+- name: Remove relay from one subinterface while configuring others
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    device: "edge-3-sdktest"
+    interfaces:
+      - name: GigabitEthernet7/0/0
+        dhcpRelayIpv4:
+          - 10.2.1.2
+      - name: GigabitEthernet8/0/0
+        vlan: 30
+        state: absent
+
+# --- Per-AF state: absent (remove only IPv4 relay, keep IPv6) ---
+
+- name: Remove IPv4 relay only, keep IPv6 on subinterface
+  graphiant.naas.graphiant_dhcp_relay:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: configure
+    device: "edge-3-sdktest"
+    interfaces:
+      - name: GigabitEthernet8/0/0
+        vlan: 30
+        dhcpRelayIpv4:
+          state: absent
+        dhcpRelayIpv6:
+          relayServers:
+            - 2001:10:2:1::2
+
+# --- Check / diff mode ---
+
+- name: Preview DHCP relay changes (check + diff)
   graphiant.naas.graphiant_dhcp_relay:
     operation: configure
     dhcp_relay_config_file: "sample_dhcp_relay_config.yaml"
@@ -148,9 +319,9 @@ operation:
   type: str
   returned: always
 dhcp_relay_config_file:
-  description: The DHCP relay configuration file used for the operation.
+  description: The DHCP relay configuration file used for the operation, if provided.
   type: str
-  returned: always
+  returned: when provided
 configured_devices:
   description: Device names where configuration would be or was pushed.
   type: list
@@ -197,7 +368,13 @@ def execute_with_logging(module, func, *args, **kwargs):
 def main():
     argument_spec = dict(
         **graphiant_portal_auth_argument_spec(),
-        dhcp_relay_config_file=dict(type="str", required=True, aliases=["dhcp_relay_file"]),
+        dhcp_relay_config_file=dict(type="str", required=False, default=None, aliases=["dhcp_relay_file"]),
+        device=dict(type="str", required=False, default=None),
+        name=dict(type="str", required=False, default=None, aliases=["interface_name"]),
+        vlan=dict(type="raw", required=False, default=None),
+        dhcpRelayIpv4=dict(type="list", required=False, default=None, elements="str", aliases=["dhcp_relay_ipv4"]),
+        dhcpRelayIpv6=dict(type="list", required=False, default=None, elements="str", aliases=["dhcp_relay_ipv6"]),
+        interfaces=dict(type="list", required=False, default=None, elements="dict"),
         operation=dict(type="str", required=False, choices=["configure", "deconfigure"]),
         state=dict(type="str", required=False, default="present", choices=["present", "absent"]),
         detailed_logs=dict(type="bool", required=False, default=False),
@@ -208,10 +385,31 @@ def main():
     params = module.params
     operation = params.get("operation")
     state = params.get("state", "present")
-    dhcp_relay_config_file = params["dhcp_relay_config_file"]
+    dhcp_relay_config_file = params.get("dhcp_relay_config_file")
+    device = (params.get("device") or "").strip()
 
     if not operation:
         operation = "configure" if state == "present" else "deconfigure"
+
+    if not dhcp_relay_config_file and not device:
+        module.fail_json(
+            msg="Provide dhcp_relay_config_file and/or device (portal device name).",
+            operation=operation,
+        )
+        return
+
+    if not dhcp_relay_config_file and device:
+        if not params.get("name") and not params.get("interfaces"):
+            module.fail_json(
+                msg="When dhcp_relay_config_file is omitted, provide name (interface name) or interfaces list.",
+                operation=operation,
+            )
+            return
+
+    module_params = {"device": device or None}
+    for key in ("name", "vlan", "dhcpRelayIpv4", "dhcpRelayIpv6", "interfaces"):
+        if params.get(key) is not None:
+            module_params[key] = params[key]
 
     try:
         connection = get_graphiant_connection(params, check_mode=module.check_mode)
@@ -222,6 +420,7 @@ def main():
                 module,
                 graphiant_config.dhcp_relay_interfaces.configure_dhcp_relay_interfaces,
                 dhcp_relay_config_file,
+                module_params,
                 success_msg="Successfully configured DHCP relay on interfaces",
                 no_change_msg="DHCP relay already matches desired state; no changes needed",
             )
@@ -230,6 +429,7 @@ def main():
                 module,
                 graphiant_config.dhcp_relay_interfaces.deconfigure_dhcp_relay_interfaces,
                 dhcp_relay_config_file,
+                module_params,
                 success_msg="Successfully deconfigured DHCP relay from interfaces",
                 no_change_msg="DHCP relay already removed or not configured; no changes needed",
             )
@@ -239,11 +439,12 @@ def main():
             changed=result["changed"],
             msg=result["result_msg"],
             operation=operation,
-            dhcp_relay_config_file=dhcp_relay_config_file,
             configured_devices=details.get("configured_devices", []),
             skipped_devices=details.get("skipped_devices", []),
             details=details,
         )
+        if dhcp_relay_config_file:
+            exit_payload["dhcp_relay_config_file"] = dhcp_relay_config_file
         apply_module_diff(module, exit_payload, details)
         module.exit_json(**exit_payload)
 

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -2035,6 +2035,130 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         LOG.info("Deconfigure DHCP relay interfaces result (idempotency check): %s", result)
         assert result['changed'] is False, "Deconfigure DHCP relay interfaces idempotency failed"
 
+    @staticmethod
+    def _load_dhcp_relay_from_yaml(graphiant_config, config_yaml_file):
+        """Return {device_name: {"interfaces": [...]}} from dhcp_relay_config YAML list."""
+        cfg = graphiant_config.config_utils.render_config_file(config_yaml_file) or {}
+        raw = cfg.get("dhcp_relay_config") or []
+        by_name = {}
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            for device_name, device_cfg in entry.items():
+                by_name[device_name] = device_cfg if isinstance(device_cfg, dict) else {}
+        return by_name
+
+    def _dhcp_relay_context(self, graphiant_config):
+        """Resolve device and interface list from sample_dhcp_relay_config.yaml."""
+        by_name = self._load_dhcp_relay_from_yaml(graphiant_config, config_yaml_file="sample_dhcp_relay_config.yaml")
+        if not by_name:
+            raise KeyError("No dhcp_relay_config entries in sample_dhcp_relay_config.yaml")
+        device = next(iter(by_name))
+        interfaces = by_name[device].get("interfaces") or []
+        if not interfaces:
+            raise KeyError(f"No interfaces in dhcp_relay_config for {device!r}")
+        return {
+            "device": device,
+            "interfaces": interfaces,
+            "first_interface": interfaces[0],
+        }
+
+    def test_configure_dhcp_relay_interfaces_module_params(self):
+        """Configure DHCP relay using module_params only (no YAML file)."""
+        graphiant_config = graphiant_config_from_read_config()
+        ctx = self._dhcp_relay_context(graphiant_config)
+        module_params = {
+            "device": ctx["device"],
+            "interfaces": ctx["interfaces"],
+        }
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Configure DHCP relay via module_params result: %s", result)
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Configure DHCP relay via module_params (idempotency check): %s", result)
+        assert result["changed"] is False, "Configure DHCP relay module_params idempotency failed"
+
+    def test_deconfigure_dhcp_relay_interfaces_module_params(self):
+        """Deconfigure DHCP relay using module_params only (no YAML file)."""
+        graphiant_config = graphiant_config_from_read_config()
+        ctx = self._dhcp_relay_context(graphiant_config)
+        module_params = {
+            "device": ctx["device"],
+            "interfaces": ctx["interfaces"],
+        }
+        result = graphiant_config.dhcp_relay_interfaces.deconfigure(module_params=module_params)
+        LOG.info("Deconfigure DHCP relay via module_params result: %s", result)
+        result = graphiant_config.dhcp_relay_interfaces.deconfigure(module_params=module_params)
+        LOG.info("Deconfigure DHCP relay via module_params (idempotency check): %s", result)
+        assert result["changed"] is False, "Deconfigure DHCP relay module_params idempotency failed"
+
+    def test_configure_dhcp_relay_interfaces_module_params_override(self):
+        """Configure DHCP relay from YAML with a module_params override for one device."""
+        graphiant_config = graphiant_config_from_read_config()
+        ctx = self._dhcp_relay_context(graphiant_config)
+        first_iface = ctx["first_interface"]
+        # Override: use only the first IPv4 relay server (subset of what the YAML specifies).
+        override_servers = (first_iface.get("dhcpRelayIpv4") or [])[:1]
+        module_params = {
+            "device": ctx["device"],
+            "interfaces": [{**first_iface, "dhcpRelayIpv4": override_servers}],
+        }
+        result = graphiant_config.dhcp_relay_interfaces.configure(
+            "sample_dhcp_relay_config.yaml",
+            module_params=module_params,
+        )
+        LOG.info("Configure DHCP relay YAML + module_params override result: %s", result)
+        result = graphiant_config.dhcp_relay_interfaces.configure(
+            "sample_dhcp_relay_config.yaml",
+            module_params=module_params,
+        )
+        LOG.info("Configure DHCP relay YAML + module_params override (idempotency check): %s", result)
+        assert result["changed"] is False, "Configure DHCP relay module_params override idempotency failed"
+
+    def test_configure_dhcp_relay_per_interface_state_absent(self):
+        """Per-interface state: absent removes relay from one entry while others are configured normally."""
+        graphiant_config = graphiant_config_from_read_config()
+        ctx = self._dhcp_relay_context(graphiant_config)
+        interfaces = ctx["interfaces"]
+        if len(interfaces) < 2:
+            self.skipTest("Need at least 2 interface entries in sample_dhcp_relay_config.yaml for this test")
+        # Configure the first interface normally, mark the second absent.
+        module_params = {
+            "device": ctx["device"],
+            "interfaces": [
+                interfaces[0],
+                {**interfaces[1], "state": "absent"},
+            ],
+        }
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Per-interface state: absent result: %s", result)
+        # Idempotency: second run should report no changes.
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Per-interface state: absent (idempotency check): %s", result)
+        assert result["changed"] is False, "Per-interface state: absent idempotency failed"
+
+    def test_configure_dhcp_relay_per_af_state_absent(self):
+        """Per-AF state: absent removes only the specified address family, leaving the other intact."""
+        graphiant_config = graphiant_config_from_read_config()
+        ctx = self._dhcp_relay_context(graphiant_config)
+        first_iface = ctx["first_interface"]
+        if not first_iface.get("dhcpRelayIpv4"):
+            self.skipTest("First interface in sample_dhcp_relay_config.yaml has no dhcpRelayIpv4")
+        # Remove IPv4 relay only; leave IPv6 untouched.
+        module_params = {
+            "device": ctx["device"],
+            "interfaces": [{
+                "name": first_iface["name"],
+                "vlan": first_iface.get("vlan"),
+                "dhcpRelayIpv4": {"state": "absent"},
+            }],
+        }
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Per-AF state: absent result: %s", result)
+        # Idempotency: second run should report no changes.
+        result = graphiant_config.dhcp_relay_interfaces.configure(module_params=module_params)
+        LOG.info("Per-AF state: absent (idempotency check): %s", result)
+        assert result["changed"] is False, "Per-AF state: absent idempotency failed"
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
@@ -2140,6 +2264,9 @@ if __name__ == '__main__':
     # DHCP Relay Interface Configuration Management
     suite.addTest(TestGraphiantPlaybooks('test_configure_dhcp_relay_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_dhcp_relay_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_dhcp_relay_interfaces_module_params'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_dhcp_relay_interfaces_module_params'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_dhcp_relay_interfaces_module_params_override'))
 
     # LAG Interface Configuration Management
     suite.addTest(TestGraphiantPlaybooks('test_configure_lag_interfaces'))

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -2012,6 +2012,29 @@ class TestGraphiantPlaybooks(unittest.TestCase):
         LOG.info("Deconfigure port lists result (idempotency check): %s", result2)
         assert result2["changed"] is False, "Deconfigure port lists idempotency failed"
 
+    def test_configure_dhcp_relay_interfaces(self):
+        """
+        Configure DHCP relay on main interfaces and subinterfaces for multiple devices.
+        Prerequisite: interfaces configured via sample_interface_config.yaml.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.dhcp_relay_interfaces.configure("sample_dhcp_relay_config.yaml")
+        LOG.info("Configure DHCP relay interfaces result: %s", result)
+        result = graphiant_config.dhcp_relay_interfaces.configure("sample_dhcp_relay_config.yaml")
+        LOG.info("Configure DHCP relay interfaces result (rerun check): %s", result)
+        assert result['changed'] is False, "Configure DHCP relay interfaces idempotency failed"
+
+    def test_deconfigure_dhcp_relay_interfaces(self):
+        """
+        Deconfigure DHCP relay from main interfaces and subinterfaces for multiple devices.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.dhcp_relay_interfaces.deconfigure("sample_dhcp_relay_config.yaml")
+        LOG.info("Deconfigure DHCP relay interfaces result: %s", result)
+        result = graphiant_config.dhcp_relay_interfaces.deconfigure("sample_dhcp_relay_config.yaml")
+        LOG.info("Deconfigure DHCP relay interfaces result (idempotency check): %s", result)
+        assert result['changed'] is False, "Deconfigure DHCP relay interfaces idempotency failed"
+
 
 if __name__ == '__main__':
     suite = unittest.TestSuite()
@@ -2113,6 +2136,10 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vrrp_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_enable_vrrp_interfaces'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_vrrp_interfaces'))
+
+    # DHCP Relay Interface Configuration Management
+    suite.addTest(TestGraphiantPlaybooks('test_configure_dhcp_relay_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_deconfigure_dhcp_relay_interfaces'))
 
     # LAG Interface Configuration Management
     suite.addTest(TestGraphiantPlaybooks('test_configure_lag_interfaces'))

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_dhcp_relay_interface_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_dhcp_relay_interface_manager.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for DHCP relay interface manager."""
+
+from __future__ import annotations
+
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.dhcp_relay_interface_manager import (
+    DhcpRelayInterfaceManager,
+)
+
+
+def test_relay_servers_from_config_list() -> None:
+    assert DhcpRelayInterfaceManager._relay_servers_from_config(["10.1.1.1", "10.2.1.1"]) == [
+        "10.1.1.1",
+        "10.2.1.1",
+    ]
+
+
+def test_relay_servers_from_config_dict() -> None:
+    assert DhcpRelayInterfaceManager._relay_servers_from_config(
+        {"relayServers": ["2001:10:1:1::1"]}
+    ) == ["2001:10:1:1::1"]
+
+
+def test_build_dhcp_relay_subinterface_payload() -> None:
+    rendered = DhcpRelayInterfaceManager.build_dhcp_relay_interfaces_payload(
+        action="add",
+        name="GigabitEthernet5/0/0",
+        vlan=1,
+        dhcpRelayIpv4={"relayServers": ["10.1.1.1", "10.2.1.1"]},
+        dhcpRelayIpv6=["2001:10:1:1::1"],
+    )
+    iface = rendered["interfaces"]["GigabitEthernet5/0/0"]["interface"]["subinterfaces"]["1"]["interface"]
+    assert iface["ipv4"]["dhcp"]["dhcpRelay"]["relayServers"] == ["10.1.1.1", "10.2.1.1"]
+    assert iface["ipv6"]["dhcp"]["dhcpRelay"]["relayServers"] == ["2001:10:1:1::1"]
+
+
+def test_build_dhcp_relay_main_interface_payload() -> None:
+    rendered = DhcpRelayInterfaceManager.build_dhcp_relay_interfaces_payload(
+        action="add",
+        name="GigabitEthernet7/0/0",
+        dhcpRelayIpv4=["10.1.11.1"],
+    )
+    iface = rendered["interfaces"]["GigabitEthernet7/0/0"]["interface"]
+    assert iface["ipv4"]["dhcp"]["dhcpRelay"]["relayServers"] == ["10.1.11.1"]
+    assert "ipv6" not in iface
+
+
+def test_build_dhcp_relay_delete_payload() -> None:
+    rendered = DhcpRelayInterfaceManager.build_dhcp_relay_interfaces_payload(
+        action="delete",
+        name="GigabitEthernet7/0/0",
+        dhcpRelayIpv4={},
+        dhcpRelayIpv6={},
+    )
+    iface = rendered["interfaces"]["GigabitEthernet7/0/0"]["interface"]
+    assert iface["ipv4"]["dhcp"]["dhcpRelay"] == {"relayServers": []}
+    assert iface["ipv6"]["dhcp"]["dhcpRelay"] == {"relayServers": []}
+
+
+def test_has_relay_config() -> None:
+    assert DhcpRelayInterfaceManager._has_relay_config({"dhcpRelayIpv4": ["10.1.1.1"]}) is True
+    assert DhcpRelayInterfaceManager._has_relay_config({"name": "eth0"}) is False
+
+
+def test_relay_state_matches_configure() -> None:
+    existing = {"ipv4": ["10.1.1.1"], "ipv6": []}
+    desired = {"ipv4": ["10.1.1.1"], "ipv6": []}
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "add") is True
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "add") is True
+    desired2 = {"ipv4": ["10.2.1.1"], "ipv6": []}
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired2, ["ipv4"], "add") is False
+
+
+def test_relay_state_matches_deconfigure() -> None:
+    existing = {"ipv4": ["10.1.1.1"], "ipv6": []}
+    desired = {"ipv4": [], "ipv6": []}
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "delete") is False
+    assert DhcpRelayInterfaceManager._relay_state_matches({"ipv4": [], "ipv6": []}, desired, ["ipv4"], "delete") is True
+
+
+def test_merge_dhcp_relay_payload_two_subinterfaces_same_parent() -> None:
+    edge: dict = {"interfaces": {}}
+    payload_vlan28 = DhcpRelayInterfaceManager.build_dhcp_relay_interfaces_payload(
+        action="add",
+        name="GigabitEthernet8/0/0",
+        vlan=28,
+        dhcpRelayIpv4=["10.3.177.1"],
+    )
+    payload_vlan29 = DhcpRelayInterfaceManager.build_dhcp_relay_interfaces_payload(
+        action="add",
+        name="GigabitEthernet8/0/0",
+        vlan=29,
+        dhcpRelayIpv4=["10.2.18.1"],
+    )
+    DhcpRelayInterfaceManager.merge_dhcp_relay_payload(edge, payload_vlan28)
+    DhcpRelayInterfaceManager.merge_dhcp_relay_payload(edge, payload_vlan29)
+
+    subs = edge["interfaces"]["GigabitEthernet8/0/0"]["interface"]["subinterfaces"]
+    assert subs["28"]["interface"]["ipv4"]["dhcp"]["dhcpRelay"]["relayServers"] == ["10.3.177.1"]
+    assert subs["29"]["interface"]["ipv4"]["dhcp"]["dhcpRelay"]["relayServers"] == ["10.2.18.1"]
+
+
+def test_validate_interface_entry_unknown_raises() -> None:
+    from ansible_collections.graphiant.naas.plugins.module_utils.libs.exceptions import ConfigurationError
+
+    class _Sub:
+        def __init__(self, vlan: int) -> None:
+            self.vlan = vlan
+
+    class _Iface:
+        def __init__(self, name: str, subinterfaces=None) -> None:
+            self.name = name
+            self.subinterfaces = subinterfaces or []
+
+    class _Device:
+        def __init__(self, interfaces) -> None:
+            self.interfaces = interfaces
+
+    class _Gcs:
+        def __init__(self, interfaces) -> None:
+            self.device = _Device(interfaces)
+
+    gcs = _Gcs([_Iface("GigabitEthernet8/0/0", [_Sub(28)])])
+
+    try:
+        DhcpRelayInterfaceManager._validate_interface_entry(
+            "edge-1", gcs, "GigabitEthernet8/0/0", vlan=99
+        )
+        assert False, "expected ConfigurationError"
+    except ConfigurationError as exc:
+        assert "does not exist" in str(exc)
+        assert "GigabitEthernet8/0/0.99" in str(exc)

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_dhcp_relay_interface_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_dhcp_relay_interface_manager.py
@@ -66,17 +66,39 @@ def test_has_relay_config() -> None:
 def test_relay_state_matches_configure() -> None:
     existing = {"ipv4": ["10.1.1.1"], "ipv6": []}
     desired = {"ipv4": ["10.1.1.1"], "ipv6": []}
-    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "add") is True
-    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "add") is True
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"]) is True
     desired2 = {"ipv4": ["10.2.1.1"], "ipv6": []}
-    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired2, ["ipv4"], "add") is False
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired2, ["ipv4"]) is False
 
 
 def test_relay_state_matches_deconfigure() -> None:
     existing = {"ipv4": ["10.1.1.1"], "ipv6": []}
     desired = {"ipv4": [], "ipv6": []}
-    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"], "delete") is False
-    assert DhcpRelayInterfaceManager._relay_state_matches({"ipv4": [], "ipv6": []}, desired, ["ipv4"], "delete") is True
+    assert DhcpRelayInterfaceManager._relay_state_matches(existing, desired, ["ipv4"]) is False
+    assert DhcpRelayInterfaceManager._relay_state_matches({"ipv4": [], "ipv6": []}, desired, ["ipv4"]) is True
+
+
+def test_per_af_state_absent_desired() -> None:
+    cfg = {"name": "GigabitEthernet8/0/0", "vlan": 30, "dhcpRelayIpv4": {"state": "absent"}}
+    desired = DhcpRelayInterfaceManager._desired_relay_state(cfg, "add")
+    assert desired["ipv4"] == []
+
+
+def test_per_af_state_absent_block() -> None:
+    block = DhcpRelayInterfaceManager._dhcp_relay_block({"state": "absent"}, "add")
+    assert block == {"dhcp": {"dhcpRelay": {"relayServers": []}}}
+
+
+def test_per_af_state_absent_with_servers_overrides() -> None:
+    cfg = {"name": "GigabitEthernet8/0/0", "dhcpRelayIpv4": {"relayServers": ["10.1.1.1"], "state": "absent"}}
+    desired = DhcpRelayInterfaceManager._desired_relay_state(cfg, "add")
+    assert desired["ipv4"] == []
+
+
+def test_per_af_state_present_overrides_delete() -> None:
+    cfg = {"name": "GigabitEthernet8/0/0", "dhcpRelayIpv4": {"relayServers": ["10.1.1.1"], "state": "present"}}
+    desired = DhcpRelayInterfaceManager._desired_relay_state(cfg, "delete")
+    assert desired["ipv4"] == ["10.1.1.1"]
 
 
 def test_merge_dhcp_relay_payload_two_subinterfaces_same_parent() -> None:

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_dhcp_relay.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_dhcp_relay.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for graphiant_dhcp_relay module (mocked Ansible + connection)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.graphiant.naas.plugins.modules import graphiant_dhcp_relay
+
+
+def _base_params() -> dict:
+    return {
+        "host": "https://api.example.com",
+        "username": "u",
+        "password": "p",
+        "access_token": None,
+        "dhcp_relay_config_file": "sample_dhcp_relay_config.yaml",
+        "operation": "configure",
+        "state": "present",
+        "detailed_logs": False,
+    }
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.AnsibleModule")
+def test_main_configure_no_change_message(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod._diff = False
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    mgr = MagicMock()
+    mgr.configure_dhcp_relay_interfaces.return_value = {
+        "changed": False,
+        "configured_devices": [],
+        "skipped_devices": ["edge-1-sdktest"],
+        "diff_plan": [],
+    }
+    gc = MagicMock()
+    gc.dhcp_relay_interfaces = mgr
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_dhcp_relay.main()
+
+    kwargs = mod.exit_json.call_args[1]
+    assert kwargs["changed"] is False
+    assert "already matches" in kwargs["msg"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.AnsibleModule")
+def test_main_diff_mode_sets_diff_key(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod._diff = True
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    mgr = MagicMock()
+    mgr.configure_dhcp_relay_interfaces.return_value = {
+        "changed": True,
+        "configured_devices": ["edge-1-sdktest"],
+        "skipped_devices": [],
+        "diff_plan": [
+            {
+                "device": "edge-1-sdktest",
+                "branch": "edge.interfaces",
+                "before": {"GigabitEthernet4/0/0.1": {"ipv4": []}},
+                "after": {"GigabitEthernet4/0/0.1": {"ipv4": ["10.1.1.1"]}},
+            }
+        ],
+    }
+    gc = MagicMock()
+    gc.dhcp_relay_interfaces = mgr
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_dhcp_relay.main()
+
+    kwargs = mod.exit_json.call_args[1]
+    assert "diff" in kwargs
+    assert "edge-1-sdktest" in kwargs["diff"]["before"]
+    assert "GigabitEthernet4/0/0.1" in kwargs["diff"]["after"]

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_modules_main_smoke.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_modules_main_smoke.py
@@ -193,6 +193,44 @@ def test_graphiant_vrrp_configure(m_am, m_gc) -> None:
     m.exit_json.assert_called_once()
 
 
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.AnsibleModule")
+def test_graphiant_dhcp_relay_deconfigure(m_am, m_gc) -> None:
+    from ansible_collections.graphiant.naas.plugins.modules import graphiant_dhcp_relay
+
+    m = _mod(
+        dhcp_relay_config_file="d.yaml",
+        operation="deconfigure",
+        state="present",
+    )
+    m_am.return_value = m
+    mgr = MagicMock()
+    mgr.deconfigure_dhcp_relay_interfaces.return_value = _result()
+    m_gc.return_value = _conn_with(dhcp_relay_interfaces=mgr)
+    graphiant_dhcp_relay.main()
+    m.exit_json.assert_called_once()
+    mgr.deconfigure_dhcp_relay_interfaces.assert_called_once_with("d.yaml")
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.AnsibleModule")
+def test_graphiant_dhcp_relay_configure(m_am, m_gc) -> None:
+    from ansible_collections.graphiant.naas.plugins.modules import graphiant_dhcp_relay
+
+    m = _mod(
+        dhcp_relay_config_file="d.yaml",
+        operation="configure",
+        state="present",
+    )
+    m_am.return_value = m
+    mgr = MagicMock()
+    mgr.configure_dhcp_relay_interfaces.return_value = _result()
+    m_gc.return_value = _conn_with(dhcp_relay_interfaces=mgr)
+    graphiant_dhcp_relay.main()
+    m.exit_json.assert_called_once()
+    mgr.configure_dhcp_relay_interfaces.assert_called_once_with("d.yaml")
+
+
 @patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_interfaces.get_graphiant_connection")
 @patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_interfaces.AnsibleModule")
 def test_graphiant_interfaces_configure_circuits(m_am, m_gc) -> None:

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_modules_main_smoke.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_modules_main_smoke.py
@@ -209,7 +209,7 @@ def test_graphiant_dhcp_relay_deconfigure(m_am, m_gc) -> None:
     m_gc.return_value = _conn_with(dhcp_relay_interfaces=mgr)
     graphiant_dhcp_relay.main()
     m.exit_json.assert_called_once()
-    mgr.deconfigure_dhcp_relay_interfaces.assert_called_once_with("d.yaml")
+    mgr.deconfigure_dhcp_relay_interfaces.assert_called_once_with("d.yaml", {"device": None})
 
 
 @patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_dhcp_relay.get_graphiant_connection")
@@ -228,7 +228,7 @@ def test_graphiant_dhcp_relay_configure(m_am, m_gc) -> None:
     m_gc.return_value = _conn_with(dhcp_relay_interfaces=mgr)
     graphiant_dhcp_relay.main()
     m.exit_json.assert_called_once()
-    mgr.configure_dhcp_relay_interfaces.assert_called_once_with("d.yaml")
+    mgr.configure_dhcp_relay_interfaces.assert_called_once_with("d.yaml", {"device": None})
 
 
 @patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_interfaces.get_graphiant_connection")


### PR DESCRIPTION
## Description

This PR adds support for configuring DHCP Relay on Edge interfaces through a new graphiant_dhcp_relay module. The module provides a dedicated and structured approach to managing DHCP Relay settings on interfaces, eliminating the need to push raw device configurations using the existing graphiant_device_config module.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [x] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [x] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

Validated the graphiant_dhcp_relay module using the Ansible Collection with the following scenarios:

- Configure DHCP Relay on an interface
- Update DHCP Relay settings on an existing interface
- Add and remove DHCP Relay server addresses
- Configure DHCP Relay on multiple interfaces
- Remove DHCP Relay configuration from an interface
- Complete deconfiguration of DHCP Relay settings
- Verify that the module fails with an appropriate error when DHCP Server is already configured on the interface, since DHCP Server and DHCP Relay cannot coexist on the same interface

[Ansible_playbook_DHCP_Relay.txt](https://github.com/user-attachments/files/29900582/Ansible_playbook_DHCP_Relay.txt)
[test.txt](https://github.com/user-attachments/files/29900583/test.txt)


## Related Issues

https://github.com/Graphiant-Inc/graphiant-playbooks/issues/131

Fixes #
Related to #

## Additional Notes

As part of this PR, the Edge service module has also been updated to support early validation for DHCP Server configuration. The module now fails early if DHCP Relay is already configured on the interface, since DHCP Server and DHCP Relay are mutually exclusive and cannot coexist on the same interface.

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
