### PR TITLE
Add support for local extranet module

### DIFF
--- a/ansible_collections/graphiant/naas/README.md
+++ b/ansible_collections/graphiant/naas/README.md
@@ -37,6 +37,7 @@ This collection provides Ansible modules to automate:
 - Security Policy configuration on Edge Devices
 - NAT Policy configuration on Edge Devices (rulesets and LAN segment attachments)
 - Prefix and Port List configuration on Edge Devices
+- Local Extranet policies (single-tenant LAN segment sharing across sites/branches)
 
 ### Key Features
 
@@ -88,6 +89,8 @@ This collection provides Ansible modules to automate:
 | `graphiant_security_policy` | Manage device security policy rulesets and zone pair attachments (configure workflow: rulesets + attach_to_zone_pairs; deconfigure workflow: detach_from_zone_pairs + delete) |
 | `graphiant_nat_policy` | Manage device NAT policy rulesets and LAN segment attachments (configure workflow: rulesets + attach_to_lan_segments; deconfigure workflow: detach_from_lan_segments + delete; `state: absent` on ruleset/rule/segment entries for fine-grained deletion) |
 | `graphiant_prefix_port_list` | Manage Prefix & Port Lists on Edge devices |
+| `graphiant_local_extranet` | Manage Local Extranet policies (create/update/delete); shares a LAN segment with other LAN segments across sites/branches within the same enterprise; policy auto-applies to devices after create/update |
+| `graphiant_local_extranet_info` | Query Local Extranet info (policies summary, per-device rollout status, LAN segment usage, NAT usage) |
 
 ## Installation
 
@@ -417,6 +420,7 @@ The collection includes ready-to-use example playbooks in the `playbooks/` direc
 | `security_policies_management.yml` | Security policies and zone-pair attachments |
 | `nat_policy_management.yml` | NAT policy rulesets and LAN-segment attachments |
 | `prefix_port_list_management.yml` | Prefix and port lists |
+| `local_extranet_management.yml` | Local Extranet policies create/update/delete/query |
 
 #### Data Exchange Workflows
 
@@ -467,6 +471,8 @@ ansible-doc graphiant.naas.graphiant_data_exchange_info
 ansible-doc graphiant.naas.graphiant_device_config
 ansible-doc graphiant.naas.graphiant_backbone
 ansible-doc graphiant.naas.graphiant_prefix_port_list.py
+ansible-doc graphiant.naas.graphiant_local_extranet
+ansible-doc graphiant.naas.graphiant_local_extranet_info
 ```
 
 ## Documentation
@@ -527,13 +533,13 @@ Use `ansible-playbook ... --check` or set `check_mode: true` on a task to run wi
 
 | Support | Modules | Behavior |
 |--------|---------|----------|
-| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_dhcp_relay`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ospfv2`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_nat_policy` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
+| **Full** | `graphiant_interfaces`, `graphiant_vrrp`, `graphiant_dhcp_relay`, `graphiant_lag_interfaces`, `graphiant_sites`, `graphiant_site_to_site_vpn`, `graphiant_global_config`, `graphiant_static_routes`, `graphiant_ospfv2`, `graphiant_ntp`, `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_data_exchange`, `graphiant_data_exchange_info`, `graphiant_prefix_port_list`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_nat_policy`, `graphiant_local_extranet` | Mutating writes are skipped. Intended requests are usually logged with a `[check_mode]` prefix; use `detailed_logs: true` and often `ANSIBLE_STDOUT_CALLBACK=debug` for readable output. |
 | **Partial** | `graphiant_bgp`, `graphiant_device_config`, `graphiant_backbone`                                                                                                                                                                                                                                                                    | Writes are still skipped, but `changed` is not computed from a full live diff: BGP reports `changed: true` for configure/deconfigure/detach in check mode; `graphiant_device_config` returns `changed: false` for `show_validated_payload` and `changed: true` for `configure`; `graphiant_backbone` reports `changed: true` whenever the supplied config file contains matching backbone resources (no live diff against current Core device state). See each module's `attributes.check_mode` details. |
 | **Read-only** | `graphiant_macsec_info` | Always read-only; check mode has no side effects. |
 
-**Full-mode nuances:** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, `graphiant_security_policy`, and `graphiant_nat_policy` read device state in check mode and set `changed` from whether an apply would be needed. For `graphiant_nat_policy`, the segment attachment safety check and absent no-op pruning are skipped in check mode so that a full deconfigure workflow (detach + deconfigure) can be previewed with `--check --diff` without running the real detach step first. For LWS, omit `localWebServerPasswordForce` after a successful set—force re-pushes every run because the portal stores a hash. `graphiant_data_exchange_info` and `graphiant_macsec_info` are always read-only. `graphiant_data_exchange` skips mutating writes in check mode; see that module's `attributes.check_mode` for details.
+**Full-mode nuances:** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_nat_policy`, and `graphiant_local_extranet` read device state in check mode and set `changed` from whether an apply would be needed. For `graphiant_nat_policy`, the segment attachment safety check and absent no-op pruning are skipped in check mode so that a full deconfigure workflow (detach + deconfigure) can be previewed with `--check --diff` without running the real detach step first. For LWS, omit `localWebServerPasswordForce` after a successful set—force re-pushes every run because the portal stores a hash. `graphiant_data_exchange_info` and `graphiant_macsec_info` are always read-only. `graphiant_data_exchange` skips mutating writes in check mode; see that module's `attributes.check_mode` for details.
 
-**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_prefix_port_list`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_nat_policy`, `graphiant_data_exchange`, `graphiant_ntp`, `graphiant_static_routes`, `graphiant_ospfv2`,  and `graphiant_site_to_site_vpn` support `--diff`. Use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan`. For `graphiant_data_exchange`, diff is available for `create_services`, `update_services`, `create_customers`, and `update_customers`; in `--check --diff` mode, `create_customers` also surfaces `adminEmails` drift on existing customers with a hint to use `update_customers`. For `graphiant_site_to_site_vpn`, secrets (`presharedKey`, `md5Password`) are redacted in diff output. For `graphiant_dhcp_relay`, diff shows per-interface relay server lists under `edge.interfaces`.
+**Diff mode (`--diff`):** `graphiant_device_system`, `graphiant_edge_services`, `graphiant_prefix_port_list`, `graphiant_macsec`, `graphiant_dhcp_relay`, `graphiant_traffic_policy`, `graphiant_security_policy`, `graphiant_nat_policy`, `graphiant_data_exchange`, `graphiant_ntp`, `graphiant_static_routes`, `graphiant_ospfv2`, `graphiant_local_extranet`, and `graphiant_site_to_site_vpn` support `--diff`. Use `--check --diff` or `--diff` to see `before`/`after` and `details.diff_plan`. For `graphiant_data_exchange`, diff is available for `create_services`, `update_services`, `create_customers`, and `update_customers`; in `--check --diff` mode, `create_customers` also surfaces `adminEmails` drift on existing customers with a hint to use `update_customers`. For `graphiant_site_to_site_vpn`, secrets (`presharedKey`, `md5Password`) are redacted in diff output. For `graphiant_dhcp_relay`, diff shows per-interface relay server lists under `edge.interfaces`.
 
 **Example: run playbooks in check mode (dry run)**
 
@@ -596,6 +602,7 @@ Modules are designed to be idempotent where possible and to report `changed` acc
 - **Configure operations**: Many configure operations (e.g. full interface or BGP push) do not perform a full state comparison before applying. They push the desired config and may report `changed: true` even if the device is already in that state. This is documented in the relevant modules.
 - **Traffic, security, and NAT policies**: `graphiant_traffic_policy`, `graphiant_security_policy`, and `graphiant_nat_policy` compare intended rulesets (and segment or zone-pair attachments) to live device state and skip the push when already matched. Use `--check` to preview whether changes would be made and `--diff` to see per-rule deltas in `details.diff_plan`. For `graphiant_nat_policy`, absent ruleset/rule entries that do not exist on the device are pruned from the payload (no-ops skipped); deleting a ruleset still referenced by LAN segments raises an error — detach segments first.
 - **Data Exchange operations**: All Data Exchange operations are idempotent. `create_services` and `create_customers` skip already-existing resources (`changed: false`, `skipped` non-empty). `match_service_to_customers` skips already-matched pairs. `delete_customers` and `delete_services` skip already-absent resources. `accept_invitation` skips already-linked consumers. Re-running any workflow playbook is safe.
+- **Local Extranet policies**: `create_policies` and `delete_policies` skip already-existing/already-absent policies (`changed: false`). `update_policies` compares the intended policy (prefix sets, sites, excluded devices, target segments, all normalized) to live device state and skips the push when already matched. Use `--check` to preview and `--diff` for per-policy before/after in `details.diff_plan`.
 
 **Summary:**
 - Run deconfigure and Data Exchange delete tasks repeatedly without concern; they are idempotent.
@@ -698,6 +705,7 @@ Configuration files use YAML format with optional Jinja2 templating. Sample file
 - `sample_backbone_config.yaml` - Core (backbone) device configuration covering interfaces (loopback, core_link, ipsec_tunnel, p2mp_tunnel, isp_circuit, direct_peer, disabled), site info, and per-VRF syslog targets
 - `sample_sites.yaml` - Site configurations
 - `sample_prefix_and_port_list.yaml` - Network Prefix and Port configuration
+- `sample_local_extranet_policies.yaml` / `sample_local_extranet_policies_update.yaml` - Local Extranet policy configuration (`local_extranet_policies` list: shared segment, branch segments, optional prefix-set restrictions)
 
 ### Config File Path Resolution
 

--- a/ansible_collections/graphiant/naas/changelogs/changelog.yaml
+++ b/ansible_collections/graphiant/naas/changelogs/changelog.yaml
@@ -5,6 +5,12 @@
 
 ancestor: null
 releases:
+  "26.8.0":
+      release_date: "2026-09-02"
+      changes:
+        minor_changes:
+        - "New ``graphiant_local_extranet`` module and ``local_extranet_management.yml`` playbook for single-tenant intra-enterprise LAN segment sharing across sites/branches; operations ``create_policies`` / ``update_policies`` / ``delete_policies``; policy is auto-applied to devices after create/update (no separate apply step); sample ``sample_local_extranet_policies.yaml`` and update sample ``sample_local_extranet_policies_update.yaml``; idempotent create/delete and before/after comparison on update (prefix sets, sites, excluded devices, target segments all normalized); full check mode and diff mode (``--check --diff`` returns ``details.diff_plan``); unit tests for the manager and both modules plus integration tests in ``tests/test.py`` covering create/update/delete idempotency"
+        - "New ``graphiant_local_extranet_info`` module for querying Local Extranet policy state — ``policies_summary``, ``policy_device_status`` (requires ``policy_name``), ``lan_segments_usage`` (optional ``policy_name``/``is_provider``), ``nat_usage`` (requires ``policy_name``); tabulated output"
   "26.7.0":
     release_date: "2026-08-05"
     changes:

--- a/ansible_collections/graphiant/naas/configs/sample_local_extranet_policies.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_local_extranet_policies.yaml
@@ -1,0 +1,63 @@
+# Sample Local Extranet Policies Configuration
+# This file demonstrates how to configure Local Extranet policies
+#
+# Local Extranet shares a LAN segment (VRF) with one or more other LAN segments across
+# sites/branches within the SAME enterprise — unlike Data Exchange, there is no
+# producer/customer/match/invitation workflow, just a single policy resource.
+#
+# 'sharedSegment' is the LAN segment being shared, and 'targetSegments' are the LAN segments
+# allowed to consume it. 'source' scopes the shared segment side (sites, prefixSet,
+# excludedDevices) and 'branches' scopes the consuming side (sites, excludedDevices).
+#
+# The system will:
+# 1. Read policy configuration from the 'local_extranet_policies' list
+# 2. Resolve sharedSegment/targetSegments LAN segment names to IDs
+# 3. Resolve source/branches site names and excludedDevices device names to IDs
+# 4. POST to v1/extranets with the payload ('type' is always sent as "2" — not user-configurable)
+# 5. Automatically push the policy to devices (apply) — no separate apply step needed
+#
+# Optional "targetDevices" (device names) controls which devices the policy is pushed to
+# on apply; when omitted, the API applies the policy to all applicable devices.
+#
+# See sample_local_extranet_policies_update.yaml for update_policies (the policy must already
+# exist — created via create_policies with this file). Unlike Data Exchange, the full policy
+# is mutable here, not just a single field.
+#
+# NOTE: This policy only shares routes between the LAN segments; it does not open traffic
+# between them. A zone-based firewall (security policy) must also be configured between the
+# shared segment and each branch segment to actually permit the extranet traffic — see
+# sample_device_security_policies.yaml.
+
+local_extranet_policies:
+  - name: "local-extranet-policy-1"
+    description: "local_extranet_policy_1_description"
+    sharedSegment: "lan-segment-3" # Will be resolved to ID
+    targetSegments:
+      - "lan-7-test" # Will be resolved to ID
+      - "lan-8-test"
+    source:
+      sites:
+        - "San Jose-sdktest" # Will be resolved to IDs
+      # Optional. Restricts which prefixes from the shared segment are advertised (omit
+      # entirely to share all prefixes). Each entry needs "ipPrefix"; "maskLower"/"maskUpper"
+      # are optional and further restrict ipPrefix to only the subnets within that
+      # mask-length range (matches the portal UI's Exact/Range/Less & Equal/Greater & Equal
+      # rule dropdown). Defaults depend on which are given: neither given -> both default to
+      # ipPrefix's own mask length (exact match); only maskUpper given -> maskLower defaults
+      # to ipPrefix's own mask length; only maskLower given -> maskUpper defaults to 32; both
+      # given -> used as-is.
+      prefixSet:
+        name: "list"
+        mode: "ipv4"
+        entries:
+          - ipPrefix: "10.1.1.0/24"
+          - ipPrefix: "70.0.0.0/23"
+            maskLower: 25
+            maskUpper: 30
+          - ipPrefix: "100.100.0.0/22"
+            maskUpper: 30
+        # add more entries as needed, e.g.:
+        #   - ipPrefix: "10.1.2.0/24"
+    branches:
+      sites:
+        - "New York-sdktest" # Will be resolved to IDs

--- a/ansible_collections/graphiant/naas/configs/sample_local_extranet_policies_update.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_local_extranet_policies_update.yaml
@@ -1,0 +1,50 @@
+# Sample Local Extranet Policies Update Configuration
+# Same policy 'name' as sample_local_extranet_policies.yaml, with a maskLower/maskUpper
+# range restriction added to the source prefixSet entry — demonstrates update_policies
+# (the policy must already exist, created via create_policies with
+# sample_local_extranet_policies.yaml). Unlike Data Exchange, the full policy is mutable
+# here, not just a single field.
+#
+# NOTE: This policy only shares routes between the LAN segments; it does not open traffic
+# between them. A zone-based firewall (security policy) must also be configured between the
+# shared segment and each branch segment to actually permit the extranet traffic — see
+# sample_device_security_policies.yaml.
+#
+# NOTE: update_policies replaces the full policy, not a merge/patch — carry over every field
+# from the create config unchanged, and only change the fields you actually want to update.
+# E.g. to add a new prefix to the prefixSet, list all existing entries plus the new one;
+# omitting an existing entry removes it.
+
+local_extranet_policies:
+  - name: "local-extranet-policy-1"
+    description: "local_extranet_policy_1_description"
+    sharedSegment: "lan-segment-3" # Will be resolved to ID
+    targetSegments:
+      - "lan-7-test" # Will be resolved to ID
+      - "lan-8-test"
+    source:
+      sites:
+        - "San Jose-sdktest" # Will be resolved to IDs
+      # Optional. Restricts which prefixes from the shared segment are advertised (omit
+      # entirely to share all prefixes). Each entry needs "ipPrefix"; "maskLower"/"maskUpper"
+      # are optional and further restrict ipPrefix to only the subnets within that
+      # mask-length range (matches the portal UI's Exact/Range/Less & Equal/Greater & Equal
+      # rule dropdown). Defaults depend on which are given: neither given -> both default to
+      # ipPrefix's own mask length (exact match); only maskUpper given -> maskLower defaults
+      # to ipPrefix's own mask length; only maskLower given -> maskUpper defaults to 32; both
+      # given -> used as-is.
+      prefixSet:
+        name: "list"
+        mode: "ipv4"
+        entries:
+          - ipPrefix: "10.0.0.0/24"
+          - ipPrefix: "70.0.0.0/23"
+            maskLower: 25
+            maskUpper: 30
+          - ipPrefix: "100.100.0.0/22"
+            maskUpper: 30
+          - ipPrefix: "2.2.100.0/23"
+            maskUpper: 27
+    branches:
+      sites:
+        - "New York-sdktest" # Will be resolved to IDs

--- a/ansible_collections/graphiant/naas/docs/README.md
+++ b/ansible_collections/graphiant/naas/docs/README.md
@@ -43,7 +43,9 @@ ansible-doc graphiant.naas.graphiant_site_to_site_vpn
 ansible-doc graphiant.naas.graphiant_global_config
 ansible-doc graphiant.naas.graphiant_sites
 ansible-doc graphiant.naas.graphiant_data_exchange
+ansible-doc graphiant.naas.graphiant_local_extranet
 ansible-doc graphiant.naas.graphiant_static_routes
+ansible-doc graphiant.naas.graphiant_ospfv2
 ansible-doc graphiant.naas.graphiant_dhcp_relay
 ansible-doc graphiant.naas.graphiant_ntp
 ansible-doc graphiant.naas.graphiant_traffic_policy

--- a/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
+++ b/ansible_collections/graphiant/naas/docs/guides/EXAMPLES.md
@@ -3754,6 +3754,151 @@ ansible-playbook playbooks/de_workflows/05_dataex_delete_services.yml
     msg: "{{ delete_services_result.msg }}"
 ```
 
+## Local Extranet Workflows
+
+Local Extranet shares a LAN segment (VRF) with other LAN segments across sites/branches within the
+**same** enterprise — unlike [Data Exchange Workflows](#data-exchange-workflows) (cross-enterprise
+B2B peering with producer/customer/match/invitation entities), it is a flat, single-resource policy
+CRUD with no counterpart enterprise involved. After a successful create or update, the policy is
+automatically pushed to devices (equivalent to the `/v1/extranets/{id}/apply` API) — there is no
+separate "apply" operation to run.
+
+### Step 1: Create Local Extranet policies
+
+```bash
+ansible-playbook playbooks/local_extranet_management.yml --tags create --check --diff
+ansible-playbook playbooks/local_extranet_management.yml --tags create
+```
+
+```yaml
+- name: Create Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: create_policies
+    config_file: "sample_local_extranet_policies.yaml"
+    detailed_logs: true
+  register: create_policies_result
+
+- name: Display policy creation result
+  ansible.builtin.debug:
+    msg: "{{ create_policies_result.msg }}"
+```
+
+Each policy entry requires `name`, `sharedSegment` (LAN segment name shared with other
+segments), and `targetSegments` (list of LAN segment names allowed to consume it). Optional
+`source` and `branches` blocks scope the shared-segment side and consuming side, respectively.
+Optional `source.sites`/`branches.sites` scope which
+sites participate, resolved from names to IDs automatically; `excludedDevices` is optional and
+defaults to an empty list when omitted. `type` is not
+configurable and is not exposed in the portal UI either. Its required wire
+value differs by operation, confirmed against live captures: `create_policies` sends the string
+`"enterprise"` (a numeric string like `"2"`, matching the portal's own create request, also lets
+create succeed but produces a policy the list endpoint's `?type=enterprise` filter — what the
+portal UI's own list view queries — can't find); `update_policies` sends the raw JSON integer `2`
+via a direct API call, since the same string value (or omitting `type` entirely) fails update with
+a backend foreign-key constraint violation, and only a genuine integer (confirmed via the portal
+UI's own successful update request) satisfies it.
+
+Existence checks for `create_policies`/`update_policies`/`delete_policies` and the info module's
+`policies_summary`/`policy_device_status` never filter by `type` — only the portal UI's own list
+view does. A policy with an unexpected `type` (e.g. one left over from before this was fixed)
+would otherwise be invisible to a type-filtered lookup while still blocking a fresh create under
+the same name via the backend's (enterpriseId, name) uniqueness constraint — an unrecoverable
+deadlock. This module avoids that by always seeing every policy regardless of `type`.
+
+Optional `source.prefixSet`/`branches.prefixSet` restricts which prefixes from the shared segment
+are advertised (omit entirely to share all prefixes). Each `entries` item needs `ipPrefix`;
+`maskLower`/`maskUpper` are optional and further restrict `ipPrefix` to only the subnets within
+that mask-length range (matches the portal UI's Exact/Range/Less & Equal/Greater & Equal rule
+dropdown). Defaults depend on which are given: neither given → both default to `ipPrefix`'s own
+mask length (exact match); only `maskUpper` given → `maskLower` defaults to `ipPrefix`'s own mask
+length; only `maskLower` given → `maskUpper` defaults to 32; both given → used as-is. `ipPrefix`
+(and `manual.prefixes`, if used) are validated as properly-aligned CIDR network addresses, the
+same check used by Data Exchange's `prefixTags`.
+
+On `update_policies`, the existing prefix-set object's `id` is automatically carried over from the
+current policy so the update modifies it in place — omitting it causes the backend to treat the
+request as creating a new prefix-set with the same name, which fails with "Prefix-set already
+exists" (confirmed via a live update).
+
+An existing policy (matched by `name`) is skipped (idempotent). Optional `targetDevices` (device
+names) controls which devices the policy is pushed to on apply; when omitted, the API applies the
+policy to all applicable devices.
+
+### Step 2: Update Local Extranet policies
+
+Unlike Data Exchange (where only a single field is mutable per service type), the full policy is
+mutable here. The policy must already exist; use `create_policies` for new policies.
+
+`sample_local_extranet_policies_update.yaml` has the same policy `name` as
+`sample_local_extranet_policies.yaml`, with a `maskLower`/`maskUpper` range restriction added to
+the `source.prefixSet` entry:
+
+```bash
+ansible-playbook playbooks/local_extranet_management.yml --tags update --check --diff
+ansible-playbook playbooks/local_extranet_management.yml --tags update
+```
+
+```yaml
+- name: Update Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: update_policies
+    config_file: "sample_local_extranet_policies_update.yaml"
+    detailed_logs: true
+  register: update_policies_result
+```
+
+### Step 3: Query policies and device status
+
+```bash
+ansible-playbook playbooks/local_extranet_management.yml --tags query
+```
+
+```yaml
+- name: Get Local Extranet policies summary
+  graphiant.naas.graphiant_local_extranet_info:
+    <<: *graphiant_client_params
+    query: policies_summary
+    detailed_logs: true
+  register: policies_summary
+
+- name: Get device rollout status for a policy
+  graphiant.naas.graphiant_local_extranet_info:
+    <<: *graphiant_client_params
+    query: policy_device_status
+    policy_name: "local-extranet-policy-1"
+    detailed_logs: true
+  register: device_status
+```
+
+`lan_segments_usage` and `nat_usage` queries are also available for monitoring LAN segment and NAT
+pool consumption — see `graphiant_local_extranet_info` module docs (`ansible-doc
+graphiant.naas.graphiant_local_extranet_info`) for details.
+
+### Step 4: Delete Local Extranet policies
+
+```bash
+ansible-playbook playbooks/local_extranet_management.yml --tags delete
+```
+
+```yaml
+- name: Delete Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    operation: delete_policies
+    config_file: "sample_local_extranet_policies.yaml"
+  register: delete_policies_result
+```
+
+A policy not found by `name` is skipped (idempotent).
+
 ## Raw Device Configuration (graphiant_device_config)
 
 `graphiant_device_config` is a **generic, low-level module** that pushes any JSON payload directly to the Graphiant device config API (`PUT /v1/devices/{id}/config`). Use it as an escape hatch when the structured modules (`graphiant_interfaces`, `graphiant_ntp`, etc.) do not yet cover a specific configuration field — anything the Portal UI can configure can be pushed with this module.

--- a/ansible_collections/graphiant/naas/playbooks/local_extranet_management.yml
+++ b/ansible_collections/graphiant/naas/playbooks/local_extranet_management.yml
@@ -1,0 +1,126 @@
+---
+# Manage Local Extranet policies (share a LAN segment with other LAN segments across
+# sites/branches within the same enterprise). Unlike Data Exchange (cross-enterprise B2B
+# peering), this is single-tenant — a flat policy resource with no counterpart enterprise
+# involved. After a successful create/update, the policy is automatically pushed to devices
+# (apply) — there is no separate "apply" step.
+#
+# The "update" tag defaults to sample_local_extranet_policies_update.yaml (same policy
+# 'name' as sample_local_extranet_policies.yaml, with a maskLower/maskUpper range restriction
+# added to the source prefixSet entry) — the policy must already exist (created via
+# --tags create) before running --tags update.
+#
+# NOTE: This policy only shares routes between the LAN segments; it does not open traffic
+# between them. A zone-based firewall (security policy) must also be configured between the
+# shared segment and each branch segment to actually permit the extranet traffic — see
+# sample_device_security_policies.yaml / security_policies_management.yml.
+#
+# NOTE: update_policies replaces the full policy, not a merge/patch — the update config file
+# must carry over every field from the create config unchanged, and only the fields you want
+# to change should differ. E.g. to add a new prefix to the prefixSet, list all existing
+# entries plus the new one; omitting an existing entry removes it.
+#
+# Tags:
+#   create — create policies (idempotent; skips existing)
+#   update — update existing policies (full policy is mutable; policy must already exist)
+#   delete — delete policies (idempotent; skips missing)
+#   query  — get policies summary and per-device rollout status (read-only)
+#
+# Example:
+#   ansible-playbook local_extranet_management.yml --tags create
+#   ansible-playbook local_extranet_management.yml --tags create --check --diff
+#   ansible-playbook local_extranet_management.yml --tags update --check --diff
+#   ansible-playbook local_extranet_management.yml --tags delete
+#   ansible-playbook local_extranet_management.yml --tags query
+
+- name: Manage Graphiant Local Extranet Policies
+  hosts: localhost
+  gather_facts: false
+  vars:
+    # graphiant_host: "https://api.graphiant.com"
+    # graphiant_username: "{{ vault_graphiant_username }}"
+    # graphiant_password: "{{ vault_graphiant_password }}"
+
+    # Use YAML anchors to avoid repetition.
+    # Auth: either set GRAPHIANT_ACCESS_TOKEN (e.g. graphiant login; source ~/.graphiant/env.sh)
+    # or set GRAPHIANT_USERNAME / GRAPHIANT_PASSWORD for password login. Token is tried first.
+    graphiant_client_params: &graphiant_client_params
+      host: "{{ graphiant_host | default(lookup('env', 'GRAPHIANT_HOST')) }}"
+      username: "{{ graphiant_username | default(lookup('env', 'GRAPHIANT_USERNAME')) }}"
+      password: "{{ graphiant_password | default(lookup('env', 'GRAPHIANT_PASSWORD')) }}"
+      access_token: "{{ graphiant_access_token | default(lookup('env', 'GRAPHIANT_ACCESS_TOKEN')) }}"
+
+  tasks:
+    - name: Create Local Extranet policies
+      graphiant.naas.graphiant_local_extranet:
+        <<: *graphiant_client_params
+        operation: create_policies
+        config_file: "{{ config_file | default('sample_local_extranet_policies.yaml') }}"
+        detailed_logs: true
+      register: create_policies_result
+      tags: ['create']
+
+    - name: Display policy creation result
+      ansible.builtin.debug:
+        msg: "{{ create_policies_result.msg }}"
+      when: create_policies_result is defined and create_policies_result.msg is defined
+      tags: ['create']
+
+    - name: Update Local Extranet policies
+      graphiant.naas.graphiant_local_extranet:
+        <<: *graphiant_client_params
+        operation: update_policies
+        config_file: "{{ config_file | default('sample_local_extranet_policies_update.yaml') }}"
+        detailed_logs: true
+      register: update_policies_result
+      tags: ['update']
+
+    - name: Display policy update result
+      ansible.builtin.debug:
+        msg: "{{ update_policies_result.msg }}"
+      when: update_policies_result is defined and update_policies_result.msg is defined
+      tags: ['update']
+
+    - name: Delete Local Extranet policies
+      graphiant.naas.graphiant_local_extranet:
+        <<: *graphiant_client_params
+        operation: delete_policies
+        config_file: "{{ config_file | default('sample_local_extranet_policies.yaml') }}"
+        detailed_logs: true
+      register: delete_policies_result
+      tags: ['delete']
+
+    - name: Display policy deletion result
+      ansible.builtin.debug:
+        msg: "{{ delete_policies_result.msg }}"
+      when: delete_policies_result is defined and delete_policies_result.msg is defined
+      tags: ['delete']
+
+    - name: Get Local Extranet policies summary
+      graphiant.naas.graphiant_local_extranet_info:
+        <<: *graphiant_client_params
+        query: policies_summary
+        detailed_logs: true
+      register: policies_summary_result
+      tags: ['query']
+
+    - name: Display policies summary
+      ansible.builtin.debug:
+        msg: "{{ policies_summary_result.msg }}"
+      when: policies_summary_result is defined and policies_summary_result.msg is defined
+      tags: ['query']
+
+    - name: Get device rollout status for a policy
+      graphiant.naas.graphiant_local_extranet_info:
+        <<: *graphiant_client_params
+        query: policy_device_status
+        policy_name: "{{ policy_name | default('local-extranet-policy-1') }}"
+        detailed_logs: true
+      register: device_status_result
+      tags: ['query']
+
+    - name: Display device status
+      ansible.builtin.debug:
+        msg: "{{ device_status_result.msg }}"
+      when: device_status_result is defined and device_status_result.msg is defined
+      tags: ['query']

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/gcsdk_client.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/gcsdk_client.py
@@ -2310,6 +2310,385 @@ class GraphiantPortalClient:
             )
             raise e
 
+    # Local Extranet API Methods
+
+    def create_local_extranet_policy(self, policy_config: dict) -> dict:
+        """
+        Create a new Local Extranet policy.
+
+        POST /v1/extranets (bound in graphiant-sdk >= 26.7.0 as ``v1_extranets_post``).
+        Unlike Data Exchange, this is single-enterprise (no producer/consumer split): a
+        LAN segment (``sharedSegment``) is shared with other LAN segments
+        (``targetSegments``) across sites/branches within the same tenant.
+
+        Args:
+            policy_config (dict): Policy configuration (``ManaV2ExtranetPolicyInput`` shape:
+                name, type, description, sharedSegment, targetSegments, source, branches,
+                hostPrefixSet, sharedPrefixes, auto, manual) with names already resolved to IDs.
+
+        Returns:
+            dict: Created policy response (contains "id").
+        """
+        request_body = {"policy": policy_config}
+        if getattr(self, "check_mode", False):
+            # Validate against the real SDK request model so schema mismatches / a too-old
+            # installed graphiant-sdk surface in check mode too (see create_data_exchange_services).
+            try:
+                validated_payload_dict = graphiant_sdk.V1ExtranetsPostRequest.model_validate(request_body).to_dict()
+            except Exception as sdk_e:
+                raise ValidationError(
+                    f"create_local_extranet_policy: Payload failed SDK schema validation: {sdk_e}"
+                ) from sdk_e
+            LOG.info(
+                "[check_mode] create_local_extranet_policy would create: %s",
+                json.dumps(validated_payload_dict, indent=2),
+            )
+            return {"id": 0}
+        try:
+            LOG.info("create_local_extranet_policy: Creating policy '%s'", policy_config.get("name"))
+            response = self.api.v1_extranets_post(
+                authorization=self.bearer_token, v1_extranets_post_request=request_body
+            )
+            policy_id = getattr(response, "id", None) or getattr(getattr(response, "policy", None), "id", None)
+            LOG.info("create_local_extranet_policy: Successfully created policy with ID: %s", policy_id)
+            result = response.model_dump(by_alias=True, exclude_none=True)
+            result["id"] = policy_id
+            return result
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets"
+            self._log_api_error(
+                method_name="create_local_extranet_policy", api_url=api_url, request_body=request_body, exception=e
+            )
+            raise e
+
+    def get_local_extranet_policies(self, type_filter: Optional[str] = None) -> list:
+        """
+        Get Local Extranet policies.
+
+        GET /v1/extranets(?type=<type_filter>) — called via a raw API request rather than the
+        SDK-bound ``v1_extranets_get``, which takes no query parameters at all.
+
+        Args:
+            type_filter (str, optional): When given, passed through as the ``type`` query
+                param (e.g. ``"enterprise"``, matching the portal UI's own "Local Services >
+                Extranet" list view, confirmed via its browser network request). When None
+                (the default), no filter is applied and every policy is returned regardless of
+                its ``type`` value.
+
+                Deliberately NOT the default for lookups used by create/update/delete's
+                idempotency checks (get_local_extranet_policy_by_name): a policy created with
+                an unexpected/legacy ``type`` value would be invisible to a filtered lookup,
+                while still physically existing and blocking a fresh create on the same name
+                via the backend's (enterpriseId, name) uniqueness constraint — an unrecoverable
+                deadlock (can't create: name taken; can't find-to-delete: filtered out).
+                Use type_filter="enterprise" only for display purposes (get_policies_summary),
+                where matching the portal UI's own view is the actual goal.
+
+        Returns:
+            list: List of ManaV2ExtranetPolicy entries (empty list if none found).
+        """
+        api_url = f"{self.api.api_client.configuration.host}/v1/extranets"
+        query_params = {"type": type_filter} if type_filter else {}
+        try:
+            LOG.info("get_local_extranet_policies: Retrieving Local Extranet policies (type_filter=%s)", type_filter)
+            api_client = self.api.api_client
+            method, url, header_params, body, post_params = api_client.param_serialize(
+                "GET",
+                "/v1/extranets",
+                query_params=query_params,
+                header_params={
+                    "Authorization": self.bearer_token,
+                    "Accept": "application/json",
+                },
+                body=None,
+            )
+            response_data = api_client.call_api(method, url, header_params, body, post_params)
+            response_data.read()
+            self._raise_for_raw_status(response_data)
+            raw = json.loads(response_data.data)
+            policies = [graphiant_sdk.ManaV2ExtranetPolicy.model_validate(item) for item in raw.get("policies") or []]
+            LOG.info("get_local_extranet_policies: Successfully retrieved %s policies", len(policies))
+            return policies
+        except ApiException as e:
+            self._log_api_error(method_name="get_local_extranet_policies", api_url=api_url, exception=e)
+            return []
+
+    def get_local_extranet_policy_by_name(self, policy_name: str):
+        """
+        Get a specific Local Extranet policy by name.
+
+        Args:
+            policy_name (str): Name of the policy to retrieve
+
+        Returns:
+            ManaV2ExtranetPolicy or None: Policy if found, None otherwise.
+        """
+        try:
+            LOG.info("get_local_extranet_policy_by_name: Looking for policy '%s'", policy_name)
+            policies = self.get_local_extranet_policies()
+            for policy in policies:
+                if policy.name == policy_name:
+                    LOG.info("get_local_extranet_policy_by_name: Found policy '%s' with ID: %s", policy_name, policy.id)
+                    return policy
+            LOG.info("get_local_extranet_policy_by_name: Policy '%s' not found", policy_name)
+            return None
+        except Exception as e:
+            LOG.error("get_local_extranet_policy_by_name: Error finding policy '%s': %s", policy_name, e)
+            return None
+
+    def get_local_extranet_policy_details(self, policy_id: int) -> dict:
+        """
+        Get detailed information about a specific Local Extranet policy.
+
+        GET /v1/extranets/{id} (bound as ``v1_extranets_id_get``).
+
+        Args:
+            policy_id (int): ID of the policy to retrieve
+
+        Returns:
+            dict: Policy details (``policy`` object, e.g. sharedSegment/targetSegments
+                expanded to full LAN segment objects rather than bare IDs).
+        """
+        try:
+            LOG.info("get_local_extranet_policy_details: Retrieving policy ID %s", policy_id)
+            response = self.api.v1_extranets_id_get(authorization=self.bearer_token, id=policy_id)
+            policy = response.policy.to_dict() if response and response.policy else {}
+            LOG.info("get_local_extranet_policy_details: Successfully retrieved policy ID %s", policy_id)
+            return policy
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/{policy_id}"
+            self._log_api_error(
+                method_name="get_local_extranet_policy_details",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                exception=e,
+            )
+            raise e
+
+    def edit_local_extranet_policy(self, policy_id: int, policy_config: dict) -> dict:
+        """
+        Update an existing Local Extranet policy.
+
+        PUT /v1/extranets/{id} — called via a raw API request rather than the SDK-bound
+        ``v1_extranets_id_put``. That method's ``ManaV2ExtranetPolicyInput.type`` field is
+        typed ``StrictStr``, so the typed call can only ever send ``type`` as a JSON string
+        (or omit it). A live capture of the portal UI's own successful update request showed
+        ``"type": 2`` as a genuine JSON *integer* — sending the string ``"2"`` (or
+        ``"enterprise"``) failed with a backend foreign-key constraint violation
+        (``extranet_policy_type_fkey``), and omitting ``type`` entirely failed the exact same
+        way. Only a real JSON int satisfies the backend's update path, which this raw call
+        can send (the underlying ``ApiClient.rest_client.request`` does a plain
+        ``json.dumps(body)`` when Content-Type is JSON, preserving a Python ``int`` as a JSON
+        number) but the pydantic-typed SDK method cannot.
+
+        Args:
+            policy_id (int): ID of the policy to update
+            policy_config (dict): Full desired policy configuration (names already resolved
+                to IDs). ``type`` is expected to already be the Python int ``2``, not a
+                string — see ``local_extranet_manager._resolve_policy_ids``.
+
+        Returns:
+            dict: Updated policy response (contains "id").
+        """
+        request_body = {"policy": policy_config}
+        api_url = f"{self.api.api_client.configuration.host}/v1/extranets/{policy_id}"
+        if getattr(self, "check_mode", False):
+            LOG.info(
+                "[check_mode] edit_local_extranet_policy would update policy ID %s: %s",
+                policy_id,
+                json.dumps(request_body, indent=2),
+            )
+            return {"id": policy_id}
+        try:
+            LOG.info("edit_local_extranet_policy: Updating policy ID %s", policy_id)
+            api_client = self.api.api_client
+            method, url, header_params, body, post_params = api_client.param_serialize(
+                "PUT",
+                "/v1/extranets/{id}",
+                path_params={"id": policy_id},
+                header_params={
+                    "Authorization": self.bearer_token,
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
+                body=request_body,
+            )
+            response_data = api_client.call_api(method, url, header_params, body, post_params)
+            response_data.read()
+            self._raise_for_raw_status(response_data)
+            result = json.loads(response_data.data) if response_data.data else {}
+            result["id"] = policy_id
+            LOG.info("edit_local_extranet_policy: Successfully updated policy ID %s", policy_id)
+            return result
+        except ApiException as e:
+            self._log_api_error(
+                method_name="edit_local_extranet_policy",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                request_body=request_body,
+                exception=e,
+            )
+            raise e
+
+    def delete_local_extranet_policy(self, policy_id: int):
+        """
+        Delete a Local Extranet policy.
+
+        DELETE /v1/extranets/{id} (bound as ``v1_extranets_id_delete``).
+
+        Args:
+            policy_id (int): ID of the policy to delete
+
+        Returns:
+            API response (contains affected device statuses).
+        """
+        if getattr(self, "check_mode", False):
+            LOG.info("[check_mode] delete_local_extranet_policy would delete policy with ID: %s", policy_id)
+            return type("MockResponse", (), {})()
+        try:
+            LOG.info("delete_local_extranet_policy: Deleting policy with ID: %s", policy_id)
+            response = self.api.v1_extranets_id_delete(authorization=self.bearer_token, id=policy_id)
+            LOG.info("delete_local_extranet_policy: Successfully deleted policy with ID: %s", policy_id)
+            return response
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/{policy_id}"
+            self._log_api_error(
+                method_name="delete_local_extranet_policy",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                exception=e,
+            )
+            raise e
+
+    def apply_local_extranet_policy(self, policy_id: int, target_device_ids: Optional[list] = None) -> dict:
+        """
+        Push a Local Extranet policy to devices.
+
+        POST /v1/extranets/{id}/apply (bound as ``v1_extranets_id_apply_post``).
+
+        Args:
+            policy_id (int): ID of the policy to apply
+            target_device_ids (list, optional): Device IDs to push to. When omitted/empty,
+                ``targetDevices`` is left out of the request body and the API applies the
+                policy to all applicable devices (source/branch sites) on its own.
+
+        Returns:
+            dict: Response containing per-device status and a jobId.
+        """
+        request_body = {"targetDevices": target_device_ids} if target_device_ids else {}
+        if getattr(self, "check_mode", False):
+            LOG.info(
+                "[check_mode] apply_local_extranet_policy would apply policy ID %s: %s",
+                policy_id,
+                json.dumps(request_body, indent=2),
+            )
+            return {"devices": [], "jobId": 0}
+        try:
+            LOG.info("apply_local_extranet_policy: Applying policy ID %s", policy_id)
+            response = self.api.v1_extranets_id_apply_post(
+                authorization=self.bearer_token, id=policy_id, v1_extranets_id_apply_post_request=request_body
+            )
+            LOG.info("apply_local_extranet_policy: Successfully applied policy ID %s", policy_id)
+            return response.model_dump(by_alias=True, exclude_none=True)
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/{policy_id}/apply"
+            self._log_api_error(
+                method_name="apply_local_extranet_policy",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                request_body=request_body,
+                exception=e,
+            )
+            raise e
+
+    def get_local_extranet_policy_device_status(self, policy_id: int) -> list:
+        """
+        Get per-device push/rollout status for a Local Extranet policy.
+
+        GET /v1/extranets/{id}/status (bound as ``v1_extranets_id_status_get``).
+
+        Args:
+            policy_id (int): ID of the policy
+
+        Returns:
+            list: ManaV2ExtranetDeviceStatus entries (empty list if none found).
+        """
+        try:
+            LOG.info("get_local_extranet_policy_device_status: Retrieving device status for policy ID %s", policy_id)
+            response = self.api.v1_extranets_id_status_get(authorization=self.bearer_token, id=policy_id)
+            devices = response.devices if response and response.devices else []
+            LOG.info("get_local_extranet_policy_device_status: Retrieved status for %s device(s)", len(devices))
+            return devices
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/{policy_id}/status"
+            self._log_api_error(
+                method_name="get_local_extranet_policy_device_status",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                exception=e,
+            )
+            raise e
+
+    def get_local_extranet_lan_segments_usage(
+        self, policy_id: Optional[int] = None, is_provider: Optional[bool] = None
+    ):
+        """
+        Get LAN segment usage/monitoring info for Local Extranet.
+
+        GET /v1/extranets/monitoring/lan-segments (bound as
+        ``v1_extranets_monitoring_lan_segments_get``).
+
+        Args:
+            policy_id (int, optional): Extranet policy ID to filter by.
+            is_provider (bool, optional): Provider vs consumer view.
+
+        Returns:
+            API response object with a ``vrfs`` list.
+        """
+        try:
+            LOG.info("get_local_extranet_lan_segments_usage: Retrieving LAN segment usage (policy_id=%s)", policy_id)
+            response = self.api.v1_extranets_monitoring_lan_segments_get(
+                authorization=self.bearer_token, id=policy_id, is_provider=is_provider
+            )
+            LOG.info("get_local_extranet_lan_segments_usage: Successfully retrieved LAN segment usage")
+            return response
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/monitoring/lan-segments"
+            self._log_api_error(
+                method_name="get_local_extranet_lan_segments_usage",
+                api_url=api_url,
+                query_params={"id": policy_id, "is_provider": is_provider},
+                exception=e,
+            )
+            raise e
+
+    def get_local_extranet_nat_usage(self, policy_id: int):
+        """
+        Get NAT pool usage/monitoring info for a Local Extranet policy.
+
+        GET /v1/extranets/monitoring/nat-usage (bound as ``v1_extranets_monitoring_nat_usage_get``).
+
+        Args:
+            policy_id (int): Extranet policy ID.
+
+        Returns:
+            API response object with allocatedCount/usageCount/allocations.
+        """
+        try:
+            LOG.info("get_local_extranet_nat_usage: Retrieving NAT usage for policy ID %s", policy_id)
+            response = self.api.v1_extranets_monitoring_nat_usage_get(authorization=self.bearer_token, id=policy_id)
+            LOG.info("get_local_extranet_nat_usage: Successfully retrieved NAT usage for policy ID %s", policy_id)
+            return response
+        except ApiException as e:
+            api_url = f"{self.api.api_client.configuration.host}/v1/extranets/monitoring/nat-usage"
+            self._log_api_error(
+                method_name="get_local_extranet_nat_usage",
+                api_url=api_url,
+                path_params={"id": policy_id},
+                exception=e,
+            )
+            raise e
+
     def get_ipsec_inside_subnet(self, region_id, lan_segment_id, address_family):
         """
         Get IPSec inside subnet for a specific region and LAN segment.

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/graphiant_config.py
@@ -11,6 +11,7 @@ from .bgp_manager import BGPManager
 from .global_config_manager import GlobalConfigManager
 from .site_manager import SiteManager
 from .data_exchange_manager import DataExchangeManager
+from .local_extranet_manager import LocalExtranetManager
 from .device_config_manager import DeviceConfigManager
 from .vrrp_interface_manager import VRRPInterfaceManager
 from .dhcp_relay_interface_manager import DhcpRelayInterfaceManager
@@ -86,6 +87,7 @@ class GraphiantConfig:
             self.global_config = GlobalConfigManager(self.config_utils)
             self.sites = SiteManager(self.config_utils)
             self.data_exchange = DataExchangeManager(self.config_utils)
+            self.local_extranet = LocalExtranetManager(self.config_utils)
             self.device_config = DeviceConfigManager(self.config_utils)
             self.vrrp_interfaces = VRRPInterfaceManager(self.config_utils)
             self.dhcp_relay_interfaces = DhcpRelayInterfaceManager(self.config_utils)
@@ -122,6 +124,7 @@ class GraphiantConfig:
             "global_config": hasattr(self, "global_config") and self.global_config is not None,
             "sites": hasattr(self, "sites") and self.sites is not None,
             "data_exchange": hasattr(self, "data_exchange") and self.data_exchange is not None,
+            "local_extranet": hasattr(self, "local_extranet") and self.local_extranet is not None,
             "device_config": hasattr(self, "device_config") and self.device_config is not None,
             "vrrp_interfaces": hasattr(self, "vrrp_interfaces") and self.vrrp_interfaces is not None,
             "dhcp_relay_interfaces": hasattr(self, "dhcp_relay_interfaces") and self.dhcp_relay_interfaces is not None,

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/local_extranet_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/local_extranet_manager.py
@@ -1,0 +1,812 @@
+"""
+Local Extranet Manager for Graphiant Playbooks.
+
+This module provides functionality for managing Local Extranet policies: sharing a LAN
+segment (VRF) with other LAN segments across sites/branches within the same enterprise.
+
+Unlike Data Exchange (cross-enterprise B2B peering via producer/customer/match/invitation
+entities), Local Extranet is a flat, single-resource CRUD (one ``policy`` object with an
+``id``), scoped entirely within the current tenant.
+
+Deconfigure workflow consistency (with data_exchange_manager, global_config_manager):
+- Idempotency: delete_policies skips when the policy is not found.
+- Result shape: delete_policies returns changed, deleted, skipped (no 'failed'); create_/
+  update_policies return changed, created/updated, skipped, diff_plan.
+- Logging: "Attempting to delete ..." with target names, then "Deconfigure completed: ..."
+  with explicit lists (aligned with data_exchange_manager and site_manager).
+- create_policies/update_policies automatically push the policy to devices (POST .../apply)
+  after a successful create/update — there is no separate "apply" operation.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from typing import Any, Dict, List, Optional, cast
+
+try:
+    from tabulate import tabulate
+
+    HAS_TABULATE = True
+except ImportError:
+    HAS_TABULATE = False
+
+from .base_manager import BaseManager
+from .logger import setup_logger
+from .exceptions import ConfigurationError
+
+LOG = setup_logger()
+
+
+class LocalExtranetManager(BaseManager):
+    """
+    Manager for Local Extranet policy CRUD and device rollout.
+    """
+
+    def configure(self, config_yaml_file: str) -> dict:
+        """
+        Configure Local Extranet resources based on the provided YAML file.
+        This is the main entry point for Local Extranet configuration.
+
+        Args:
+            config_yaml_file: Path to the YAML configuration file
+
+        Returns:
+            dict: Result with 'changed' status and details of operations performed
+        """
+        return self.create_policies(config_yaml_file)
+
+    def deconfigure(self, config_yaml_file: str) -> dict:
+        """
+        Deconfigure Local Extranet resources based on the provided YAML file.
+        This is the main entry point for Local Extranet deconfiguration.
+
+        Args:
+            config_yaml_file: Path to the YAML configuration file
+
+        Returns:
+            dict: Result with 'changed' status and details of operations performed
+        """
+        return self.delete_policies(config_yaml_file)
+
+    def create_policies(self, config_yaml_file: str, diff_mode: bool = False) -> dict:
+        """
+        Create new Local Extranet policies from YAML configuration.
+
+        Args:
+            config_yaml_file (str): Path to the YAML configuration file
+            diff_mode (bool): Unused for creation (kept for parity with other managers'
+                create_* signature); no drift detection is performed here since a newly
+                created policy has nothing to drift against.
+
+        Returns:
+            dict: Result with 'changed' status and lists of created/skipped items
+        """
+        result: Dict[str, Any] = {"changed": False, "created": [], "skipped": [], "diff_plan": []}
+
+        try:
+            LOG.info("Creating Local Extranet policies from %s", config_yaml_file)
+            config_data = self.render_config_file(config_yaml_file)
+
+            if not config_data or "local_extranet_policies" not in config_data:
+                LOG.info("No local_extranet_policies configuration found in YAML file")
+                return result
+
+            policies = config_data["local_extranet_policies"]
+            if not isinstance(policies, list):
+                raise ConfigurationError("Configuration error: 'local_extranet_policies' must be a list.")
+
+            LOG.info("LocalExtranetManager: Current enterprise info: %s", self.gsdk.enterprise_info)
+
+            for policy_config in policies:
+                policy_name = policy_config.get("name")
+                LOG.info("--------------------------------")
+                LOG.info("create_policies: Creating policy '%s'", policy_name)
+                if not policy_name:
+                    raise ConfigurationError("Configuration error: Each policy must have a 'name' field.")
+
+                existing_policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+                if existing_policy:
+                    LOG.info("Policy '%s' already exists (ID: %s), skipping creation", policy_name, existing_policy.id)
+                    result["skipped"].append(policy_name)
+                    continue
+
+                target_device_names = policy_config.pop("targetDevices", None)
+                api_policy = {k: v for k, v in policy_config.items() if k != "name"}
+                api_policy["name"] = policy_name
+
+                self._resolve_policy_ids(api_policy, policy_name)
+                self._validate_policy_prefixes(api_policy, policy_name)
+
+                LOG.info("Policy configuration: %s", api_policy)
+                result["diff_plan"].append(
+                    {
+                        "device": policy_name,
+                        "branch": "create",
+                        "before": {},
+                        "after": api_policy,
+                    }
+                )
+                created = self.gsdk.create_local_extranet_policy(api_policy)
+                policy_id = created.get("id") if isinstance(created, dict) else getattr(created, "id", None)
+                if policy_id is None:
+                    raise ConfigurationError(
+                        f"Policy '{policy_name}' was created but no ID was returned by the API; "
+                        "cannot apply it to devices."
+                    )
+                LOG.info("Successfully created policy '%s' (ID: %s)", policy_name, policy_id)
+
+                target_device_ids = self._resolve_device_names(target_device_names, policy_name)
+                self.gsdk.apply_local_extranet_policy(policy_id, target_device_ids)
+                LOG.info("Applied policy '%s' (ID: %s) to devices", policy_name, policy_id)
+
+                result["created"].append(policy_name)
+                result["changed"] = True
+
+            LOG.info(
+                "Local Extranet policy creation completed: %s created, %s skipped (changed: %s)",
+                len(result["created"]),
+                len(result["skipped"]),
+                result["changed"],
+            )
+            return result
+
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to create Local Extranet policy: %s", e)
+            raise ConfigurationError(f"Local Extranet policy creation failed: {e}")
+
+    def update_policies(self, config_yaml_file: str) -> dict:
+        """
+        Update existing Local Extranet policies from YAML configuration.
+
+        Unlike Data Exchange (where only a single field is mutable per service type), the
+        full policy is mutable here. The policy must already exist.
+
+        Args:
+            config_yaml_file (str): Path to the YAML configuration file.
+                Each policy entry requires 'name' plus any fields to change.
+
+        Returns:
+            dict: Result with 'changed' status and lists of updated/skipped items
+        """
+        result: Dict[str, Any] = {"changed": False, "updated": [], "skipped": [], "diff_plan": []}
+
+        try:
+            LOG.info("Updating Local Extranet policies from %s", config_yaml_file)
+            config_data = self.render_config_file(config_yaml_file)
+
+            if not config_data or "local_extranet_policies" not in config_data:
+                LOG.info("No local_extranet_policies configuration found in YAML file")
+                return result
+
+            policies = config_data["local_extranet_policies"]
+            if not isinstance(policies, list):
+                raise ConfigurationError("Configuration error: 'local_extranet_policies' must be a list.")
+
+            LOG.info("LocalExtranetManager: Current enterprise info: %s", self.gsdk.enterprise_info)
+
+            for policy_config in policies:
+                policy_name = policy_config.get("name")
+                LOG.info("--------------------------------")
+                LOG.info("update_policies: Updating policy '%s'", policy_name)
+                if not policy_name:
+                    raise ConfigurationError("Configuration error: Each policy must have a 'name' field.")
+
+                existing_policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+                if not existing_policy:
+                    raise ConfigurationError(
+                        f"Policy '{policy_name}' not found. Use create_policies to create new policies."
+                    )
+                policy_id = existing_policy.id
+
+                target_device_names = policy_config.pop("targetDevices", None)
+                api_policy = {k: v for k, v in policy_config.items() if k != "name"}
+                api_policy["name"] = policy_name
+
+                self._resolve_policy_ids(api_policy, policy_name, for_update=True)
+                self._validate_policy_prefixes(api_policy, policy_name)
+
+                current_details = self.gsdk.get_local_extranet_policy_details(policy_id)
+                self._carry_over_prefix_set_id(api_policy.get("source"), current_details.get("source") or {})
+                self._carry_over_prefix_set_id(api_policy.get("branches"), current_details.get("branches") or {})
+                current_normalized = self._normalize_policy(current_details)
+                desired_normalized = self._normalize_policy(api_policy)
+
+                if current_normalized == desired_normalized:
+                    LOG.info("Policy '%s' unchanged, skipping update", policy_name)
+                    result["skipped"].append(policy_name)
+                    continue
+
+                result["diff_plan"].append(
+                    {
+                        "device": policy_name,
+                        "branch": "policy",
+                        "before": current_normalized,
+                        "after": desired_normalized,
+                    }
+                )
+
+                LOG.info("update_policies: Update payload for '%s': %s", policy_name, api_policy)
+                self.gsdk.edit_local_extranet_policy(policy_id, api_policy)
+                LOG.info("Successfully updated policy '%s' (ID: %s)", policy_name, policy_id)
+
+                target_device_ids = self._resolve_device_names(target_device_names, policy_name)
+                self.gsdk.apply_local_extranet_policy(policy_id, target_device_ids)
+                LOG.info("Applied policy '%s' (ID: %s) to devices", policy_name, policy_id)
+
+                result["updated"].append(policy_name)
+                result["changed"] = True
+
+            LOG.info(
+                "Local Extranet policy update completed: %s updated, %s skipped (changed: %s)",
+                len(result["updated"]),
+                len(result["skipped"]),
+                result["changed"],
+            )
+            return result
+
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to update Local Extranet policy: %s", e)
+            raise ConfigurationError(f"Local Extranet policy update failed: {e}")
+
+    def delete_policies(self, config_yaml_file: str) -> dict:
+        """
+        Delete Local Extranet policies from YAML configuration.
+
+        Args:
+            config_yaml_file (str): Path to the YAML configuration file
+
+        Returns:
+            dict: Result with 'changed' status and lists of deleted/skipped items
+        """
+        result: Dict[str, Any] = {"changed": False, "deleted": [], "skipped": []}
+
+        try:
+            LOG.info("Deleting Local Extranet policies from %s", config_yaml_file)
+            config_data = self.render_config_file(config_yaml_file)
+
+            if not config_data or "local_extranet_policies" not in config_data:
+                LOG.info("No local_extranet_policies configuration found in YAML file")
+                return result
+
+            policies = config_data["local_extranet_policies"]
+            if not isinstance(policies, list):
+                raise ConfigurationError("Configuration error: 'local_extranet_policies' must be a list.")
+
+            policy_names = [p.get("name") for p in policies if p.get("name")]
+            LOG.info("Attempting to delete Local Extranet policies: %s", policy_names)
+            LOG.info("LocalExtranetManager: Current enterprise info: %s", self.gsdk.enterprise_info)
+
+            for policy_config in policies:
+                policy_name = policy_config.get("name")
+                LOG.info("--------------------------------")
+                LOG.info("delete_policies: Deleting policy '%s'", policy_name)
+                if not policy_name:
+                    raise ConfigurationError("Configuration error: Each policy must have a 'name' field.")
+
+                policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+                if not policy:
+                    LOG.info("Policy '%s' not found, skipping deletion", policy_name)
+                    result["skipped"].append(policy_name)
+                    continue
+
+                self.gsdk.delete_local_extranet_policy(policy.id)
+                LOG.info("Successfully deleted policy '%s' (ID: %s)", policy_name, policy.id)
+                result["deleted"].append(policy_name)
+                result["changed"] = True
+
+            LOG.info(
+                "Local Extranet policy deletion completed: %s deleted, %s skipped (changed: %s)",
+                len(result["deleted"]),
+                len(result["skipped"]),
+                result["changed"],
+            )
+            LOG.info("Deconfigure completed: deleted=%s, skipped=%s", result["deleted"], result["skipped"])
+            return result
+
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to delete Local Extranet policy: %s", e)
+            raise ConfigurationError(f"Local Extranet policy deletion failed: {e}")
+
+    def get_policies_summary(self) -> Dict[str, Any]:
+        """
+        Get summary of all Local Extranet policies.
+
+        Returns:
+            dict: {"policies": [...]} summary
+        """
+        try:
+            LOG.info("LocalExtranetManager: Current enterprise info: %s", self.gsdk.enterprise_info)
+            LOG.info("Retrieving Local Extranet policies summary")
+            policies = self.gsdk.get_local_extranet_policies()
+
+            summary = []
+            for policy in policies:
+                shared_segment = getattr(policy, "shared_segment", None)
+                target_segments = getattr(policy, "target_segments", None) or []
+                summary.append(
+                    {
+                        "id": policy.id,
+                        "name": policy.name,
+                        "sharedSegment": getattr(shared_segment, "name", None),
+                        "targetSegmentsCount": len(target_segments),
+                    }
+                )
+
+            if summary and HAS_TABULATE:
+                LOG.info(
+                    "Local Extranet Policies Summary:\n%s",
+                    tabulate(
+                        [[s["id"], s["name"], s["sharedSegment"], s["targetSegmentsCount"]] for s in summary],
+                        headers=["ID", "Name", "Shared Segment", "Target Segments"],
+                        tablefmt="grid",
+                    ),
+                )
+
+            return {"policies": summary}
+        except Exception as e:
+            LOG.error("Failed to retrieve Local Extranet policies summary: %s", e)
+            raise ConfigurationError(f"Failed to retrieve Local Extranet policies summary: {e}")
+
+    def get_policy_by_name(self, policy_name: str) -> Optional[Dict[str, Any]]:
+        """
+        Get a specific Local Extranet policy by name.
+
+        Args:
+            policy_name (str): Name of the policy to retrieve
+
+        Returns:
+            dict or None: Policy details if found, None otherwise
+        """
+        try:
+            LOG.info("Retrieving Local Extranet policy '%s'", policy_name)
+            policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+            if not policy:
+                return None
+            return self.gsdk.get_local_extranet_policy_details(policy.id)
+        except Exception as e:
+            LOG.error("Failed to retrieve policy '%s': %s", policy_name, e)
+            raise ConfigurationError(f"Failed to retrieve policy '{policy_name}': {e}")
+
+    def get_device_status(self, policy_name: str) -> Dict[str, Any]:
+        """
+        Get per-device push/rollout status for a Local Extranet policy.
+
+        Args:
+            policy_name (str): Name of the policy
+
+        Returns:
+            dict: {"policy_name", "devices": [...]}
+        """
+        try:
+            policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+            if not policy:
+                raise ConfigurationError(f"Policy '{policy_name}' not found.")
+
+            devices = self.gsdk.get_local_extranet_policy_device_status(policy.id)
+            device_rows = [
+                {
+                    "deviceId": getattr(d, "device_id", None),
+                    "deviceName": getattr(d, "device_name", None),
+                    "siteName": getattr(d, "site_name", None),
+                    "status": getattr(d, "status", None),
+                }
+                for d in devices
+            ]
+
+            if device_rows and HAS_TABULATE:
+                LOG.info(
+                    "Local Extranet Policy '%s' Device Status:\n%s",
+                    policy_name,
+                    tabulate(
+                        [[d["deviceId"], d["deviceName"], d["siteName"], d["status"]] for d in device_rows],
+                        headers=["Device ID", "Device Name", "Site Name", "Status"],
+                        tablefmt="grid",
+                    ),
+                )
+
+            return {"policy_name": policy_name, "devices": device_rows}
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to retrieve device status for policy '%s': %s", policy_name, e)
+            raise ConfigurationError(f"Failed to retrieve device status for policy '{policy_name}': {e}")
+
+    def get_lan_segments_usage(self, policy_name: Optional[str] = None, is_provider: Optional[bool] = None) -> dict:
+        """
+        Get LAN segment usage/monitoring info for Local Extranet.
+
+        Args:
+            policy_name (str, optional): Policy name to filter by.
+            is_provider (bool, optional): Provider vs consumer view.
+
+        Returns:
+            dict: Usage response.
+        """
+        try:
+            policy_id = None
+            if policy_name:
+                policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+                if not policy:
+                    raise ConfigurationError(f"Policy '{policy_name}' not found.")
+                policy_id = policy.id
+
+            response = self.gsdk.get_local_extranet_lan_segments_usage(policy_id, is_provider)
+            return response.model_dump(by_alias=True, exclude_none=True) if hasattr(response, "model_dump") else {}
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to retrieve LAN segment usage: %s", e)
+            raise ConfigurationError(f"Failed to retrieve LAN segment usage: {e}")
+
+    def get_nat_usage(self, policy_name: str) -> dict:
+        """
+        Get NAT pool usage/monitoring info for a Local Extranet policy.
+
+        Args:
+            policy_name (str): Policy name.
+
+        Returns:
+            dict: NAT usage response.
+        """
+        try:
+            policy = self.gsdk.get_local_extranet_policy_by_name(policy_name)
+            if not policy:
+                raise ConfigurationError(f"Policy '{policy_name}' not found.")
+
+            response = self.gsdk.get_local_extranet_nat_usage(policy.id)
+            return response.model_dump(by_alias=True, exclude_none=True) if hasattr(response, "model_dump") else {}
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            LOG.error("Failed to retrieve NAT usage for policy '%s': %s", policy_name, e)
+            raise ConfigurationError(f"Failed to retrieve NAT usage for policy '{policy_name}': {e}")
+
+    # --- Internal helpers ---
+
+    def _resolve_policy_target_ids(self, target_config: Optional[dict], policy_name: str, target_label: str) -> None:
+        """
+        Resolve site/device names to IDs in a policy 'source' or 'branches' block (modified
+        in place), and convert ``prefixSet.entries`` (if present) from the user-friendly list
+        shape to the API's wire shape (see _build_prefix_set_entries).
+
+        ``excludedDevices`` is always set (defaulting to an empty list) even when the config
+        doesn't specify one — the API expects the key to be present.
+
+        Args:
+            target_config (dict): The 'source' or 'branches' block, or None.
+            policy_name (str): Policy name, for error reporting.
+            target_label (str): "source" or "branches", for error reporting.
+        """
+        if not isinstance(target_config, dict):
+            return
+
+        site_names = target_config.get("sites")
+        if isinstance(site_names, list):
+            resolved_sites = []
+            for site_name in site_names:
+                if isinstance(site_name, str):
+                    resolved_sites.append(self.get_site_id(site_name))
+                else:
+                    resolved_sites.append(site_name)  # Already an ID
+            target_config["sites"] = resolved_sites
+
+        resolved_devices = []
+        for device_name in target_config.get("excludedDevices") or []:
+            if isinstance(device_name, str):
+                resolved_devices.append(self.get_device_id(device_name))
+            else:
+                resolved_devices.append(device_name)  # Already an ID
+        target_config["excludedDevices"] = resolved_devices
+
+        prefix_set = target_config.get("prefixSet")
+        if isinstance(prefix_set, dict) and isinstance(prefix_set.get("entries"), list):
+            prefix_set["entries"] = self._build_prefix_set_entries(
+                prefix_set["entries"], policy_name, f"{target_label}.prefixSet"
+            )
+
+    def _resolve_policy_ids(self, api_policy: dict, policy_name: str, for_update: bool = False) -> None:
+        """
+        Resolve all name references in a policy config to IDs (modified in place):
+        sharedSegment/targetSegments (LAN segments) and source/branches sites/excludedDevices.
+
+        ``type`` is not user-configurable (the portal UI doesn't expose it), and the value
+        that works differs by operation — confirmed against live create/update captures:
+          - create_policies (``for_update=False``): sent as the string ``"enterprise"``, via
+            the typed create SDK call (``StrictStr``-constrained). A bare numeric ``"type": 2``
+            (what the portal's own create request showed) coerced to string ``"2"`` also let
+            create succeed, but produced a policy invisible to GET's ``?type=enterprise``
+            list filter (what the portal UI's list view calls) — "enterprise" avoids that.
+          - update_policies (``for_update=True``): sent as the Python int ``2`` (a real JSON
+            integer, via a raw call in ``edit_local_extranet_policy`` — the typed update SDK
+            call can only send ``type`` as a string or omit it, and a live capture proved
+            those both fail with a backend foreign-key constraint violation
+            (``extranet_policy_type_fkey``); only the portal UI's own raw ``"type": 2`` int
+            succeeded).
+
+        Args:
+            api_policy (dict): Policy configuration to resolve.
+            policy_name (str): Policy name, for error reporting.
+            for_update (bool): False for create_policies (default), True for update_policies
+                — see above for what value each sends.
+
+        Raises:
+            ConfigurationError: If a referenced LAN segment name cannot be found.
+        """
+        api_policy["type"] = 2 if for_update else "enterprise"
+
+        if "sharedSegment" in api_policy and isinstance(api_policy["sharedSegment"], str):
+            lan_segment_name = api_policy["sharedSegment"]
+            lan_segment_id = self.gsdk.get_lan_segment_id(lan_segment_name)
+            if not lan_segment_id:
+                raise ConfigurationError(f"LAN segment '{lan_segment_name}' not found for policy '{policy_name}'.")
+            api_policy["sharedSegment"] = lan_segment_id
+
+        target_segments = api_policy.get("targetSegments")
+        if isinstance(target_segments, list):
+            resolved_segments = []
+            for segment_name in target_segments:
+                if isinstance(segment_name, str):
+                    segment_id = self.gsdk.get_lan_segment_id(segment_name)
+                    if not segment_id:
+                        raise ConfigurationError(
+                            f"LAN segment '{segment_name}' not found for policy '{policy_name}' (targetSegments)."
+                        )
+                    resolved_segments.append(segment_id)
+                else:
+                    resolved_segments.append(segment_name)  # Already an ID
+            api_policy["targetSegments"] = resolved_segments
+
+        self._resolve_policy_target_ids(api_policy.get("source"), policy_name, "source")
+        self._resolve_policy_target_ids(api_policy.get("branches"), policy_name, "branches")
+
+    def _resolve_device_names(self, device_names: Optional[list], policy_name: str) -> Optional[List[int]]:
+        """
+        Resolve a list of device names (the config-only 'targetDevices' key, used solely for
+        the apply/device-push step, not part of the API's 'policy' object) to device IDs.
+
+        Args:
+            device_names (list, optional): Device names (or already-resolved IDs).
+            policy_name (str): Policy name, for error reporting.
+
+        Returns:
+            list[int] or None: Resolved device IDs, or None if device_names was empty/omitted
+                (apply then pushes to all applicable devices).
+        """
+        if not device_names:
+            return None
+        resolved: List[int] = []
+        for device_name in device_names:
+            if isinstance(device_name, str):
+                # get_device_id() raises DeviceNotFoundError rather than returning None.
+                resolved.append(cast(int, self.get_device_id(device_name)))
+            else:
+                resolved.append(device_name)  # Already an ID
+        return resolved
+
+    def _build_prefix_set_entries(self, entries: list, policy_name: str, context: str) -> dict:
+        """
+        Convert a user-friendly list of ``{ipPrefix, maskLower, maskUpper}`` dicts into the
+        API's wire shape: ``entries`` keyed by string sequence number, each with an
+        auto-assigned ``seq``.
+
+        Defaults mirror the portal UI's "Rule" dropdown (Exact/Range/Less & Equal/Greater &
+        Equal), confirmed against a live POST/GET capture — the default is conditional on
+        which of maskLower/maskUpper are given, not a flat default for each:
+          - Neither given ("Exact"): maskLower = maskUpper = ipPrefix's own mask length.
+          - Only maskUpper given ("Less & Equal"): maskLower defaults to ipPrefix's own mask
+            length.
+          - Only maskLower given ("Greater & Equal"): maskUpper defaults to 32.
+          - Both given ("Range"): used as-is.
+
+        Args:
+            entries (list): User-supplied prefix entries, e.g.
+                ``[{"ipPrefix": "10.1.1.0/24", "maskLower": 25, "maskUpper": 28}]``.
+            policy_name (str): Policy name, for error reporting.
+            context (str): Where these entries came from (e.g. "source.prefixSet").
+
+        Returns:
+            dict: Wire-shaped entries, e.g. ``{"1": {"seq": 1, "ipPrefix": ..., "maskLower":
+                ..., "maskUpper": ...}}``.
+        """
+        wire_entries = {}
+        for idx, entry in enumerate(entries, start=1):
+            if not isinstance(entry, dict) or "ipPrefix" not in entry:
+                raise ConfigurationError(f"Policy '{policy_name}': each {context} entry must have 'ipPrefix'.")
+            ip_prefix = entry["ipPrefix"]
+            self._validate_cidr_prefixes([ip_prefix], policy_name, context)
+            own_mask_length = ipaddress.ip_network(ip_prefix, strict=True).prefixlen
+
+            has_mask_lower = "maskLower" in entry
+            has_mask_upper = "maskUpper" in entry
+            mask_lower = entry.get("maskLower", own_mask_length)
+            if has_mask_upper:
+                mask_upper = entry["maskUpper"]
+            elif has_mask_lower:
+                mask_upper = 32
+            else:
+                mask_upper = own_mask_length
+
+            wire_entries[str(idx)] = {
+                "seq": idx,
+                "ipPrefix": ip_prefix,
+                "maskLower": mask_lower,
+                "maskUpper": mask_upper,
+            }
+        return wire_entries
+
+    @staticmethod
+    def _carry_over_prefix_set_id(desired_target_config: Optional[dict], current_target_config: dict) -> None:
+        """
+        Carry the existing prefixSet's ``id`` (as returned by GET) into the desired update
+        payload for the same source/branches block, unless the desired config already
+        specifies one (modifies ``desired_target_config`` in place).
+
+        Without this, a PUT whose ``prefixSet.name`` matches an already-existing prefix-set
+        object — but omits ``id`` — is treated by the backend as an attempt to *create* a new
+        prefix-set object with that name, which fails with "Prefix-set already exists"
+        (confirmed via a live update). The current object's ``id`` must be echoed back to
+        update it in place instead.
+
+        Args:
+            desired_target_config (dict): The desired 'source' or 'branches' block being
+                built for the PUT payload, or None.
+            current_target_config (dict): The corresponding 'source'/'branches' block from
+                get_local_extranet_policy_details() (expanded read-side shape).
+        """
+        if not isinstance(desired_target_config, dict):
+            return
+        desired_prefix_set = desired_target_config.get("prefixSet")
+        current_prefix_set = current_target_config.get("prefixSet")
+        if not isinstance(desired_prefix_set, dict) or not isinstance(current_prefix_set, dict):
+            return
+        if "id" not in desired_prefix_set and current_prefix_set.get("id") is not None:
+            desired_prefix_set["id"] = current_prefix_set["id"]
+
+    @staticmethod
+    def _validate_cidr_prefixes(prefixes: list, policy_name: str, context: str) -> None:
+        """
+        Validate that each prefix is a properly-aligned CIDR network address (host bits
+        zero), matching the portal UI's own validation (see
+        DataExchangeManager._validate_cidr_prefixes for the equivalent Data Exchange check).
+
+        Args:
+            prefixes (list): Prefix strings to validate.
+            policy_name (str): Policy name, for error reporting.
+            context (str): Where these prefixes came from (e.g. "manual.prefixes").
+        """
+        for prefix in prefixes or []:
+            if not isinstance(prefix, str):
+                continue
+            try:
+                ipaddress.ip_network(prefix, strict=True)
+            except ValueError:
+                try:
+                    corrected = str(ipaddress.ip_network(prefix, strict=False))
+                    hint = f" (e.g. '{corrected}')"
+                except ValueError:
+                    hint = ""
+                raise ConfigurationError(
+                    f"Policy '{policy_name}': invalid {context} prefix '{prefix}'. Please make sure the "
+                    f"network address of the CIDR is provided{hint}."
+                )
+
+    def _validate_policy_prefixes(self, api_policy: dict, policy_name: str) -> None:
+        """
+        Validate manual.prefixes are properly aligned CIDR network addresses.
+
+        Args:
+            api_policy (dict): Resolved policy configuration.
+            policy_name (str): Policy name, for error reporting.
+        """
+        manual_config = api_policy.get("manual")
+        if isinstance(manual_config, dict):
+            self._validate_cidr_prefixes(manual_config.get("prefixes") or [], policy_name, "manual.prefixes")
+
+    @staticmethod
+    def _normalize_prefix_set(prefix_set: Optional[dict]) -> dict:
+        """
+        Normalize a 'prefixSet' block for idempotency comparison. ``entries`` is a dict
+        keyed by string sequence number on the desired/write side (after
+        _build_prefix_set_entries) but a plain list on the current/read side (GET) — both
+        are reduced here to a sorted list of {ipPrefix, maskLower, maskUpper}, applying the
+        same conditional maskLower/maskUpper defaults as _build_prefix_set_entries, so an
+        entry the API echoes back without them still compares equal to one that set them
+        explicitly.
+        """
+        if not isinstance(prefix_set, dict):
+            return {}
+
+        entries = prefix_set.get("entries")
+        raw_entries: List[Any]
+        if isinstance(entries, dict):
+            raw_entries = list(entries.values())
+        elif isinstance(entries, list):
+            raw_entries = entries
+        else:
+            raw_entries = []
+
+        normalized_entries = []
+        for entry in raw_entries:
+            if not isinstance(entry, dict):
+                continue
+            ip_prefix = entry.get("ipPrefix")
+            try:
+                own_mask_length = ipaddress.ip_network(ip_prefix, strict=False).prefixlen if ip_prefix else None
+            except ValueError:
+                own_mask_length = None
+
+            has_mask_lower = "maskLower" in entry
+            has_mask_upper = "maskUpper" in entry
+            mask_lower = entry.get("maskLower", own_mask_length)
+            if has_mask_upper:
+                mask_upper = entry["maskUpper"]
+            elif has_mask_lower:
+                mask_upper = 32
+            else:
+                mask_upper = own_mask_length
+
+            normalized_entries.append({"ipPrefix": ip_prefix, "maskLower": mask_lower, "maskUpper": mask_upper})
+        normalized_entries.sort(
+            key=lambda e: (e.get("ipPrefix") or "", e.get("maskLower") or 0, e.get("maskUpper") or 0)
+        )
+
+        return {
+            "name": prefix_set.get("name") or "",
+            "mode": prefix_set.get("mode") or "",
+            "entries": normalized_entries,
+        }
+
+    def _normalize_policy_target(self, target_config: Optional[dict]) -> dict:
+        """Normalize a resolved 'source'/'branches' block (already-expanded read-side objects
+        are reduced to bare IDs) for idempotency comparison."""
+        if not isinstance(target_config, dict):
+            return {}
+
+        def _as_ids(entries):
+            ids = []
+            for entry in entries or []:
+                if isinstance(entry, dict):
+                    ids.append(entry.get("id"))
+                elif hasattr(entry, "id"):
+                    ids.append(entry.id)
+                else:
+                    ids.append(entry)
+            return sorted([i for i in ids if i is not None])
+
+        return {
+            "sites": _as_ids(target_config.get("sites")),
+            "excludedDevices": _as_ids(target_config.get("excludedDevices")),
+            "prefixSet": self._normalize_prefix_set(target_config.get("prefixSet")),
+        }
+
+    def _normalize_policy(self, policy_config: dict) -> dict:
+        """
+        Normalize a policy dict (either the resolved-IDs desired config, or the
+        expanded-objects current state from get_local_extranet_policy_details) into a
+        comparable shape for idempotency checks.
+        """
+        if not isinstance(policy_config, dict):
+            return {}
+
+        shared_segment = policy_config.get("sharedSegment")
+        if isinstance(shared_segment, dict):
+            shared_segment = shared_segment.get("id")
+
+        target_segments = policy_config.get("targetSegments") or []
+        target_segment_ids_raw = [(seg.get("id") if isinstance(seg, dict) else seg) for seg in target_segments]
+        target_segment_ids = sorted([i for i in target_segment_ids_raw if i is not None])
+
+        return {
+            "description": policy_config.get("description") or "",
+            "sharedSegment": shared_segment,
+            "targetSegments": target_segment_ids,
+            "source": self._normalize_policy_target(policy_config.get("source")),
+            "branches": self._normalize_policy_target(policy_config.get("branches")),
+            "manual": {"prefixes": sorted((policy_config.get("manual") or {}).get("prefixes") or [])},
+        }

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_local_extranet.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_local_extranet.py
@@ -1,0 +1,367 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Graphiant Team <support@graphiant.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Ansible module for managing Graphiant Local Extranet policies.
+
+This module provides Local Extranet management capabilities including:
+- Local Extranet policy creation, update, and deletion
+- Automatic device rollout (apply) after create/update
+"""
+
+DOCUMENTATION = r"""
+---
+module: graphiant_local_extranet
+short_description: Manage Graphiant Local Extranet policies
+description:
+  - Manages Local Extranet policies, which share a LAN segment (the provider/shared-service side)
+    with other LAN segments (the consumer/branch side) across sites within the same enterprise.
+  - Unlike M(graphiant.naas.graphiant_data_exchange) (cross-enterprise B2B peering), Local Extranet
+    is single-tenant with no counterpart enterprise involved.
+  - Supports creating, updating, and deleting policies. After a successful create or update, the
+    policy is automatically pushed to devices — there is no separate "apply" step.
+version_added: "26.7.0"
+extends_documentation_fragment:
+  - graphiant.naas.graphiant_portal_auth
+notes:
+  - "Configuration files support Jinja2 templating syntax for dynamic configuration generation."
+  - "The module automatically resolves names to IDs for LAN segments, sites, and devices."
+  - "All operations are idempotent and safe to run multiple times without creating duplicates."
+  - "Check mode (C(--check)) is supported: config load, validation, and name-to-ID resolution run"
+  - "normally, but write operations are skipped and payloads are logged with a C([check_mode]) prefix."
+  - "Use M(graphiant.naas.graphiant_local_extranet_info) to query policy summaries and device status."
+options:
+  operation:
+    description:
+      - "The specific Local Extranet operation to perform."
+      - >-
+        V(create_policies)/V(update_policies): Create or update policies from a YAML config file
+        containing an I(local_extranet_policies) list. Each policy needs a I(name), a
+        I(sharedSegment) (the provider LAN segment being shared), and I(targetSegments) (the
+        consumer LAN segments allowed to access it). Optional I(source)/I(branches) blocks scope
+        the provider and consumer sides respectively, each supporting I(sites) and I(prefixSet).
+      - >-
+        I(prefixSet) restricts which subnets are advertised{{ ":" }} omit it to share/allow all
+        prefixes, or provide I(entries) (each with an I(ipPrefix) and optional I(maskLower)/
+        I(maskUpper)) to restrict shared prefixes to specific subnets.
+      - >-
+        Optional I(targetDevices) limits which devices a policy is pushed to (defaults to all
+        applicable devices). V(update_policies) requires the policy to already exist and supports
+        C(--check)/C(--diff) to preview changes.
+      - "V(delete_policies): Delete Local Extranet policies from a YAML configuration file."
+      - >-
+        For query operations (policies_summary, policy_device_status, lan_segments_usage, nat_usage),
+        use M(graphiant.naas.graphiant_local_extranet_info) instead.
+    type: str
+    choices:
+      - create_policies
+      - update_policies
+      - delete_policies
+    required: true
+  state:
+    description:
+      - "The desired state of the Local Extranet policies."
+      - "V(present): Maps to V(create_policies) when O(operation) not specified."
+      - "V(absent): Maps to V(delete_policies) when O(operation) not specified."
+    type: str
+    choices:
+      - present
+      - absent
+    default: present
+  config_file:
+    description:
+      - Path to the YAML configuration file for the operation.
+      - Required for V(create_policies), V(update_policies), and V(delete_policies) operations.
+      - Can be an absolute path or relative path. Relative paths are resolved using the configured config_path.
+      - Configuration files support Jinja2 templating syntax for dynamic generation.
+      - File must contain I(local_extranet_policies) list.
+    type: str
+  detailed_logs:
+    description:
+      - Enable detailed logging output for troubleshooting and monitoring.
+      - When enabled, provides comprehensive logs of all Local Extranet operations.
+      - Logs are captured and included in the RV(msg) return value for display using M(ansible.builtin.debug) module.
+    type: bool
+    default: false
+
+attributes:
+  check_mode:
+    description: >
+      Supported. In check mode, no API writes are performed; payloads that would be sent
+      are logged with a C([check_mode]) prefix.
+    support: full
+
+requirements:
+  - python >= 3.7
+  - "graphiant-sdk >= 26.7.0"
+  - tabulate
+
+seealso:
+  - module: graphiant.naas.graphiant_global_config
+    description: Configure global objects (LAN segments) required for Local Extranet
+  - module: graphiant.naas.graphiant_sites
+    description: Configure sites required for Local Extranet policies
+  - module: graphiant.naas.graphiant_local_extranet_info
+    description: Query Local Extranet policy summaries and device status
+  - module: graphiant.naas.graphiant_data_exchange
+    description: Manage cross-enterprise (B2B) Data Exchange services, customers, matches, and invitations
+
+author:
+  - Graphiant Team (@graphiant)
+
+"""
+
+EXAMPLES = r"""
+- name: Create Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    operation: create_policies
+    config_file: "sample_local_extranet_policies.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+  register: create_result
+
+- name: Display policy creation result
+  ansible.builtin.debug:
+    msg: "{{ create_result.msg }}"
+
+- name: Preview Local Extranet policy updates (check + diff)
+  graphiant.naas.graphiant_local_extranet:
+    operation: update_policies
+    config_file: "sample_local_extranet_policies_update.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+  register: update_result
+  # Run playbook with: ansible-playbook playbook.yml --check --diff
+
+- name: Update Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    operation: update_policies
+    config_file: "sample_local_extranet_policies_update.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+  register: update_result
+
+- name: Display policy update result
+  ansible.builtin.debug:
+    msg: "{{ update_result.msg }}"
+
+- name: Delete Local Extranet policies
+  graphiant.naas.graphiant_local_extranet:
+    operation: delete_policies
+    config_file: "sample_local_extranet_policies.yaml"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+"""
+
+RETURN = r"""
+msg:
+  description:
+    - Result message from the operation, including detailed logs when O(detailed_logs) is enabled.
+  type: str
+  returned: always
+  sample: |
+    Successfully created 1 Local Extranet policies
+
+    Detailed logs:
+    2025-11-19 23:08:05,315 - Graphiant_playbook - INFO - Creating policy 'le-policy-1'...
+    2025-11-19 23:08:05,450 - Graphiant_playbook - INFO - Successfully created policy 'le-policy-1'
+result_data:
+  description:
+    - Result data from the operation.
+  type: dict
+  returned: when applicable
+  sample: {}
+changed:
+  description:
+    - Whether the operation made changes to the system.
+  type: bool
+  returned: always
+  sample: true
+operation:
+  description:
+    - The operation that was performed.
+    - One of V(create_policies), V(update_policies), or V(delete_policies).
+  type: str
+  returned: always
+  sample: "create_policies"
+config_file:
+  description:
+    - The configuration file used for the operation.
+  type: str
+  returned: when applicable
+  sample: "sample_local_extranet_policies.yaml"
+diff:
+  description:
+    - Ansible C(--diff) output showing before/after state for each changed item.
+    - Returned for V(create_policies) and V(update_policies) when the playbook is run with C(--diff)
+      and at least one item would change.
+    - For new items, C(before) is empty and C(after) is the full target config.
+    - For updates, C(before) shows current values and C(after) shows target values.
+  type: dict
+  returned: when playbook uses C(--diff) and V(create_policies) or V(update_policies) has changes
+  sample:
+    before: |
+      === le-policy-1 (policy) ===
+      {"source": {"prefixSet": {"entries": [{"ipPrefix": "10.1.1.0/24", "maskLower": 24, "maskUpper": 32}]}}}
+    after: |
+      === le-policy-1 (policy) ===
+      {"source": {"prefixSet": {"entries": [{"ipPrefix": "10.1.1.0/24", "maskLower": 25, "maskUpper": 28}]}}}
+"""
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+from ansible_collections.graphiant.naas.plugins.module_utils.graphiant_utils import (  # noqa: E402
+    graphiant_portal_auth_argument_spec,
+    get_graphiant_connection,
+    handle_graphiant_exception,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.device_config_common import (  # noqa: E402
+    apply_module_diff,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.logging_decorator import capture_library_logs  # noqa: E402
+
+
+@capture_library_logs
+def execute_with_logging(module, func, *args, **kwargs):
+    """
+    Execute a function with optional detailed logging.
+
+    Args:
+        module: Ansible module instance
+        func: Function to execute
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+
+    Returns:
+        dict: Result with 'changed' and 'result_msg' keys
+    """
+    success_msg = kwargs.pop("success_msg", "Operation completed successfully")
+
+    try:
+        result = func(*args, **kwargs)
+        if isinstance(result, dict) and "changed" in result:
+            return {"changed": result["changed"], "result_msg": success_msg, "details": result}
+        return {"changed": True, "result_msg": success_msg}
+    except Exception as e:
+        raise e
+
+
+def main():
+    """Main function for the Local Extranet module."""
+
+    argument_spec = dict(
+        **graphiant_portal_auth_argument_spec(),
+        operation=dict(
+            type="str",
+            required=True,
+            choices=["create_policies", "update_policies", "delete_policies"],
+        ),
+        state=dict(type="str", choices=["present", "absent"], default="present"),
+        config_file=dict(type="str", required=False),
+        detailed_logs=dict(type="bool", default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[("operation", "state")],
+        required_one_of=[("operation", "state")],
+    )
+
+    params = module.params
+    operation = params.get("operation")
+    state = params.get("state")
+    config_file = params.get("config_file")
+
+    if not operation:
+        if state == "present":
+            operation = "create_policies"
+        elif state == "absent":
+            operation = "delete_policies"
+
+    if operation in ["create_policies", "update_policies", "delete_policies"]:
+        if not config_file:
+            module.fail_json(msg=f"config_file parameter is required for operation '{operation}'")
+
+    try:
+        connection = get_graphiant_connection(params, check_mode=module.check_mode)
+        graphiant_config = connection.graphiant_config
+
+        changed = False
+        result_msg = ""
+        result_data = {}
+        diff_plan = []
+
+        if operation == "create_policies":
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.create_policies,
+                config_file,
+                success_msg=f"Successfully created Local Extranet policies from {config_file}",
+                diff_mode=getattr(module, "_diff", False),
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+            diff_plan = result.get("details", {}).get("diff_plan", [])
+
+        elif operation == "update_policies":
+            success_msg = f"Successfully updated Local Extranet policies from {config_file}"
+            if module.check_mode:
+                success_msg = (
+                    f"Check mode: validated Local Extranet policy updates from {config_file} " "(API calls skipped)"
+                )
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.update_policies,
+                config_file,
+                success_msg=success_msg,
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+            diff_plan = result.get("details", {}).get("diff_plan", [])
+
+        elif operation == "delete_policies":
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.delete_policies,
+                config_file,
+                success_msg=f"Successfully deleted Local Extranet policies from {config_file}",
+            )
+            changed = result["changed"]
+            result_msg = result["result_msg"]
+
+        else:
+            module.fail_json(
+                msg=f"Unsupported operation: {operation}. "
+                f"Supported operations are: create_policies, update_policies, delete_policies. "
+                f"For query operations, use graphiant.naas.graphiant_local_extranet_info module."
+            )
+
+        exit_payload = dict(
+            changed=changed,
+            msg=result_msg,
+            result_msg=result_msg,
+            result_data=result_data,
+            operation=operation or "unknown",
+            config_file=config_file if config_file else None,
+        )
+        apply_module_diff(module, exit_payload, {"diff_plan": diff_plan})
+
+        module.exit_json(**exit_payload)
+
+    except Exception as e:
+        error_msg = handle_graphiant_exception(e, operation or "unknown")
+        module.fail_json(msg=error_msg, operation=operation or "unknown")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/graphiant/naas/plugins/modules/graphiant_local_extranet_info.py
+++ b/ansible_collections/graphiant/naas/plugins/modules/graphiant_local_extranet_info.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Graphiant Team <support@graphiant.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Ansible module for querying Graphiant Local Extranet information.
+
+This module provides query capabilities for Local Extranet:
+- Policies summary information
+- Per-device policy rollout status
+- LAN segment and NAT usage monitoring
+"""
+
+DOCUMENTATION = r"""
+---
+module: graphiant_local_extranet_info
+short_description: Query Graphiant Local Extranet policies, device status, and usage information
+description:
+  - This module provides query capabilities for Graphiant Local Extranet information.
+  - Returns summary information about Local Extranet policies.
+  - Provides per-device policy rollout status.
+  - Provides LAN segment and NAT pool usage monitoring information.
+  - All operations return read-only information and never modify the system.
+version_added: "26.7.0"
+extends_documentation_fragment:
+  - graphiant.naas.graphiant_portal_auth
+notes:
+  - "This is a read-only module that queries information only."
+  - "All operations return tabulated output for easy reading, where applicable."
+options:
+  query:
+    description:
+      - "The specific information to query."
+      - "V(policies_summary): Get summary of all Local Extranet policies with tabulated output."
+      - "Returns policy details including IDs, names, type, shared segment, and target segments count."
+      - "V(policy_device_status): Get per-device push/rollout status for a Local Extranet policy."
+      - "Requires O(policy_name)."
+      - "V(lan_segments_usage): Get LAN segment usage/monitoring information."
+      - "O(policy_name) is optional; when omitted, returns usage across all policies."
+      - "V(nat_usage): Get NAT pool usage/monitoring information for a Local Extranet policy."
+      - "Requires O(policy_name)."
+    type: str
+    required: true
+    choices:
+      - policies_summary
+      - policy_device_status
+      - lan_segments_usage
+      - nat_usage
+  policy_name:
+    description:
+      - Local Extranet policy name.
+      - Required for V(policy_device_status) and V(nat_usage) queries.
+      - Optional for V(lan_segments_usage).
+    type: str
+  is_provider:
+    description:
+      - Whether to get provider view for LAN segment usage monitoring.
+      - Only applicable to V(lan_segments_usage) query.
+    type: bool
+  detailed_logs:
+    description:
+      - Enable detailed logging output for troubleshooting and monitoring.
+      - When enabled, provides comprehensive logs of all query operations.
+      - Logs are captured and included in the RV(msg) return value for display using M(ansible.builtin.debug) module.
+    type: bool
+    default: false
+
+attributes:
+  check_mode:
+    description: Supports check mode (always read-only).
+    support: full
+
+requirements:
+  - python >= 3.7
+  - graphiant-sdk >= 26.7.0
+  - tabulate
+
+seealso:
+  - module: graphiant.naas.graphiant_local_extranet
+    description: Manage Local Extranet policies
+
+author:
+  - Graphiant Team (@graphiant)
+
+"""
+
+EXAMPLES = r"""
+- name: Get Local Extranet policies summary
+  graphiant.naas.graphiant_local_extranet_info:
+    query: policies_summary
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+  register: policies_summary
+
+- name: Display policies summary
+  ansible.builtin.debug:
+    msg: "{{ policies_summary.msg }}"
+
+- name: Get device rollout status for a policy
+  graphiant.naas.graphiant_local_extranet_info:
+    query: policy_device_status
+    policy_name: "le-policy-1"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+    detailed_logs: true
+  register: device_status
+
+- name: Display device status
+  ansible.builtin.debug:
+    msg: "{{ device_status.msg }}"
+
+- name: Get LAN segment usage
+  graphiant.naas.graphiant_local_extranet_info:
+    query: lan_segments_usage
+    policy_name: "le-policy-1"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+  register: lan_segments_usage
+
+- name: Get NAT pool usage
+  graphiant.naas.graphiant_local_extranet_info:
+    query: nat_usage
+    policy_name: "le-policy-1"
+    host: "{{ graphiant_host }}"
+    username: "{{ graphiant_username }}"
+    password: "{{ graphiant_password }}"
+  register: nat_usage
+"""
+
+RETURN = r"""
+msg:
+  description:
+    - Result message from the query operation, including detailed logs when O(detailed_logs) is enabled.
+  type: str
+  returned: always
+  sample: |
+    Local Extranet Policies Summary:
+    +------+---------------+----------------+------------------+
+    |   ID | Name          | Shared Segment |  Target Segments |
+    +======+===============+================+==================+
+    | 8568 | le-policy-1   | lan-1          |                2 |
+    +------+---------------+----------------+------------------+
+result_data:
+  description:
+    - Result data from the query operation, including structured data for the requested query.
+  type: dict
+  returned: always
+  sample:
+    policies:
+      - id: 8568
+        name: "le-policy-1"
+        sharedSegment: "lan-1"
+        targetSegmentsCount: 2
+query:
+  description:
+    - The query that was performed.
+    - One of V(policies_summary), V(policy_device_status), V(lan_segments_usage), or V(nat_usage).
+  type: str
+  returned: always
+  sample: "policies_summary"
+"""
+
+from ansible.module_utils.basic import AnsibleModule  # noqa: E402
+from ansible_collections.graphiant.naas.plugins.module_utils.graphiant_utils import (  # noqa: E402
+    graphiant_portal_auth_argument_spec,
+    get_graphiant_connection,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.logging_decorator import (  # noqa: E402
+    capture_library_logs,
+)
+
+
+@capture_library_logs
+def execute_with_logging(module, func, *args, **kwargs):
+    """
+    Execute a function with optional detailed logging.
+
+    Args:
+        module: Ansible module instance
+        func: Function to execute
+        *args: Arguments to pass to the function
+        **kwargs: Keyword arguments to pass to the function
+
+    Returns:
+        dict: Result with 'result_msg' and 'result_data' keys
+    """
+    success_msg = kwargs.pop("success_msg", "Query completed successfully")
+
+    try:
+        result = func(*args, **kwargs)
+        if isinstance(result, dict) and "result_msg" in result:
+            return {"result_msg": result.get("result_msg", success_msg), "result_data": result.get("result_data", {})}
+        return {"result_msg": success_msg, "result_data": result if isinstance(result, dict) else {}}
+    except Exception as e:
+        raise e
+
+
+def main():
+    """Main function for the Local Extranet info module."""
+
+    argument_spec = dict(
+        **graphiant_portal_auth_argument_spec(),
+        query=dict(
+            type="str",
+            required=True,
+            choices=["policies_summary", "policy_device_status", "lan_segments_usage", "nat_usage"],
+        ),
+        policy_name=dict(type="str", required=False),
+        is_provider=dict(type="bool", required=False),
+        detailed_logs=dict(type="bool", default=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ("query", "policy_device_status", ["policy_name"]),
+            ("query", "nat_usage", ["policy_name"]),
+        ],
+    )
+
+    params = module.params
+    query = params.get("query")
+    policy_name = params.get("policy_name")
+
+    try:
+        connection = get_graphiant_connection(params, check_mode=module.check_mode)
+        graphiant_config = connection.graphiant_config
+
+        result_msg = ""
+        result_data = {}
+
+        if query == "policies_summary":
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.get_policies_summary,
+                success_msg="Successfully retrieved Local Extranet policies summary",
+            )
+            result_msg = result["result_msg"]
+            result_data = result.get("result_data", {})
+
+        elif query == "policy_device_status":
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.get_device_status,
+                policy_name,
+                success_msg=f"Successfully retrieved device status for policy {policy_name}",
+            )
+            result_msg = result["result_msg"]
+            result_data = result.get("result_data", {})
+
+        elif query == "lan_segments_usage":
+            is_provider = params.get("is_provider")
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.get_lan_segments_usage,
+                policy_name,
+                is_provider,
+                success_msg="Successfully retrieved LAN segment usage",
+            )
+            result_msg = result["result_msg"]
+            result_data = result.get("result_data", {})
+
+        elif query == "nat_usage":
+            result = execute_with_logging(
+                module,
+                graphiant_config.local_extranet.get_nat_usage,
+                policy_name,
+                success_msg=f"Successfully retrieved NAT usage for policy {policy_name}",
+            )
+            result_msg = result["result_msg"]
+            result_data = result.get("result_data", {})
+
+        else:
+            module.fail_json(
+                msg=f"Unsupported query: {query}. "
+                f"Supported queries are: policies_summary, policy_device_status, lan_segments_usage, nat_usage"
+            )
+
+        module.exit_json(changed=False, msg=result_msg, query=query, result_data=result_data)
+
+    except Exception as e:
+        module.fail_json(msg=f"Error executing query: {str(e)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/graphiant/naas/tests/test.py
+++ b/ansible_collections/graphiant/naas/tests/test.py
@@ -1443,6 +1443,75 @@ class TestGraphiantPlaybooks(unittest.TestCase):
             self.assertIn(r["status"], ("check_mode", "skipped"),
                           f"Unexpected status '{r['status']}' for {r.get('customer_name')}")
 
+    def test_create_local_extranet_policies(self):
+        """
+        Create Local Extranet policies.
+
+        Second run should be idempotent (changed=False, skipped, nothing created).
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.local_extranet.create_policies("sample_local_extranet_policies.yaml")
+        LOG.info("Create Local Extranet policies result: %s", result)
+
+        result2 = graphiant_config.local_extranet.create_policies("sample_local_extranet_policies.yaml")
+        LOG.info("Create Local Extranet policies result (idempotency check): %s", result2)
+        self.assertFalse(result2["changed"], f"Expected no change on idempotent create_policies, got: {result2}")
+        self.assertTrue(result2["skipped"], f"Expected policies to be skipped, got: {result2}")
+        self.assertFalse(result2["created"], f"Expected no new policies to be created, got: {result2}")
+
+    def test_get_local_extranet_policies_summary(self):
+        """
+        Get Local Extranet policies summary.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        graphiant_config.local_extranet.get_policies_summary()
+
+    def test_update_local_extranet_policies(self):
+        """
+        Update Local Extranet policies (adds a second sharedPrefixes entry).
+
+        Second run should be idempotent (changed=False) since the desired state already matches.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        updated_config_path = "sample_local_extranet_policies_update.yaml"
+
+        result = graphiant_config.local_extranet.update_policies(updated_config_path)
+        LOG.info("Update Local Extranet policies result: %s", result)
+        self.assertTrue(result["changed"], f"Expected update to change the policy, got: {result}")
+
+        result2 = graphiant_config.local_extranet.update_policies(updated_config_path)
+        LOG.info("Update Local Extranet policies result (idempotency check): %s", result2)
+        self.assertFalse(result2["changed"], f"Expected no change on idempotent update, got: {result2}")
+        self.assertTrue(result2["skipped"], f"Expected policy to be skipped, got: {result2}")
+
+    def test_update_local_extranet_policies_restore(self):
+        """
+        Restore Local Extranet policies to their original sharedPrefixes after the update test.
+        """
+        graphiant_config = graphiant_config_from_read_config()
+        result = graphiant_config.local_extranet.update_policies(
+            "sample_local_extranet_policies.yaml"
+        )
+        self.assertTrue(result["changed"], f"Expected restore to change the policy, got: {result}")
+
+    def test_delete_local_extranet_policies(self):
+        """
+        Delete Local Extranet policies.
+
+        Second run should be idempotent (changed=False, skipped, nothing deleted).
+        """
+        graphiant_config = graphiant_config_from_read_config()
+
+        result = graphiant_config.local_extranet.delete_policies("sample_local_extranet_policies.yaml")
+        LOG.info("Delete Local Extranet policies result: %s", result)
+
+        result2 = graphiant_config.local_extranet.delete_policies("sample_local_extranet_policies.yaml")
+        LOG.info("Delete Local Extranet policies result (idempotency check): %s", result2)
+        self.assertFalse(result2["changed"], f"Expected no change on idempotent delete_policies, got: {result2}")
+        self.assertTrue(result2["skipped"], f"Expected policies to be skipped, got: {result2}")
+        self.assertFalse(result2["deleted"], f"Expected no policies to be deleted, got: {result2}")
+
     def test_show_validated_payload_for_device_config(self):
         """
         Show validated payload for device configuration.
@@ -2776,6 +2845,16 @@ if __name__ == '__main__':
     suite.addTest(TestGraphiantPlaybooks('test_delete_data_exchange_services'))
     suite.addTest(TestGraphiantPlaybooks('test_delete_data_exchange_services_client_to_server'))
     suite.addTest(TestGraphiantPlaybooks('test_delete_data_exchange_services_client_to_server_idempotent'))
+
+    # Local Extranet Tests (Pre-req: LAN segments, configured above for Data Exchange)
+    suite.addTest(TestGraphiantPlaybooks('test_configure_global_lan_segments'))
+    suite.addTest(TestGraphiantPlaybooks('test_configure_interfaces'))
+    suite.addTest(TestGraphiantPlaybooks('test_create_local_extranet_policies'))
+    suite.addTest(TestGraphiantPlaybooks('test_get_local_extranet_policies_summary'))
+    suite.addTest(TestGraphiantPlaybooks('test_update_local_extranet_policies'))
+    suite.addTest(TestGraphiantPlaybooks('test_update_local_extranet_policies_restore'))
+    suite.addTest(TestGraphiantPlaybooks('test_delete_local_extranet_policies'))
+
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_global_config_graphiant_filters'))
     suite.addTest(TestGraphiantPlaybooks('test_deconfigure_global_config_prefix_lists'))
 
@@ -2849,7 +2928,6 @@ if __name__ == '__main__':
     # Device Configuration Management Tests
     suite.addTest(TestGraphiantPlaybooks('test_show_validated_payload_for_device_config'))
     suite.addTest(TestGraphiantPlaybooks('test_configure_device_config'))
-
     '''
     # Backbone (Core) Configuration Management Tests
     suite.addTest(TestGraphiantPlaybooks('test_configure_backbone'))

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_gcsdk_client.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_gcsdk_client.py
@@ -853,3 +853,305 @@ def test_accept_data_exchange_service_check_mode_raises_on_invalid_payload() -> 
 
     with pytest.raises(ValidationError):
         client.accept_data_exchange_service(6534, {"id": 8417, "policy": {"sites": "not-a-list"}})
+
+
+# ---- Local Extranet: gcsdk_client wire-level coverage ----
+#
+# Single-tenant flat policy resource (create/get/edit/delete/apply at /v1/extranets), unlike
+# Data Exchange's producer/customer/match split. get_local_extranet_policies and
+# edit_local_extranet_policy use the raw param_serialize()/call_api() pattern (see
+# _raise_for_raw_status above); the rest are typed SDK-bound calls.
+
+
+def _raw_json_response(payload: dict, status: int = 200) -> MagicMock:
+    response = MagicMock(status=status, data=json.dumps(payload).encode())
+    response.read = MagicMock()
+    return response
+
+
+def test_create_local_extranet_policy_returns_id_on_success() -> None:
+    client = _make_client()
+    response = MagicMock()
+    response.id = None
+    response.policy = MagicMock(id=555)
+    response.model_dump.return_value = {"policy": {"name": "local-extranet-policy-1"}}
+    client.api.v1_extranets_post.return_value = response
+
+    result = client.create_local_extranet_policy(
+        {"name": "local-extranet-policy-1", "type": "enterprise", "sharedSegment": 1, "targetSegments": [2, 3]}
+    )
+
+    assert result["id"] == 555
+    kwargs = client.api.v1_extranets_post.call_args.kwargs
+    assert kwargs["v1_extranets_post_request"]["policy"]["sharedSegment"] == 1
+
+
+def test_create_local_extranet_policy_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_post.side_effect = ApiException(status=500, reason="sites are required")
+
+    with pytest.raises(ApiException):
+        client.create_local_extranet_policy({"name": "local-extranet-policy-1", "sharedSegment": 1})
+
+
+def test_create_local_extranet_policy_check_mode_validates_payload() -> None:
+    client = _make_client()
+    client.check_mode = True
+
+    result = client.create_local_extranet_policy(
+        {"name": "local-extranet-policy-1", "type": "enterprise", "sharedSegment": 1, "targetSegments": [2, 3]}
+    )
+
+    assert result == {"id": 0}
+    client.api.v1_extranets_post.assert_not_called()
+
+
+def test_create_local_extranet_policy_check_mode_raises_on_invalid_payload() -> None:
+    client = _make_client()
+    client.check_mode = True
+
+    with pytest.raises(ValidationError):
+        client.create_local_extranet_policy({"name": "local-extranet-policy-1", "sharedSegment": "not-an-int"})
+
+
+def test_get_local_extranet_policies_parses_raw_response() -> None:
+    client = _make_client()
+    client.api.api_client.param_serialize.return_value = ("GET", "url", {}, None, {})
+    client.api.api_client.call_api.return_value = _raw_json_response(
+        {"policies": [{"id": 1, "name": "local-extranet-policy-1"}]}
+    )
+
+    result = client.get_local_extranet_policies()
+
+    assert len(result) == 1
+    assert result[0].id == 1
+    assert result[0].name == "local-extranet-policy-1"
+
+
+def test_get_local_extranet_policies_passes_type_filter_query_param() -> None:
+    client = _make_client()
+    client.api.api_client.param_serialize.return_value = ("GET", "url", {}, None, {})
+    client.api.api_client.call_api.return_value = _raw_json_response({"policies": []})
+
+    client.get_local_extranet_policies(type_filter="enterprise")
+
+    kwargs = client.api.api_client.param_serialize.call_args.kwargs
+    assert kwargs["query_params"] == {"type": "enterprise"}
+
+
+def test_get_local_extranet_policies_returns_empty_list_on_error() -> None:
+    """
+    Regression: unlike most gcsdk_client getters, this one swallows the error and returns []
+    rather than propagating — callers (get_local_extranet_policy_by_name, is-in-use checks)
+    depend on a plain empty list, not an exception, when the endpoint is unreachable.
+    """
+    client = _make_client()
+    client.api.api_client.param_serialize.return_value = ("GET", "url", {}, None, {})
+    client.api.api_client.call_api.return_value = _raw_json_response(
+        {"errorCode": 13, "displayError": "boom"}, status=500
+    )
+
+    result = client.get_local_extranet_policies()
+
+    assert result == []
+
+
+def test_get_local_extranet_policy_by_name_found() -> None:
+    client = _make_client()
+    policy = MagicMock(id=7)
+    policy.name = "local-extranet-policy-1"  # "name" is a reserved MagicMock() constructor kwarg
+    with patch.object(client, "get_local_extranet_policies", return_value=[policy]):
+        result = client.get_local_extranet_policy_by_name("local-extranet-policy-1")
+
+    assert result is policy
+
+
+def test_get_local_extranet_policy_by_name_not_found() -> None:
+    client = _make_client()
+    with patch.object(client, "get_local_extranet_policies", return_value=[]):
+        result = client.get_local_extranet_policy_by_name("missing-policy")
+
+    assert result is None
+
+
+def test_get_local_extranet_policy_details_returns_policy_dict() -> None:
+    client = _make_client()
+    policy_obj = MagicMock()
+    policy_obj.to_dict.return_value = {"id": 42, "name": "local-extranet-policy-1"}
+    client.api.v1_extranets_id_get.return_value = MagicMock(policy=policy_obj)
+
+    result = client.get_local_extranet_policy_details(42)
+
+    assert result == {"id": 42, "name": "local-extranet-policy-1"}
+
+
+def test_get_local_extranet_policy_details_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_get.side_effect = ApiException(status=404, reason="not found")
+
+    with pytest.raises(ApiException):
+        client.get_local_extranet_policy_details(42)
+
+
+def test_edit_local_extranet_policy_success() -> None:
+    client = _make_client()
+    client.api.api_client.param_serialize.return_value = ("PUT", "url", {}, None, {})
+    client.api.api_client.call_api.return_value = _raw_json_response({"policy": {"id": 42}})
+
+    result = client.edit_local_extranet_policy(42, {"name": "local-extranet-policy-1", "type": 2, "sharedSegment": 1})
+
+    assert result["id"] == 42
+    kwargs = client.api.api_client.param_serialize.call_args.kwargs
+    assert kwargs["path_params"] == {"id": 42}
+    assert kwargs["body"]["policy"]["type"] == 2
+
+
+def test_edit_local_extranet_policy_raises_on_non_2xx_status() -> None:
+    """
+    Regression: a raw call_api() error response must actually raise (see
+    _raise_for_raw_status above) rather than being parsed as if it were a success.
+    """
+    client = _make_client()
+    client.api.api_client.param_serialize.return_value = ("PUT", "url", {}, None, {})
+    client.api.api_client.call_api.return_value = _raw_json_response(
+        {"errorCode": 13, "displayError": "policy not found"}, status=500
+    )
+
+    with pytest.raises(ApiException):
+        client.edit_local_extranet_policy(42, {"name": "local-extranet-policy-1"})
+
+
+def test_edit_local_extranet_policy_check_mode_does_not_call_api() -> None:
+    client = _make_client()
+    client.check_mode = True
+
+    result = client.edit_local_extranet_policy(42, {"name": "local-extranet-policy-1"})
+
+    assert result == {"id": 42}
+    client.api.api_client.call_api.assert_not_called()
+
+
+def test_delete_local_extranet_policy_success() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_delete.return_value = MagicMock()
+
+    client.delete_local_extranet_policy(42)
+
+    client.api.v1_extranets_id_delete.assert_called_once_with(authorization="test-token", id=42)
+
+
+def test_delete_local_extranet_policy_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_delete.side_effect = ApiException(status=404, reason="not found")
+
+    with pytest.raises(ApiException):
+        client.delete_local_extranet_policy(42)
+
+
+def test_delete_local_extranet_policy_check_mode_does_not_call_api() -> None:
+    client = _make_client()
+    client.check_mode = True
+
+    client.delete_local_extranet_policy(42)
+
+    client.api.v1_extranets_id_delete.assert_not_called()
+
+
+def test_apply_local_extranet_policy_without_target_devices_omits_key() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_apply_post.return_value = MagicMock(
+        model_dump=MagicMock(return_value={"devices": [], "jobId": 99})
+    )
+
+    result = client.apply_local_extranet_policy(42)
+
+    assert result == {"devices": [], "jobId": 99}
+    kwargs = client.api.v1_extranets_id_apply_post.call_args.kwargs
+    assert kwargs["v1_extranets_id_apply_post_request"] == {}
+
+
+def test_apply_local_extranet_policy_with_target_devices_includes_key() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_apply_post.return_value = MagicMock(
+        model_dump=MagicMock(return_value={"devices": [], "jobId": 100})
+    )
+
+    client.apply_local_extranet_policy(42, target_device_ids=[1, 2])
+
+    kwargs = client.api.v1_extranets_id_apply_post.call_args.kwargs
+    assert kwargs["v1_extranets_id_apply_post_request"] == {"targetDevices": [1, 2]}
+
+
+def test_apply_local_extranet_policy_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_apply_post.side_effect = ApiException(status=500, reason="apply failed")
+
+    with pytest.raises(ApiException):
+        client.apply_local_extranet_policy(42)
+
+
+def test_apply_local_extranet_policy_check_mode_does_not_call_api() -> None:
+    client = _make_client()
+    client.check_mode = True
+
+    result = client.apply_local_extranet_policy(42, target_device_ids=[1])
+
+    assert result == {"devices": [], "jobId": 0}
+    client.api.v1_extranets_id_apply_post.assert_not_called()
+
+
+def test_get_local_extranet_policy_device_status_returns_devices() -> None:
+    client = _make_client()
+    devices = [MagicMock(), MagicMock()]
+    client.api.v1_extranets_id_status_get.return_value = MagicMock(devices=devices)
+
+    result = client.get_local_extranet_policy_device_status(42)
+
+    assert result == devices
+
+
+def test_get_local_extranet_policy_device_status_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_id_status_get.side_effect = ApiException(status=500, reason="failed")
+
+    with pytest.raises(ApiException):
+        client.get_local_extranet_policy_device_status(42)
+
+
+def test_get_local_extranet_lan_segments_usage_passes_params() -> None:
+    client = _make_client()
+    response = MagicMock()
+    client.api.v1_extranets_monitoring_lan_segments_get.return_value = response
+
+    result = client.get_local_extranet_lan_segments_usage(policy_id=42, is_provider=True)
+
+    assert result is response
+    client.api.v1_extranets_monitoring_lan_segments_get.assert_called_once_with(
+        authorization="test-token", id=42, is_provider=True
+    )
+
+
+def test_get_local_extranet_lan_segments_usage_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_monitoring_lan_segments_get.side_effect = ApiException(status=500, reason="failed")
+
+    with pytest.raises(ApiException):
+        client.get_local_extranet_lan_segments_usage()
+
+
+def test_get_local_extranet_nat_usage_returns_response() -> None:
+    client = _make_client()
+    response = MagicMock()
+    client.api.v1_extranets_monitoring_nat_usage_get.return_value = response
+
+    result = client.get_local_extranet_nat_usage(42)
+
+    assert result is response
+
+
+def test_get_local_extranet_nat_usage_raises_on_error_response() -> None:
+    client = _make_client()
+    client.api.v1_extranets_monitoring_nat_usage_get.side_effect = ApiException(status=500, reason="failed")
+
+    with pytest.raises(ApiException):
+        client.get_local_extranet_nat_usage(42)

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_local_extranet_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_local_extranet_manager.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for local_extranet_manager helpers (no live API)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.local_extranet_manager import (
+    LocalExtranetManager,
+)
+from ansible_collections.graphiant.naas.plugins.module_utils.libs.exceptions import (
+    ConfigurationError,
+    DeviceNotFoundError,
+    SiteNotFoundError,
+)
+
+
+def _make_manager() -> LocalExtranetManager:
+    config_utils = MagicMock()
+    config_utils.gsdk = MagicMock()
+    config_utils.template = MagicMock()
+    return LocalExtranetManager(config_utils)
+
+
+def test_validate_cidr_prefixes_accepts_network_address() -> None:
+    mgr = _make_manager()
+    mgr._validate_cidr_prefixes(["10.1.1.0/24"], "policy1", "manual.prefixes")  # pylint: disable=protected-access
+
+
+def test_validate_cidr_prefixes_rejects_non_network_address() -> None:
+    mgr = _make_manager()
+    with pytest.raises(ConfigurationError, match="invalid manual.prefixes prefix"):
+        mgr._validate_cidr_prefixes(["10.1.1.5/24"], "policy1", "manual.prefixes")  # pylint: disable=protected-access
+
+
+def test_validate_policy_prefixes_checks_all_prefix_sources() -> None:
+    mgr = _make_manager()
+    with pytest.raises(ConfigurationError, match="manual.prefixes"):
+        mgr._validate_policy_prefixes(  # pylint: disable=protected-access
+            {"manual": {"prefixes": ["10.1.1.5/24"]}}, "policy1"
+        )
+
+
+def test_resolve_policy_ids_raises_when_shared_segment_missing() -> None:
+    mgr = _make_manager()
+    mgr.gsdk.get_lan_segment_id.return_value = None
+    with pytest.raises(ConfigurationError, match="LAN segment 'lan-1' not found"):
+        mgr._resolve_policy_ids({"sharedSegment": "lan-1"}, "policy1")  # pylint: disable=protected-access
+
+
+def test_resolve_policy_ids_resolves_names_to_ids() -> None:
+    mgr = _make_manager()
+    mgr.gsdk.get_lan_segment_id.side_effect = {"lan-1": 100, "lan-2": 200}.get
+    mgr.gsdk.get_site_id.side_effect = {"site-a": 11}.get
+    mgr.gsdk.get_device_id.side_effect = {"dev-a": 21}.get
+
+    api_policy = {
+        "sharedSegment": "lan-1",
+        "targetSegments": ["lan-2"],
+        "source": {"sites": ["site-a"], "excludedDevices": ["dev-a"]},
+    }
+    mgr._resolve_policy_ids(api_policy, "policy1")  # pylint: disable=protected-access
+
+    assert api_policy["type"] == "enterprise"
+    assert api_policy["sharedSegment"] == 100
+    assert api_policy["targetSegments"] == [200]
+    assert api_policy["source"]["sites"] == [11]
+    assert api_policy["source"]["excludedDevices"] == [21]
+
+
+def test_resolve_policy_ids_sends_int_type_for_update() -> None:
+    # A live PUT confirmed the backend's update path only accepts "type" as a genuine JSON
+    # int (2) -- the string "enterprise" (which works for create) and omitting it entirely
+    # both failed with a backend foreign-key constraint violation on update.
+    mgr = _make_manager()
+    mgr.gsdk.get_lan_segment_id.return_value = 100
+
+    api_policy = {"sharedSegment": "lan-1", "type": "enterprise"}
+    mgr._resolve_policy_ids(api_policy, "policy1", for_update=True)  # pylint: disable=protected-access
+
+    assert api_policy["type"] == 2
+    assert isinstance(api_policy["type"], int)
+
+
+def test_resolve_policy_target_ids_defaults_excluded_devices_to_empty_list() -> None:
+    mgr = _make_manager()
+    mgr.gsdk.get_site_id.return_value = 11
+
+    target_config = {"sites": ["site-a"]}
+    mgr._resolve_policy_target_ids(target_config, "policy1", "source")  # pylint: disable=protected-access
+
+    assert target_config["excludedDevices"] == []
+
+
+def test_resolve_policy_target_ids_raises_site_not_found() -> None:
+    mgr = _make_manager()
+    mgr.gsdk.get_site_id.return_value = None
+    with pytest.raises(SiteNotFoundError):
+        mgr._resolve_policy_target_ids(  # pylint: disable=protected-access
+            {"sites": ["missing-site"]}, "policy1", "source"
+        )
+
+
+def test_resolve_policy_target_ids_raises_device_not_found() -> None:
+    mgr = _make_manager()
+    mgr.gsdk.get_device_id.return_value = None
+    with pytest.raises(DeviceNotFoundError):
+        mgr._resolve_policy_target_ids(  # pylint: disable=protected-access
+            {"excludedDevices": ["missing-device"]}, "policy1", "source"
+        )
+
+
+def test_create_policies_skips_existing_policy() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {
+        "local_extranet_policies": [{"name": "policy1", "sharedSegment": "lan-1"}]
+    }
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = SimpleNamespace(id=1, name="policy1")
+
+    result = mgr.create_policies("dummy.yaml")
+
+    assert result["changed"] is False
+    assert result["skipped"] == ["policy1"]
+    assert result["created"] == []
+    mgr.gsdk.create_local_extranet_policy.assert_not_called()
+    mgr.gsdk.apply_local_extranet_policy.assert_not_called()
+
+
+def test_create_policies_creates_and_applies_new_policy() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {
+        "local_extranet_policies": [
+            {"name": "policy1", "sharedSegment": "lan-1", "targetSegments": ["lan-2"]}
+        ]
+    }
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = None
+    mgr.gsdk.get_lan_segment_id.side_effect = {"lan-1": 100, "lan-2": 200}.get
+    mgr.gsdk.create_local_extranet_policy.return_value = {"id": 42}
+
+    result = mgr.create_policies("dummy.yaml")
+
+    assert result["changed"] is True
+    assert result["created"] == ["policy1"]
+    sent_policy = mgr.gsdk.create_local_extranet_policy.call_args[0][0]
+    assert sent_policy["type"] == "enterprise"
+    assert sent_policy["targetSegments"] == [200]
+    mgr.gsdk.apply_local_extranet_policy.assert_called_once_with(42, None)
+
+
+def test_create_policies_raises_when_created_policy_has_no_id() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {
+        "local_extranet_policies": [{"name": "policy1", "sharedSegment": "lan-1"}]
+    }
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = None
+    mgr.gsdk.get_lan_segment_id.return_value = 100
+    mgr.gsdk.create_local_extranet_policy.return_value = {"id": None}
+
+    with pytest.raises(ConfigurationError, match="no ID was returned"):
+        mgr.create_policies("dummy.yaml")
+
+    mgr.gsdk.apply_local_extranet_policy.assert_not_called()
+
+
+def test_carry_over_prefix_set_id_fills_in_missing_id() -> None:
+    mgr = _make_manager()
+    desired = {"prefixSet": {"name": "list", "mode": "ipv4", "entries": {}}}
+    current = {"prefixSet": {"name": "list", "id": 8621, "mode": "ipv4", "entries": []}}
+
+    mgr._carry_over_prefix_set_id(desired, current)  # pylint: disable=protected-access
+
+    assert desired["prefixSet"]["id"] == 8621
+
+
+def test_carry_over_prefix_set_id_does_not_override_explicit_id() -> None:
+    mgr = _make_manager()
+    desired = {"prefixSet": {"name": "list", "id": 999, "mode": "ipv4", "entries": {}}}
+    current = {"prefixSet": {"name": "list", "id": 8621, "mode": "ipv4", "entries": []}}
+
+    mgr._carry_over_prefix_set_id(desired, current)  # pylint: disable=protected-access
+
+    assert desired["prefixSet"]["id"] == 999
+
+
+def test_build_prefix_set_entries_applies_defaults_and_seq() -> None:
+    mgr = _make_manager()
+    entries = mgr._build_prefix_set_entries(  # pylint: disable=protected-access
+        [
+            {"ipPrefix": "10.1.1.0/24"},  # neither given ("Exact"): both default to own length
+            {"ipPrefix": "100.100.0.0/22", "maskUpper": 30},  # "Less & Equal": maskLower defaults to own length
+            {"ipPrefix": "2.2.100.0/23", "maskLower": 27},  # "Greater & Equal": maskUpper defaults to 32
+            {"ipPrefix": "70.0.0.0/23", "maskLower": 25, "maskUpper": 28},  # "Range": both explicit
+        ],
+        "policy1",
+        "source.prefixSet",
+    )
+
+    assert entries == {
+        "1": {"seq": 1, "ipPrefix": "10.1.1.0/24", "maskLower": 24, "maskUpper": 24},
+        "2": {"seq": 2, "ipPrefix": "100.100.0.0/22", "maskLower": 22, "maskUpper": 30},
+        "3": {"seq": 3, "ipPrefix": "2.2.100.0/23", "maskLower": 27, "maskUpper": 32},
+        "4": {"seq": 4, "ipPrefix": "70.0.0.0/23", "maskLower": 25, "maskUpper": 28},
+    }
+
+
+def test_build_prefix_set_entries_rejects_invalid_cidr() -> None:
+    mgr = _make_manager()
+    with pytest.raises(ConfigurationError, match="invalid source.prefixSet prefix"):
+        mgr._build_prefix_set_entries(  # pylint: disable=protected-access
+            [{"ipPrefix": "10.1.1.5/24"}], "policy1", "source.prefixSet"
+        )
+
+
+def test_normalize_policy_target_detects_prefix_set_mask_change() -> None:
+    mgr = _make_manager()
+    current = {"prefixSet": {"name": "list", "mode": "ipv4", "entries": [{"seq": 1, "ipPrefix": "10.1.1.0/24"}]}}
+    desired = {
+        "prefixSet": {
+            "name": "list",
+            "mode": "ipv4",
+            "entries": {"1": {"seq": 1, "ipPrefix": "10.1.1.0/24", "maskLower": 25, "maskUpper": 28}},
+        }
+    }
+
+    # pylint: disable=protected-access
+    assert mgr._normalize_policy_target(current) != mgr._normalize_policy_target(desired)
+    assert mgr._normalize_policy_target(current) == mgr._normalize_policy_target(current)
+
+
+def test_update_policies_raises_when_policy_missing() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {"local_extranet_policies": [{"name": "policy1"}]}
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = None
+
+    with pytest.raises(ConfigurationError, match="not found"):
+        mgr.update_policies("dummy.yaml")
+
+
+def test_delete_policies_skips_when_not_found() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {"local_extranet_policies": [{"name": "policy1"}]}
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = None
+
+    result = mgr.delete_policies("dummy.yaml")
+
+    assert result["changed"] is False
+    assert result["skipped"] == ["policy1"]
+    assert result["deleted"] == []
+    mgr.gsdk.delete_local_extranet_policy.assert_not_called()
+
+
+def test_delete_policies_deletes_existing_policy() -> None:
+    mgr = _make_manager()
+    mgr.config_utils.render_config_file.return_value = {"local_extranet_policies": [{"name": "policy1"}]}
+    mgr.gsdk.get_local_extranet_policy_by_name.return_value = SimpleNamespace(id=7, name="policy1")
+
+    result = mgr.delete_policies("dummy.yaml")
+
+    assert result["changed"] is True
+    assert result["deleted"] == ["policy1"]
+    mgr.gsdk.delete_local_extranet_policy.assert_called_once_with(7)

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_local_extranet.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_local_extranet.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for graphiant_local_extranet module (mocked Ansible + connection)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.graphiant.naas.plugins.modules import graphiant_local_extranet
+
+
+def _base_params() -> dict:
+    return {
+        "host": "https://api.example.com",
+        "username": "u",
+        "password": "p",
+        "access_token": None,
+        "operation": "create_policies",
+        "state": "present",
+        "config_file": "sample_local_extranet_policies.yaml",
+        "detailed_logs": False,
+    }
+
+
+def test_execute_with_logging_wraps_dict_result_with_changed_key() -> None:
+    module = MagicMock()
+    module.params = {"detailed_logs": False}
+
+    out = graphiant_local_extranet.execute_with_logging(
+        module,
+        lambda: {"changed": True, "created": ["p1"], "skipped": []},
+        success_msg="ok",
+    )
+
+    assert out["changed"] is True
+    assert out["result_msg"] == "ok"
+    assert out["details"] == {"changed": True, "created": ["p1"], "skipped": []}
+
+
+def test_execute_with_logging_non_dict_result_uses_default_success() -> None:
+    module = MagicMock()
+    module.params = {"detailed_logs": False}
+
+    out = graphiant_local_extranet.execute_with_logging(module, lambda: None, success_msg="ok")
+
+    assert out["changed"] is True
+    assert out["result_msg"] == "ok"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_create_policies_calls_create_policies(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod._diff = False
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.create_policies.return_value = {
+        "changed": True,
+        "created": ["local-extranet-policy-1"],
+        "skipped": [],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    local_extranet.create_policies.assert_called_once()
+    args, kwargs = local_extranet.create_policies.call_args
+    assert args[0] == "sample_local_extranet_policies.yaml"
+    assert kwargs["diff_mode"] is False
+    mod.exit_json.assert_called_once()
+    exit_kwargs = mod.exit_json.call_args.kwargs
+    assert exit_kwargs["changed"] is True
+    assert exit_kwargs["operation"] == "create_policies"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_update_policies_calls_update_policies(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = "update_policies"
+    p["config_file"] = "sample_local_extranet_policies_update.yaml"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.update_policies.return_value = {
+        "changed": True,
+        "updated": ["local-extranet-policy-1"],
+        "skipped": [],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    local_extranet.update_policies.assert_called_once_with("sample_local_extranet_policies_update.yaml")
+    mod.exit_json.assert_called_once()
+    assert mod.exit_json.call_args.kwargs["changed"] is True
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_update_policies_check_mode_uses_check_mode_success_message(
+    mock_ansible_module, mock_get_connection
+) -> None:
+    mod = MagicMock()
+    mod.check_mode = True
+    p = _base_params()
+    p["operation"] = "update_policies"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.update_policies.return_value = {
+        "changed": False,
+        "updated": [],
+        "skipped": ["local-extranet-policy-1"],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    # success_msg is consumed by execute_with_logging (popped from kwargs before calling the
+    # manager method) and surfaces in the exit payload's "msg", not in update_policies' own args.
+    local_extranet.update_policies.assert_called_once_with("sample_local_extranet_policies.yaml")
+    assert "Check mode" in mod.exit_json.call_args.kwargs["msg"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_delete_policies_calls_delete_policies(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["operation"] = None
+    p["state"] = "absent"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.delete_policies.return_value = {
+        "changed": True,
+        "deleted": ["local-extranet-policy-1"],
+        "skipped": [],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    local_extranet.delete_policies.assert_called_once_with("sample_local_extranet_policies.yaml")
+    mod.exit_json.assert_called_once()
+    assert mod.exit_json.call_args.kwargs["operation"] == "delete_policies"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_missing_config_file_fails_json(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["config_file"] = None
+    mod.params = p
+    mock_ansible_module.return_value = mod
+    mock_get_connection.return_value = MagicMock(graphiant_config=MagicMock())
+
+    graphiant_local_extranet.main()
+
+    mod.fail_json.assert_called_once()
+    assert "config_file parameter is required" in mod.fail_json.call_args.kwargs["msg"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_diff_mode_sets_diff_key(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod._diff = True
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.create_policies.return_value = {
+        "changed": True,
+        "created": ["local-extranet-policy-1"],
+        "skipped": [],
+        "diff_plan": [
+            {
+                "device": "local-extranet-policy-1",
+                "branch": "create",
+                "before": {},
+                "after": {"sharedSegment": 1},
+            }
+        ],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    kwargs = mod.exit_json.call_args.kwargs
+    assert "diff" in kwargs
+    assert "local-extranet-policy-1" in kwargs["diff"]["before"]
+    assert "local-extranet-policy-1" in kwargs["diff"]["after"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet.AnsibleModule")
+def test_main_exception_calls_fail_json(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.create_policies.side_effect = RuntimeError("LAN segment 'lan-x' not found")
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet.main()
+
+    mod.fail_json.assert_called_once()
+    assert mod.fail_json.call_args.kwargs["operation"] == "create_policies"

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_local_extranet_info.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/modules/test_graphiant_local_extranet_info.py
@@ -1,0 +1,184 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Graphiant, Inc. | GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+"""Unit tests for graphiant_local_extranet_info module (mocked Ansible + connection)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ansible_collections.graphiant.naas.plugins.modules import graphiant_local_extranet_info
+
+
+def _base_params() -> dict:
+    return {
+        "host": "https://api.example.com",
+        "username": "u",
+        "password": "p",
+        "access_token": None,
+        "query": "policies_summary",
+        "policy_name": None,
+        "is_provider": None,
+        "detailed_logs": False,
+    }
+
+
+def test_execute_with_logging_wraps_plain_dict_as_result_data() -> None:
+    """
+    Regression: manager query methods (get_policies_summary, get_device_status, ...) return
+    their payload directly (e.g. {"policies": [...]}), with no "result_msg" key of their own
+    — the whole dict must be preserved as result_data, not dropped.
+    """
+    module = MagicMock()
+    module.params = {"detailed_logs": False}
+
+    out = graphiant_local_extranet_info.execute_with_logging(
+        module, lambda: {"policies": [{"id": 1, "name": "local-extranet-policy-1"}]}, success_msg="ok"
+    )
+
+    assert out["result_msg"] == "ok"
+    assert out["result_data"] == {"policies": [{"id": 1, "name": "local-extranet-policy-1"}]}
+
+
+def test_execute_with_logging_non_dict_result_returns_empty_result_data() -> None:
+    module = MagicMock()
+    module.params = {"detailed_logs": False}
+
+    out = graphiant_local_extranet_info.execute_with_logging(module, lambda: None, success_msg="ok")
+
+    assert out["result_msg"] == "ok"
+    assert out["result_data"] == {}
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_policies_summary_calls_get_policies_summary(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.get_policies_summary.return_value = {
+        "policies": [{"id": 1, "name": "local-extranet-policy-1", "sharedSegment": "lan-segment-3"}]
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet_info.main()
+
+    local_extranet.get_policies_summary.assert_called_once_with()
+    mod.exit_json.assert_called_once()
+    kwargs = mod.exit_json.call_args.kwargs
+    assert kwargs["changed"] is False
+    assert kwargs["query"] == "policies_summary"
+    assert kwargs["result_data"]["policies"][0]["name"] == "local-extranet-policy-1"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_policy_device_status_passes_policy_name(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["query"] = "policy_device_status"
+    p["policy_name"] = "local-extranet-policy-1"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.get_device_status.return_value = {
+        "policy_name": "local-extranet-policy-1",
+        "devices": [{"deviceName": "edge-1-sdktest", "status": "SUCCESS"}],
+    }
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet_info.main()
+
+    local_extranet.get_device_status.assert_called_once_with("local-extranet-policy-1")
+    kwargs = mod.exit_json.call_args.kwargs
+    assert kwargs["result_data"]["devices"][0]["deviceName"] == "edge-1-sdktest"
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_lan_segments_usage_passes_policy_name_and_is_provider(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["query"] = "lan_segments_usage"
+    p["policy_name"] = "local-extranet-policy-1"
+    p["is_provider"] = True
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.get_lan_segments_usage.return_value = {"vrfs": []}
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet_info.main()
+
+    local_extranet.get_lan_segments_usage.assert_called_once_with("local-extranet-policy-1", True)
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_nat_usage_passes_policy_name(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["query"] = "nat_usage"
+    p["policy_name"] = "local-extranet-policy-1"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.get_nat_usage.return_value = {"allocatedCount": 0, "usageCount": 0, "allocations": []}
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet_info.main()
+
+    local_extranet.get_nat_usage.assert_called_once_with("local-extranet-policy-1")
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_unsupported_query_fails_json(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    p = _base_params()
+    p["query"] = "not-a-real-query"
+    mod.params = p
+    mock_ansible_module.return_value = mod
+    mock_get_connection.return_value = MagicMock(graphiant_config=MagicMock())
+
+    graphiant_local_extranet_info.main()
+
+    mod.fail_json.assert_called_once()
+    assert "Unsupported query" in mod.fail_json.call_args.kwargs["msg"]
+
+
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.get_graphiant_connection")
+@patch("ansible_collections.graphiant.naas.plugins.modules.graphiant_local_extranet_info.AnsibleModule")
+def test_main_exception_calls_fail_json(mock_ansible_module, mock_get_connection) -> None:
+    mod = MagicMock()
+    mod.check_mode = False
+    mod.params = _base_params()
+    mock_ansible_module.return_value = mod
+
+    local_extranet = MagicMock()
+    local_extranet.get_policies_summary.side_effect = RuntimeError("boom")
+    gc = MagicMock()
+    gc.local_extranet = local_extranet
+    mock_get_connection.return_value = MagicMock(graphiant_config=gc)
+
+    graphiant_local_extranet_info.main()
+
+    mod.fail_json.assert_called_once()
+    assert "boom" in mod.fail_json.call_args.kwargs["msg"]


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- Supports three operations: create, update, and delete (deconfigure), executed via the provided playbook tags/module operation parameter — a single flat, tenant-scoped policy resource (/v1/extranets) rather than per-device nested config.
- Implements idempotency differently per operation:
    - Create/delete: skip when a policy of the given name already/no-longer exists (existence check by name, no field-level comparison).
   - Update: normalizes both the live policy (from get_local_extranet_policy_details) and the desired YAML-derived policy into a canonical shape (sorted segment/site/device IDs, canonicalized prefix-set entries with the portal's Exact/Range/Less&Equal/Greater&Equal mask defaults applied) and skips the push only when the two match exactly — this is a whole-object comparison, not a sparse per-field merge like OSPFv2's.
- Resolves human-readable names to device/API IDs before every push: sharedSegment and branchSegments (LAN segment names → IDs, the latter renamed to the API's targetSegments), source/branches.sites (site names → IDs), excludedDevices (device names → IDs, defaulted to [] when omitted since the API requires the key), and targetDevices used only for the post-write apply call.
- Validates all prefixes (manual.prefixes and prefixSet.entries[].ipPrefix) as proper CIDR network addresses (host bits zero) via ipaddress.ip_network(..., strict=True), raising a ConfigurationError with a suggested corrected CIDR otherwise.
- Handles a backend quirk around the type field explicitly: sent as the string "enterprise" on create but as a genuine Python int 2 on update (confirmed via live capture — the update path's foreign-key constraint rejects a string or omitted key). Existence lookups deliberately never filter by type, avoiding a scenario where a stray policy with an unexpected type value would be invisible to a filtered lookup while still blocking a new create via the backend's name-uniqueness constraint.
- Carries over the existing prefixSet.id into the desired payload on update when the YAML omits it, since a PUT with a matching prefixSet.name but no id is otherwise treated by the backend as creating a duplicate prefix-set object and fails.
- Applies the policy to target devices automatically after every create or update via apply_local_extranet_policy(policy_id, target_device_ids) — there is no separate user-facing "apply" step; the API itself fans the push out to devices server-side.
- Supports Ansible check mode (--check): validation, ID-resolution, and diffing always run against live state; only the final write call is skipped, and this is handled at the SDK-client layer (gcsdk_client.py) rather than in the manager — each write method checks check_mode and short-circuits with a logged payload and a fake ID. create_local_extranet_policy additionally validates the payload against the real SDK Pydantic model in check mode to surface schema mismatches early. Combined with --diff, shows accurate before/after state for create and update (delete has no diff entries).
- Includes fully-annotated sample configuration files (sample_local_extranet_policies.yaml for create, sample_local_extranet_policies_update.yaml for update) demonstrating every prefix-set mask-default combination, plus a dedicated "Local Extranet Workflows" section in EXAMPLES.md, and README/changelog updates covering the new module, its check-mode/--diff support, and its idempotency behavior.


## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [x] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [x] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

<!-- Describe the testing you performed to verify your changes -->
- Create a new policy — skip (no-op, changed=False) when a policy of that name already exists; on genuine create, resolve sharedSegment/branchSegments/source.sites/excludedDevices names to IDs, default excludedDevices to [] when omitted, set type="enterprise", and immediately apply the policy to targetDevices.
- Reject a create whose response omits an id, without calling apply.
- Reject unresolvable sharedSegment, site, or device names (SiteNotFoundError/DeviceNotFoundError) during ID resolution.
- Validate manual.prefixes and prefixSet.entries[].ipPrefix as aligned CIDR network addresses; reject host-bit-set prefixes with a corrected-CIDR suggestion.
- Build prefixSet.entries with correct seq numbering and mask defaults across all four Exact/Less&Equal/Greater&Equal/Range input combinations.
- Update an existing policy — send type as a Python int (2), carry over an existing prefixSet.id when the desired config omits it, and reject the update entirely if no policy of that name exists (no create-on-update fallback).
-  Determine update idempotency by normalizing current (GET) and desired policies — sorted segment/site/device IDs, canonicalized prefix-set entries with mask defaults applied — and skipping the push (and diff entry) only on an exact match.
- Delete an existing policy (changed=True) and skip deletion of a policy that doesn't exist.
- Confirm module dispatch: operation=create_policies/update_policies/delete_policies (and state=absent → delete) call the right manager method with the right kwargs, and manager exceptions propagate to fail_json with operation set.
- Confirm check-mode dispatch produces a "Check mode: validated..." success message while still exercising the real manager code path.
- Confirm --diff populates diff.before/diff.after keyed by policy name for create/update.
- Exercise each SDK client method's success, error, and check-mode branches directly.
- Confirm the read-only info module (graphiant_local_extranet_info) dispatches policies_summary/policy_device_status/lan_segments_usage/nat_usage queries correctly and fails on an unsupported query type.

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #151

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
