### PR TITLE
OSPFv2 validation fix

### DIFF
--- a/ansible_collections/graphiant/naas/changelogs/changelog.yaml
+++ b/ansible_collections/graphiant/naas/changelogs/changelog.yaml
@@ -16,6 +16,8 @@ releases:
         - "``00_dataex_lan_segments_prerequisites.yml``, ``00_dataex_lan_interface_prerequisites.yml``, and ``00_dataex_vpn_profile_prerequisites.yml`` accept ``-e config_file=`` to override the default sample config"
         bugfixes:
         - "``graphiant_data_exchange``: fixed ``accept_invitation`` raising ``No VPN profiles found in acceptances`` for a Graphiant customer that legitimately needs no Site-to-Site VPN (issue #154)"
+        - "``graphiant_ospfv2``: ensure that the SDK model is used to build and validate the payload."
+        - "``graphiant_ospfv2``: BFD ``multiplier`` renamed to ``localMultiplier`` in ``sample_ospfv2.yaml`` and the interface payload to match the field name the API expects on write; the device GET response still stays the same; stopped sending the legacy flat fields when creating a new interface."
   "26.7.0":
     release_date: "2026-08-05"
     changes:

--- a/ansible_collections/graphiant/naas/configs/sample_ospfv2.yaml
+++ b/ansible_collections/graphiant/naas/configs/sample_ospfv2.yaml
@@ -146,7 +146,7 @@ ospfv2:
                       # Optional, only meaningful when enabled: true.
                       minimumInterval: 1000
                       # Optional, only meaningful when enabled: true.
-                      multiplier: 3
+                      localMultiplier: 3
 
                   # Interface #2: MD5 authentication instead of BFD.
                   - interfaceName: "GigabitEthernet7/0/0.19"   # REQUIRED

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/device_config_common.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/device_config_common.py
@@ -25,6 +25,7 @@ _SENSITIVE_LOG_KEYS = frozenset(
         "psk",
         "cak",
         "md5Password",
+        "key",  # OSPFv2 MD5 authentication key (interface.authentication.authentication.key)
     }
 )
 

--- a/ansible_collections/graphiant/naas/plugins/module_utils/libs/ospfv2_manager.py
+++ b/ansible_collections/graphiant/naas/plugins/module_utils/libs/ospfv2_manager.py
@@ -71,7 +71,7 @@ edge.segments.<segment>.ospfv2.process = {
 from typing import Any, Dict, Iterator, Optional, Tuple
 
 from .base_manager import BaseManager
-from .device_config_common import fetch_device_by_name, format_config_payload_for_log, new_apply_result
+from .device_config_common import fetch_device_by_name, new_apply_result, redact_sensitive_for_log
 from .exceptions import ConfigurationError
 from .logger import setup_logger
 
@@ -92,8 +92,8 @@ class OSPFv2Manager(BaseManager):
             bfd_obj["enabled"] = bfd_cfg.get("enabled")
         if bfd_cfg.get("minimumInterval") is not None:
             bfd_obj["minimumInterval"] = bfd_cfg.get("minimumInterval")
-        if bfd_cfg.get("multiplier") is not None:
-            bfd_obj["multiplier"] = bfd_cfg.get("multiplier")
+        if bfd_cfg.get("localMultiplier") is not None:
+            bfd_obj["localMultiplier"] = bfd_cfg.get("localMultiplier")
         return {"bfd": bfd_obj}
 
     @staticmethod
@@ -160,13 +160,6 @@ class OSPFv2Manager(BaseManager):
                 interface_obj["bfd"] = OSPFv2Manager._build_bfd(if_cfg.get("bfd"))
             else:
                 interface_obj["bfd"] = {"bfd": {"enabled": False, "minimumInterval": None}}
-            # Creation-only legacy flat fields (always zero; real values live in
-            # the *Value siblings above)
-            interface_obj["ifIndex"] = 0
-            interface_obj["helloInterval"] = 0
-            interface_obj["deadInterval"] = 0
-            interface_obj["retransmitInterval"] = 0
-            interface_obj["mtuIgnore"] = False
         else:
             if if_cfg.get("bfd") is not None:
                 interface_obj["bfd"] = OSPFv2Manager._build_bfd(if_cfg.get("bfd"))
@@ -612,7 +605,7 @@ class OSPFv2Manager(BaseManager):
                             "bfd": {
                                 "enabled": True,
                                 "minimumInterval": bfd.get("minimumInterval"),
-                                "multiplier": bfd.get("multiplier"),
+                                "localMultiplier": bfd.get("multiplier"),
                             }
                         }
                     else:
@@ -882,74 +875,6 @@ class OSPFv2Manager(BaseManager):
 
                 yield device_id, device_name, payload, device_dict
 
-    def _push_device_config_preserving_nulls(self, device_id: int, payload: Dict[str, Any]):
-        """
-        PUT one device's OSPFv2 config payload while preserving explicit `null` values.
-
-        Deconfigure payloads built by this manager rely on an explicit `null` (e.g.
-        {"interface": None}, {"protocol": None}) to tell the API "delete this key" --
-        as opposed to omitting the key, which means "leave it untouched" (see the module
-        docstring above). Pushing that payload via gsdk.put_device_config_raw() builds a
-        graphiant_sdk.V1DevicesDeviceIdConfigPutRequest and serializes it through that
-        model's .to_dict() (used both for the log line and for the actual request body) --
-        which calls pydantic's model_dump(exclude_none=True) and silently collapses every
-        explicit None down to an omitted key (e.g. {"interface": None} -> {}). The API then
-        rejects/misinterprets that empty object instead of performing the intended deletion
-        (observed as 500s like "error creating ospf process on device ..."). This method
-        instead builds the request via the SDK's api_client.param_serialize()/call_api()
-        directly, with the raw payload dict as the body -- the same "bypass the typed
-        request model" pattern already used elsewhere in gcsdk_client.py (see
-        edit_data_exchange_customer) for calls that need explicit control over what's on
-        the wire. ApiClient.sanitize_for_serialization() preserves None for plain dicts, so
-        the nulls this payload depends on actually reach the API.
-
-        This is scoped to ospfv2_manager.py deliberately -- gsdk.put_device_config_raw()
-        is shared across many managers, so it is not touched here.
-        """
-        gsdk = self.gsdk
-
-        request_body: Dict[str, Any] = {}
-        if payload.get("edge") is not None:
-            request_body["edge"] = payload["edge"]
-        if payload.get("core") is not None:
-            request_body["core"] = payload["core"]
-
-        if getattr(gsdk, "check_mode", False):
-            LOG.info(
-                "[check_mode] ospfv2: would push config for device_id=%s: \n%s",
-                device_id,
-                format_config_payload_for_log(request_body),
-            )
-            return None
-
-        gsdk.verify_device_portal_status(device_id=device_id)
-        LOG.info(
-            "ospfv2: config to be pushed for %s: \n%s",
-            device_id,
-            format_config_payload_for_log(request_body),
-        )
-
-        api_client = gsdk.api.api_client
-        method, url, header_params, body, post_params = api_client.param_serialize(
-            "PUT",
-            "/v1/devices/{deviceId}/config",
-            path_params={"deviceId": device_id},
-            header_params={
-                "Authorization": gsdk.bearer_token,
-                "Content-Type": "application/json",
-                "Accept": "application/json",
-            },
-            body=request_body,
-        )
-        try:
-            response_data = api_client.call_api(method, url, header_params, body, post_params)
-            response_data.read()
-        except Exception as e:
-            raise ConfigurationError(f"ospfv2: config push failed for device {device_id}: {e}") from e
-
-        gsdk.verify_device_portal_status(device_id=device_id)
-        return response_data
-
     def apply_ospf(
         self,
         config_yaml_file: str,
@@ -981,8 +906,8 @@ class OSPFv2Manager(BaseManager):
                 {
                     "device": device_name,
                     "branch": "edge.segments",
-                    "before": {"segments": before_segments},
-                    "after": {"segments": desired_segments},
+                    "before": redact_sensitive_for_log({"segments": before_segments}),
+                    "after": redact_sensitive_for_log({"segments": desired_segments}),
                 }
             )
 
@@ -992,8 +917,15 @@ class OSPFv2Manager(BaseManager):
         if not output_config:
             return result
 
+        LOG.info("[ospfv2] Validating payload for %d device(s)...", len(output_config))
+        try:
+            self.execute_concurrent_tasks(self.gsdk.show_validated_payload, output_config)
+        except Exception as e:
+            LOG.error("[ospfv2] SDK validation failed: %s", str(e))
+            raise ConfigurationError(f"OSPFv2 {operation} payload failed SDK schema validation: {str(e)}") from e
+
         LOG.info("[ospfv2] Pushing payload for %d device(s)...", len(output_config))
-        self.execute_concurrent_tasks(self._push_device_config_preserving_nulls, output_config)
+        self.execute_concurrent_tasks(self.gsdk.put_device_config_raw, output_config)
 
         result["changed"] = True
         return result

--- a/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_ospfv2_manager.py
+++ b/ansible_collections/graphiant/naas/tests/unit/plugins/module_utils/libs/test_ospfv2_manager.py
@@ -22,7 +22,7 @@ _VAULT_MD5 = {"edge-1": {"GigabitEthernet3": "vaultsecret"}}
 # _build_bfd -- no defaults filled in; only None/non-dict input raises.
 
 
-_BFD_FULL = {"enabled": True, "minimumInterval": 300, "multiplier": 3}
+_BFD_FULL = {"enabled": True, "minimumInterval": 300, "localMultiplier": 3}
 
 
 @pytest.mark.parametrize("bfd_cfg,expected", [
@@ -122,7 +122,6 @@ def test_build_interface_new_minimal_fills_all_defaults() -> None:
         "deadIntervalValue": {"deadInterval": 40},
         "retransmitIntervalValue": {"retransmitInterval": 5000},
         "bfd": {"bfd": {"enabled": False, "minimumInterval": None}},
-        "ifIndex": 0, "helloInterval": 0, "deadInterval": 0, "retransmitInterval": 0, "mtuIgnore": False,
     }}}
 
 
@@ -140,9 +139,6 @@ def test_build_interface_new_config_values_override_defaults_and_threads_vault()
     assert obj["retransmitIntervalValue"] == {"retransmitInterval": 999}
     assert obj["bfd"] == {"bfd": {"enabled": True, "minimumInterval": 300}}
     assert obj["authentication"] == {"authentication": {"keyId": 1, "key": "vaultsecret"}}
-    # Legacy flat fields are always zero/false on a new interface, regardless of config.
-    assert (obj["ifIndex"], obj["helloInterval"], obj["deadInterval"], obj["retransmitInterval"], obj["mtuIgnore"]) \
-        == (0, 0, 0, 0, False)
 
 
 # _build_area -- keyed by 'name'. 'existing_areas' (dict-keyed-by-name) decides new vs. existing,
@@ -172,7 +168,7 @@ def test_build_area_new_interfaces_are_all_new_and_thread_vault() -> None:
     _key, area_obj = OSPFv2Manager._build_area(area_cfg, {}, "edge-1", _VAULT_MD5)
     obj = area_obj["area"]["interfaces"]["GigabitEthernet3"]["interface"]
     # Full defaults (is_new=True shape) even though only interfaceName+auth were given.
-    assert obj["type"] == "point_to_point" and obj["ifIndex"] == 0
+    assert obj["type"] == "point_to_point"
     assert obj["helloIntervalValue"] == {"helloInterval": 10}
     assert obj["authentication"] == {"authentication": {"keyId": 1, "key": "vaultsecret"}}
 
@@ -211,7 +207,7 @@ def test_build_area_existing_interface_sparse_update_vs_new_interface_full_defau
         "helloIntervalValue": {"helloInterval": 99}, "interfaceName": "GigabitEthernet3",
     }
     new_if = interfaces["GigabitEthernet9"]["interface"]
-    assert new_if["type"] == "point_to_point" and new_if["ifIndex"] == 0 and new_if["mtuIgnore"] is False
+    assert new_if["type"] == "point_to_point"
 
 
 def test_build_area_existing_no_interfaces_given_key_omitted_not_forced_empty() -> None:
@@ -479,7 +475,7 @@ def test_build_deconfigure_payload_area_removal_ignores_sibling_fields() -> None
         "name": "CoreArea", "areaId": "0.0.0.0", "type": "normal",
         "interfaces": [{
             "interfaceName": "GigabitEthernet6/0/0",
-            "bfd": {"enabled": True, "minimumInterval": 1000, "multiplier": 3},
+            "bfd": {"enabled": True, "minimumInterval": 1000, "localMultiplier": 3},
             "authentication": {"keyId": 1, "key": "hello"},
         }],
     }]}
@@ -589,7 +585,7 @@ def test_extract_ospf_from_get_response_full_translation() -> None:
         "deadIntervalValue": {"deadInterval": 40},
         "retransmitIntervalValue": {"retransmitInterval": 5000},
         "authentication": {"authentication": {"keyId": 1, "key": "secret"}},
-        "bfd": {"bfd": {"enabled": True, "minimumInterval": 300, "multiplier": 3}},
+        "bfd": {"bfd": {"enabled": True, "minimumInterval": 300, "localMultiplier": 3}},
     }  # device-only fields (id/cost/ifIndex) have no equivalent and are dropped
     assert result["redistribution"] == {"bgp": {"protocol": {"type": "bgp", "metric": 1, "metricType": "type_2"}}}
 
@@ -910,12 +906,21 @@ def test_apply_ospf_configure_threads_vault_md5_password_for_new_interface() -> 
         }]},
     }]}}]}
     vault = {"edge-1-sdktest": {"GigabitEthernet3": "vaultsecret"}}
-    with patch.object(mgr, "render_config_file", return_value=cfg), patch.object(mgr, "execute_concurrent_tasks"):
+    with patch.object(mgr, "render_config_file", return_value=cfg), \
+            patch.object(mgr, "execute_concurrent_tasks") as mock_execute:
         result = mgr.apply_ospf("f.yaml", operation="configure", vault_ospf_md5_passwords=vault)
+
+    # diff_plan is display/facts output -- the MD5 key is redacted there, same as other secret fields.
     after_iface = result["diff_plan"][0]["after"]["segments"]["Documentation"]["ospfv2"]["process"]["areas"][
         "CoreArea"]["area"]["interfaces"]["GigabitEthernet3"]["interface"]
-    assert after_iface["authentication"] == {"authentication": {"keyId": 1, "key": "vaultsecret"}}
-    assert after_iface["type"] == "point_to_point" and after_iface["ifIndex"] == 0
+    assert after_iface["authentication"] == {"authentication": {"keyId": 1, "key": "********"}}
+    assert after_iface["type"] == "point_to_point"
+
+    # The vault key still has to reach the actual API push payload unredacted.
+    pushed_output_config = mock_execute.call_args[0][1]
+    pushed_iface = pushed_output_config[42]["payload"]["edge"]["segments"]["Documentation"]["ospfv2"]["process"][
+        "areas"]["CoreArea"]["area"]["interfaces"]["GigabitEthernet3"]["interface"]
+    assert pushed_iface["authentication"] == {"authentication": {"keyId": 1, "key": "vaultsecret"}}
 
 
 def test_apply_ospf_configure_raises_when_segment_or_interface_missing() -> None:


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->
- BFD interface field renamed from multiplier → localMultiplier. The API expects localMultiplier on write; the GET response is unaffected.
- Dropped legacy flat fields (ifIndex, helloInterval, deadInterval, retransmitInterval, mtuIgnore) that were always being sent as zero/False placeholders on new-interface creation.
- apply_ospf now runs the payload through gsdk.show_validated_payload (SDK schema validation) before pushing, raising ConfigurationError with details if it fails, instead of only discovering malformed payloads as an opaque API error.
- Replaced the custom _push_device_config_preserving_nulls workaround with gsdk.put_device_config_raw, simplifying the push path.
- diff_plan before/after segments are now passed through redact_sensitive_for_log so they don't leak OSPF md5 secrets in logs/output.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an 'x'. All items should be checked before requesting review. -->

### Pre-Submission Checklist

- [x] **Ansible Inclusion Checklist Compliance**
  - [ ] Ran `python scripts/check_inclusion_checklist.py --strict` and all checks passed
  - [ ] Reviewed `ANSIBLE_INCLUSION_CHECKLIST.md` for compliance
  - [ ] All module references in DOCUMENTATION use `M()` with FQCN (e.g., `M(graphiant.naas.graphiant_global_config)`)
  - [ ] All builtin modules use FQCN (e.g., `ansible.builtin.debug`)
  - [ ] Semantic markup is correct (V() for values, O() for options, etc.)

- [x] **Code Quality**
  - [ ] Collection structure validation passed: `python scripts/validate_collection.py`
  - [ ] All linting checks pass locally
  - [ ] Code follows project style guidelines
  - [ ] No new linting errors introduced

- [x] **Testing**
  - [ ] Local tests pass
  - [ ] Added/updated unit tests if applicable
  - [ ] E2E integration test passes (if applicable)

- [x] **Documentation**
  - [ ] Updated README.md if needed
  - [ ] Updated module documentation if needed
  - [ ] Added/updated examples if applicable
  - [ ] Changelog updated (in `changelogs/changelog.yaml`) for user-facing changes

- [x] **CI/CD**
  - [ ] All CI/CD workflows are expected to pass
  - [ ] No breaking changes to existing functionality (unless intentional)

## Testing

- ran ospf configure/deconfigure tests
/Users/krithiharesamudra/Desktop/Graphiant_Playbooks/test_ospf.txt

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Related to #

## Additional Notes

<!-- Any additional information that reviewers should know -->

---

**Note:** This PR template helps ensure compliance with the [Ansible Inclusion Checklist](ANSIBLE_INCLUSION_CHECKLIST.md). Please review the checklist before submitting your PR.
